### PR TITLE
⬆️ expand protobuf compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "grpcio>=1.35.0,<2.0",
     "ijson>=3.1.4,<3.2.0",
     "munch>=2.5.0,<3.0",
-    "protobuf>=3.20.0,<4",
+    "protobuf>=3.20.1,<5",
     "prometheus_client==0.12.0",
     "py-grpc-prometheus>=0.7.0,<0.8",
     "PyYAML>=6.0,<7.0",


### PR DESCRIPTION
In Gabe's own words:
"Yes, it would allow a user to install unsafe versions, but it wouldn't require that a user do so and with pip it would automatically choose the latest semantic version that didn't conflict with other deps"