### PR TITLE
:sparkles: Service factory accounts for optional and default parameters

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,4 +7,4 @@ import_heading_thirdparty=Third Party
 import_heading_firstparty=First Party
 import_heading_localfolder=Local
 known_firstparty=alog,aconfig,jtd_to_proto,import_tracker
-known_localfolder=caikit,tests
+known_localfolder=caikit,sample_lib,tests

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -751,8 +751,6 @@ class DataBase(metaclass=_DataBaseMetaClass):
                 or as the unqualified class name
 
         Returns:
-
-        Returns:
             dm_class (Type[DataBase])
                 The data model class corresponding to the given protobuf
         """

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -87,15 +87,6 @@ _NATIVE_TYPE_TO_JTD = {
 # Common package prefix
 CAIKIT_DATA_MODEL = "caikit_data_model"
 
-# Type container used for static analysis
-# Simply denotes that a function parameter of Defaultable[T]
-# is of type T, and contains a default value
-T = TypeVar("T")
-
-
-class Defaultable(Generic[T]):
-    pass
-
 
 def dataobject(
     schema: _SCHEMA_DEF_TYPE,

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -21,7 +21,7 @@ model objects inline without manually defining the protobufs representation
 from datetime import datetime
 from functools import update_wrapper
 from types import ModuleType
-from typing import Callable, Dict, Generic, List, Type, TypeVar, Union
+from typing import Callable, Dict, List, Type, Union
 import importlib
 import sys
 import types
@@ -242,7 +242,7 @@ class _EnumBaseSentinel:
     classes so that they can be identified generically
     """
 
-
+# pylint: disable=too-many-return-statements
 def _to_jtd_schema(
     input_schema: _SCHEMA_DEF_TYPE, optional_property_names: typing.Set[str] = None
 ) -> _JTD_DEF_TYPE:

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -246,6 +246,8 @@ def _to_jtd_schema(
     JTD schema
     """
     try:
+        # Unwrap optional to base type if applicable
+        input_schema = _unwrap_optional_type(input_schema)
 
         # If it's a reference to an EnumBase, de-alias to that enum's EnumDescriptor
         # NOTE: This must come before the check for dict since EnumBase instances
@@ -277,9 +279,6 @@ def _to_jtd_schema(
                 if not is_inside_properties_dict
                 else translated_dict
             )
-
-        # Unwrap optional to base type if applicable
-        input_schema = _unwrap_optional_type(input_schema)
 
         # If it's a reference to another data model object, de-alias to that
         # object's underlying proto descriptor

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -243,7 +243,9 @@ class _EnumBaseSentinel:
     """
 
 
-def _to_jtd_schema(input_schema: _SCHEMA_DEF_TYPE, optional_property_names: typing.Set[str] = None) -> _JTD_DEF_TYPE:
+def _to_jtd_schema(
+    input_schema: _SCHEMA_DEF_TYPE, optional_property_names: typing.Set[str] = None
+) -> _JTD_DEF_TYPE:
     """Recursive helper that will convert an input schema to a fully fleshed out
     JTD schema
     """
@@ -269,7 +271,10 @@ def _to_jtd_schema(input_schema: _SCHEMA_DEF_TYPE, optional_property_names: typi
             # If the dict is structured as a JTD element already, recurse on the
             # values
             if any(keyword in input_schema for keyword in _JTD_KEYWORDS):
-                return {k: _to_jtd_schema(v, optional_property_names) for k, v in input_schema.items()}
+                return {
+                    k: _to_jtd_schema(v, optional_property_names)
+                    for k, v in input_schema.items()
+                }
 
             # If not, assume we have properties or optional properties that we
             # need to recursively put into jtd format
@@ -298,7 +303,11 @@ def _to_jtd_schema(input_schema: _SCHEMA_DEF_TYPE, optional_property_names: typi
         # If it's a list or data stream, wrap it with "elements":
         if typing.get_origin(input_schema) in [list, DataStream]:
             # type_ could be caikit.core.data_model.streams.data_stream.DataStream[int]
-            return {"elements": _to_jtd_schema(typing.get_args(input_schema)[0], optional_property_names)}
+            return {
+                "elements": _to_jtd_schema(
+                    typing.get_args(input_schema)[0], optional_property_names
+                )
+            }
 
         # All other cases are invalid!
         raise ValueError(f"Invalid input schema: {input_schema}")

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -21,7 +21,7 @@ model objects inline without manually defining the protobufs representation
 from datetime import datetime
 from functools import update_wrapper
 from types import ModuleType
-from typing import Callable, Dict, List, Optional, Set, Type, Union
+from typing import Callable, Dict, List, Type, Union
 import importlib
 import sys
 import types

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -21,7 +21,7 @@ model objects inline without manually defining the protobufs representation
 from datetime import datetime
 from functools import update_wrapper
 from types import ModuleType
-from typing import Callable, Dict, List, Type, Union
+from typing import Callable, Dict, List, Optional, Set, Type, Union
 import importlib
 import sys
 import types
@@ -91,7 +91,7 @@ CAIKIT_DATA_MODEL = "caikit_data_model"
 def dataobject(
     schema: _SCHEMA_DEF_TYPE,
     package: str = CAIKIT_DATA_MODEL,
-    optional_property_names: typing.Set[str] = None,
+    optional_property_names: Optional[Set[str]] = None,
 ) -> Callable[[Type], Type[DataBase]]:
     """The @schema decorator can be used to define a Data Model object's schema
     inline with the definition of the python class rather than needing to bind
@@ -242,9 +242,10 @@ class _EnumBaseSentinel:
     classes so that they can be identified generically
     """
 
+
 # pylint: disable=too-many-return-statements
 def _to_jtd_schema(
-    input_schema: _SCHEMA_DEF_TYPE, optional_property_names: typing.Set[str] = None
+    input_schema: _SCHEMA_DEF_TYPE, optional_property_names: Optional[Set[str]] = None
 ) -> _JTD_DEF_TYPE:
     """Recursive helper that will convert an input schema to a fully fleshed out
     JTD schema

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -303,8 +303,6 @@ def _to_jtd_schema(input_schema: _SCHEMA_DEF_TYPE) -> _JTD_DEF_TYPE:
 
 def _is_optional_type(type_: Type) -> bool:
     origin = typing.get_origin(type_)
-    if origin == Defaultable:
-        return True
     if origin == Union:
         return type(None) in typing.get_args(type_)
     return False

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -250,11 +250,21 @@ class ServicePackageFactory:
         """Dynamically create data model classes for the inputs to these RPCs"""
         data_model_classes = []
         for task in rpcs_list:
-            schema = {
+            properties = {
                 # triple e.g. ('caikit.interfaces.common.ProducerPriority', 'producer_id', 1)
                 # This does not take care of nested descriptors
                 triple[1]: triple[0]
                 for triple in task.request.triples
+                if triple[1] not in task.request.default_set
+            }
+            optional_properties = {
+                triple[1]: triple[0]
+                for triple in task.request.triples
+                if triple[1] in task.request.default_set
+            }
+            schema = {
+                "properties": properties,
+                "optionalProperties": optional_properties,
             }
 
             if not schema:
@@ -264,7 +274,6 @@ class ServicePackageFactory:
             decorator = dataobject(
                 schema=schema,
                 package=package_name,
-                optional_property_names=task.request.default_set,
             )
             cls_ = type(task.request.name, (object,), {})
             decorated_cls = decorator(cls_)

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -263,7 +263,11 @@ class ServicePackageFactory:
                 # hacky hack hack: make sure we actually have a schema to generate
                 continue
 
-            decorator = dataobject(schema=schema, package=package_name, optional_property_names=task.request.default_set)
+            decorator = dataobject(
+                schema=schema,
+                package=package_name,
+                optional_property_names=task.request.default_set,
+            )
             cls_ = type(task.request.name, (object,), {})
             decorated_cls = decorator(cls_)
             data_model_classes.append(decorated_cls)

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -245,13 +245,6 @@ class ServicePackageFactory:
 
     # Implementation details for pure python service packages #
     @staticmethod
-    def _fix_lists(type_: Type) -> Union[Dict, Type]:
-        if typing.get_origin(type_) in [list, DataStream]:
-            # type_ could be caikit.core.data_model.streams.data_stream.DataStream[int]
-            return {"elements": typing.get_args(type_)[0]}
-        return type_
-
-    @staticmethod
     def _create_request_message_types(
         rpcs_list: List[RPCSerializerBase],
         package_name: str,
@@ -262,7 +255,7 @@ class ServicePackageFactory:
             schema = {
                 # triple e.g. ('caikit.interfaces.common.ProducerPriority', 'producer_id', 1)
                 # This does not take care of nested descriptors
-                triple[1]: ServicePackageFactory._fix_lists(triple[0])
+                triple[1]: triple[0]
                 for triple in task.request.triples
             }
 

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -15,10 +15,9 @@
 # Standard
 from enum import Enum
 from types import ModuleType
-from typing import Callable, Dict, List, Type, Union
+from typing import Callable, Dict, List, Type
 import dataclasses
 import inspect
-import typing
 
 # Third Party
 import google.protobuf.descriptor
@@ -36,7 +35,6 @@ import alog
 
 # Local
 from caikit.core import dataobject
-from caikit.core.data_model import DataStream
 from caikit.core.data_model.base import DataBase
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -263,7 +263,7 @@ class ServicePackageFactory:
                 # hacky hack hack: make sure we actually have a schema to generate
                 continue
 
-            decorator = dataobject(schema=schema, package=package_name)
+            decorator = dataobject(schema=schema, package=package_name, optional_property_names=task.request.default_set)
             cls_ = type(task.request.name, (object,), {})
             decorated_cls = decorator(cls_)
             data_model_classes.append(decorated_cls)

--- a/caikit/runtime/service_generation/core_module_helpers.py
+++ b/caikit/runtime/service_generation/core_module_helpers.py
@@ -45,6 +45,7 @@ def get_module_info(ck_module: Type[ModuleBase]) -> Optional[ModuleInfo]:
     2. The module derives from a base class that itself derives from one of the
         known type-hierarchy derived from `ModuleBase`.
     """
+    # NOTE: all of this assumes <library> has no .
     # Use the library name to qualify the module type in case there are
     # collisions across domains (e.g. classification in nlp and cv)
     py_mod_name_parts = ck_module.__module__.split(".")
@@ -64,7 +65,10 @@ def get_module_info(ck_module: Type[ModuleBase]) -> Optional[ModuleInfo]:
 
     # Look for a base class that meets our expectations
     for parent in ck_module.__mro__[1:]:
-        if parent.__module__.partition(".")[0] != "caikit.core":
+        if not (
+            parent.__module__.partition(".")[0] == "caikit"
+            and parent.__module__.partition(".")[1] == "core"
+        ):
             module_parts = parent.__module__.split(".")
             module_kind = module_parts[1]
             module_type = module_parts[-1]

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -25,7 +25,6 @@ import typing
 import alog
 
 # Local
-from ...core.data_model.dataobject import Defaultable
 from .signature_parsing.module_signature import CaikitCoreModuleMethodSignature
 from .type_helpers import PROTO_TYPE_MAP
 from caikit.core.data_model.base import DataBase
@@ -117,10 +116,6 @@ def _is_primitive_type(arg_type: Type, primitive_data_model_types: List[str]) ->
     False otherwise"""
     lib_dm_primitives = _get_library_dm_primitives(primitive_data_model_types)
     primitive_set = list(PROTO_TYPE_MAP.keys()) + lib_dm_primitives
-
-    # HACKY HACK: add Defaultables
-    default_primitive_set = {Defaultable[type_] for type_ in primitive_set}
-    primitive_set.extend(default_primitive_set)
 
     if arg_type in primitive_set:
         return True

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -25,6 +25,7 @@ import typing
 import alog
 
 # Local
+from ...core.data_model.dataobject import Defaultable
 from .signature_parsing.module_signature import CaikitCoreModuleMethodSignature
 from .type_helpers import PROTO_TYPE_MAP
 from caikit.core.data_model.base import DataBase
@@ -116,6 +117,11 @@ def _is_primitive_type(arg_type: Type, primitive_data_model_types: List[str]) ->
     False otherwise"""
     lib_dm_primitives = _get_library_dm_primitives(primitive_data_model_types)
     primitive_set = list(PROTO_TYPE_MAP.keys()) + lib_dm_primitives
+
+    # HACKY HACK: add Defaultables
+    default_primitive_set = {Defaultable[type_] for type_ in primitive_set}
+    primitive_set.extend(default_primitive_set)
+
     if arg_type in primitive_set:
         return True
     if typing.get_origin(arg_type) == list:
@@ -157,3 +163,4 @@ def _get_library_dm_primitives(primitive_data_model_types) -> List[Type[DataBase
 def _is_optional_type(arg_type: Type):
     if typing.get_origin(arg_type) == Union and type(None) in typing.get_args(arg_type):
         return True
+    return False

--- a/caikit/runtime/service_generation/serializers.py
+++ b/caikit/runtime/service_generation/serializers.py
@@ -177,6 +177,9 @@ class TaskPredictRPC(RPCSerializerBase):
             )
             for arg_name, arg_type in primitive_arg_dict.items():
                 current_val = parameters_dict.get(arg_name, arg_type)
+                # TODO: raise runtime error here!
+                # TODO: need to resolve Defaultable[T] vs. T - if both come in,
+                # use Defaultable[T] (same for Optional - probably bug right now)
                 assert (
                     current_val == arg_type
                 ), f"Conflicting value types for arg {arg_name}: {current_val} != {arg_type}"

--- a/caikit/runtime/service_generation/serializers.py
+++ b/caikit/runtime/service_generation/serializers.py
@@ -17,7 +17,7 @@ This package has classes that will serialize a python interface to a protocol bu
 Typically used for `caikit.core.module`s that expose .train and .run functions.
 """
 # Standard
-from typing import Dict, List, Optional, Tuple, Type, get_args, Set
+from typing import Dict, List, Optional, Set, Tuple, Type, get_args
 import abc
 
 # First Party
@@ -76,7 +76,9 @@ class ModuleClassTrainRPC(RPCSerializerBase):
         # Store the input and output protobuf message types for this RPC
         self.return_type = self._method.return_type
         self._req = _RequestMessage(
-            self._module_class_to_req_name(), self._method.parameters, self._method.default_parameters
+            self._module_class_to_req_name(),
+            self._method.parameters,
+            self._method.default_parameters,
         )
 
     @property
@@ -187,7 +189,9 @@ class TaskPredictRPC(RPCSerializerBase):
 
                 parameters_dict[arg_name] = arg_type
 
-        self._req = _RequestMessage(self._task_to_req_name(), parameters_dict, default_parameters)
+        self._req = _RequestMessage(
+            self._task_to_req_name(), parameters_dict, default_parameters
+        )
 
         # Validate that the return_type of all modules in the grouping matches
         return_types = {method.return_type for method in method_signatures}

--- a/caikit/runtime/service_generation/serializers.py
+++ b/caikit/runtime/service_generation/serializers.py
@@ -181,7 +181,7 @@ class TaskPredictRPC(RPCSerializerBase):
             )
             for arg_name, arg_type in primitive_arg_dict.items():
                 current_val = parameters_dict.get(arg_name, arg_type)
-                # TODO: raise runtime error here!
+                # TODO: raise runtime error here instead of assert!
                 # TODO: need to resolve Optional[T] vs. T - if both come in, use Optional[T]
                 assert (
                     current_val == arg_type

--- a/caikit/runtime/service_generation/serializers.py
+++ b/caikit/runtime/service_generation/serializers.py
@@ -17,7 +17,7 @@ This package has classes that will serialize a python interface to a protocol bu
 Typically used for `caikit.core.module`s that expose .train and .run functions.
 """
 # Standard
-from typing import Dict, List, Optional, Tuple, Type, get_args
+from typing import Dict, List, Optional, Tuple, Type, get_args, Set
 import abc
 
 # First Party
@@ -76,7 +76,7 @@ class ModuleClassTrainRPC(RPCSerializerBase):
         # Store the input and output protobuf message types for this RPC
         self.return_type = self._method.return_type
         self._req = _RequestMessage(
-            self._module_class_to_req_name(), self._method.parameters
+            self._module_class_to_req_name(), self._method.parameters, self._method.default_parameters
         )
 
     @property
@@ -171,7 +171,9 @@ class TaskPredictRPC(RPCSerializerBase):
 
         # Aggregate the argument signature types into a single parameters_dict
         parameters_dict = {}
+        default_parameters = set()
         for method in method_signatures:
+            default_parameters.update(method.default_parameters)
             primitive_arg_dict = primitives.to_primitive_signature(
                 method.parameters, primitive_data_model_types
             )
@@ -185,7 +187,7 @@ class TaskPredictRPC(RPCSerializerBase):
 
                 parameters_dict[arg_name] = arg_type
 
-        self._req = _RequestMessage(self._task_to_req_name(), parameters_dict)
+        self._req = _RequestMessage(self._task_to_req_name(), parameters_dict, default_parameters)
 
         # Validate that the return_type of all modules in the grouping matches
         return_types = {method.return_type for method in method_signatures}
@@ -230,12 +232,13 @@ class _RequestMessage:
     objects.
     """
 
-    def __init__(self, msg_name: str, params: Dict[str, Type]):
+    def __init__(self, msg_name: str, params: Dict[str, Type], default_set: Set[str]):
         """Initialize with the module class and the parsed parameters to the run
         function.
         """
         self.name = msg_name
         self.triples = []
+        self.default_set = default_set
 
         existing_fields = ApiFieldNames.get_fields_for_message(self.name)
 

--- a/caikit/runtime/service_generation/serializers.py
+++ b/caikit/runtime/service_generation/serializers.py
@@ -178,8 +178,7 @@ class TaskPredictRPC(RPCSerializerBase):
             for arg_name, arg_type in primitive_arg_dict.items():
                 current_val = parameters_dict.get(arg_name, arg_type)
                 # TODO: raise runtime error here!
-                # TODO: need to resolve Defaultable[T] vs. T - if both come in,
-                # use Defaultable[T] (same for Optional - probably bug right now)
+                # TODO: need to resolve Optional[T] vs. T - if both come in, use Optional[T]
                 assert (
                     current_val == arg_type
                 ), f"Conflicting value types for arg {arg_name}: {current_val} != {arg_type}"

--- a/caikit/runtime/service_generation/signature_parsing/module_signature.py
+++ b/caikit/runtime/service_generation/signature_parsing/module_signature.py
@@ -20,7 +20,7 @@ comes to the caikit core common data model.
 """
 
 # Standard
-from typing import Dict, Optional, Type
+from typing import Dict, Optional, Type, Set
 import inspect
 
 # First Party
@@ -62,6 +62,7 @@ class CaikitCoreModuleMethodSignature:
 
         try:
             self._method_pointer = getattr(self._module, self._method_name)
+            self._default_set = parsers.get_args_with_defaults(self._method_pointer)
             method_signature = inspect.signature(self._method_pointer)
             self._return_type = parsers.get_output_type_name(
                 self._module, method_signature, self._method_pointer
@@ -75,6 +76,7 @@ class CaikitCoreModuleMethodSignature:
             )
             self._return_type = None
             self._parameters = None
+            self._default_set = set()
 
     @property
     def module(self) -> Type[ModuleBase]:
@@ -96,6 +98,11 @@ class CaikitCoreModuleMethodSignature:
         """A dictionary of the parameter names to their types, or None if the method does not
         exist"""
         return self._parameters
+
+    @property
+    def default_parameters(self) -> Set[str]:
+        """A set of all parameter names which have default values"""
+        return self._default_set
 
 
 class CustomSignature(CaikitCoreModuleMethodSignature):

--- a/caikit/runtime/service_generation/signature_parsing/module_signature.py
+++ b/caikit/runtime/service_generation/signature_parsing/module_signature.py
@@ -20,7 +20,7 @@ comes to the caikit core common data model.
 """
 
 # Standard
-from typing import Dict, Optional, Type, Set
+from typing import Dict, Optional, Set, Type
 import inspect
 
 # First Party

--- a/caikit/runtime/service_generation/signature_parsing/module_signature.py
+++ b/caikit/runtime/service_generation/signature_parsing/module_signature.py
@@ -67,13 +67,7 @@ class CaikitCoreModuleMethodSignature:
                 self._module, method_signature, self._method_pointer
             )
 
-            self._parameters = {
-                name: parsers.get_argument_type(
-                    param, self._module, self._method_pointer
-                )
-                for name, param in method_signature.parameters.items()
-                if name not in ["self", "args", "kwargs", "_"]
-            }
+            self._parameters = parsers.get_argument_types(self._method_pointer)
         except AttributeError:
             log.warning(
                 "Could not find method [%s] in this module",

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -25,7 +25,6 @@ import alog
 # Local
 from . import docstrings
 from caikit.core.data_model.base import DataBase
-from caikit.core.data_model.dataobject import Defaultable
 from caikit.core.module import ModuleBase
 
 log = alog.use_channel("SIG-PARSING")
@@ -99,17 +98,11 @@ def get_argument_types(module_method: Callable) -> Dict[str, Type]:
         Dict[str, Type]: A dictionary of parameter name to parameter type
     """
     method_signature = inspect.signature(module_method)
-    types_dict = {
+    return {
         name: _get_argument_type(param, module_method)
         for name, param in method_signature.parameters.items()
         if name not in ["self", "args", "kwargs", "_", "__"]
     }
-
-    for name, type_ in types_dict.items():
-        if method_signature.parameters[name].default != inspect.Parameter.empty:
-            types_dict[name] = Defaultable[type_]
-
-    return types_dict
 
 
 def get_args_with_defaults(module_method: Callable) -> Set[str]:
@@ -144,8 +137,6 @@ def _get_argument_type(
     * Parse the docstring
     * Look for a data model object whose name matches the argument name
     """
-    # TODO: There are more "defaultable" cases that in the section above
-    # get_default_type
     # TODO: KNOWN_ARG_TYPES should be configurable
 
     # Use known arg types first

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -16,7 +16,7 @@ Contains functions that attempt to parse the I/O types of member methods on `cai
 """
 # Standard
 from types import FunctionType
-from typing import List, Optional, Type
+from typing import Callable, Dict, List, Optional, Type
 import inspect
 
 # First Party
@@ -25,6 +25,7 @@ import alog
 # Local
 from . import docstrings
 from caikit.core.data_model.base import DataBase
+from caikit.core.data_model.dataobject import Defaultable
 from caikit.core.module import ModuleBase
 
 log = alog.use_channel("SIG-PARSING")
@@ -43,7 +44,7 @@ KNOWN_OUTPUT_TYPES = {}
 def get_output_type_name(
     module_class: ModuleBase.__class__,
     fn_signature: inspect.Signature,
-    fn: FunctionType,
+    fn: Callable,
 ) -> Type:
     """Get the type for a return type based on the name of the module class and
     the Caikit library naming convention.
@@ -71,8 +72,7 @@ def get_output_type_name(
             return fn_signature.return_annotation
 
     # Check the docstring
-    # TODO: NOOOOOOOO need the real function
-    type_from_docstring = docstrings.get_return_type(module_class, fn)
+    type_from_docstring = docstrings.get_return_type(fn)
     if type_from_docstring:
         return type_from_docstring
 
@@ -80,8 +80,7 @@ def get_output_type_name(
     module_parts = module_class.__module__.split(".")
     log.debug3("Parent module parts for %s: %s", module_class.__name__, module_parts)
 
-    # TODO: Why the F doesn't this work with docstrings?
-    # please test lol
+    # TODO: please test lol
 
     class_name = _snake_to_camel(module_parts[2]) + "Prediction"
     return _get_dm_type_from_name(class_name) or _get_dm_type_from_name(
@@ -89,12 +88,35 @@ def get_output_type_name(
     )
 
 
+def get_argument_types(module_method: Callable) -> Dict[str, Type]:
+    """Get the python types for each parameter to this method, returned in a dict.
+    This does more than simply looking at inspect.Signature, see _get_argument_type
+
+    Args:
+        module_method (Callable): A pointer to a method
+
+    Returns:
+        Dict[str, Type]: A dictionary of parameter name to parameter type
+    """
+    method_signature = inspect.signature(module_method)
+    types_dict = {
+        name: _get_argument_type(param, module_method)
+        for name, param in method_signature.parameters.items()
+        if name not in ["self", "args", "kwargs", "_", "__"]
+    }
+
+    for name, type_ in types_dict.items():
+        if method_signature.parameters[name].default != inspect.Parameter.empty:
+            types_dict[name] = Defaultable[type_]
+
+    return types_dict
+
+
 # pylint: disable=too-many-return-statements
 @alog.logged_function(log.debug2)
-def get_argument_type(
+def _get_argument_type(
     arg: inspect.Parameter,
-    module_class: ModuleBase.__class__,
-    module_method: FunctionType,
+    module_method: Callable,
 ) -> Type:
     """Get the python type for a named argument to a Module's given method. This
     is where the heuristics for determining types are implemented:
@@ -105,8 +127,9 @@ def get_argument_type(
     * Parse the docstring
     * Look for a data model object whose name matches the argument name
     """
-    # Check docstring for optional arg
-    optional_arg = docstrings.is_optional(module_method, arg.name)
+    # TODO: There are more "defaultable" cases that in the section above
+    # get_default_type
+    # TODO: KNOWN_ARG_TYPES should be configurable
 
     # Use known arg types first
     # This avoids cases where docstrings are very obviously flubbed, such as
@@ -116,6 +139,9 @@ def get_argument_type(
         # Not checking if this is optional: These known types should never be optional (maybe...?)
         # This could totally be incorrect!
         return dm_type_from_known_arg_types
+
+    # Check docstring for optional arg
+    optional_arg = docstrings.is_optional(module_method, arg.name)
 
     # Look for a type annotation
     if arg.annotation != inspect.Parameter.empty:
@@ -133,7 +159,7 @@ def get_argument_type(
 
     # Parse docstring
 
-    type_from_docstring = docstrings.get_arg_type(module_class, module_method, arg.name)
+    type_from_docstring = docstrings.get_arg_type(module_method, arg.name)
     if type_from_docstring:
         if optional_arg:
             return Optional[type_from_docstring]

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -16,7 +16,7 @@ Contains functions that attempt to parse the I/O types of member methods on `cai
 """
 # Standard
 from types import FunctionType
-from typing import Callable, Dict, List, Optional, Type
+from typing import Callable, Dict, List, Optional, Set, Type
 import inspect
 
 # First Party
@@ -110,6 +110,23 @@ def get_argument_types(module_method: Callable) -> Dict[str, Type]:
             types_dict[name] = Defaultable[type_]
 
     return types_dict
+
+
+def get_args_with_defaults(module_method: Callable) -> Set[str]:
+    """Get the names of all arguments that have a default value supplied.
+    Args:
+        module_method (Callable): A pointer to a method
+
+    Returns:
+        Set[str]: A set of all parameter names which have a default value.
+            Empty if none have defaults or no parameters exist.
+    """
+    method_signature = inspect.signature(module_method)
+    return {
+        param.name
+        for param in method_signature.parameters.values()
+        if param.default != inspect.Parameter.empty
+    }
 
 
 # pylint: disable=too-many-return-statements

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -79,8 +79,7 @@ def get_output_type_name(
     module_parts = module_class.__module__.split(".")
     log.debug3("Parent module parts for %s: %s", module_class.__name__, module_parts)
 
-    # TODO: please test lol
-
+    # TODO: this part needs a test (or consider deleting and say user needs to specify output type)
     class_name = _snake_to_camel(module_parts[2]) + "Prediction"
     return _get_dm_type_from_name(class_name) or _get_dm_type_from_name(
         KNOWN_OUTPUT_TYPES.get(class_name)

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -15,7 +15,6 @@
 Contains functions that attempt to parse the I/O types of member methods on `caikit.core.module`s
 """
 # Standard
-from types import FunctionType
 from typing import Callable, Dict, List, Optional, Set, Type
 import inspect
 

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -179,7 +179,7 @@ class GlobalTrainServicer:
             }
             log.warning(log_dict)
             raise CaikitRuntimeException(
-                StatusCode.INTERNAL, "Unhandled exception during prediction"
+                StatusCode.INTERNAL, "Unhandled exception during training"
             ) from e
 
     def run_training_job(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "six>=1.16.0,<2.0.0",
     "tqdm>=4.59.0,<5.0.0",
     "wheel>=0.37.0",
-    "jtd-to-proto>=0.11.4,<0.12.0",
+    "jtd-to-proto>=0.12.1,<0.13.0",
     "import-tracker>=3.1.5,<4",
 ]
 

--- a/tests/core/blocks/test_base.py
+++ b/tests/core/blocks/test_base.py
@@ -17,16 +17,15 @@ import os
 import shutil
 import tempfile
 
-# Third Party
-# pylint: disable=import-error
-from sample_lib.blocks.sample_task import SampleBlock
-from sample_lib.data_model.sample import SampleInputType
-
 # Local
 from caikit.core.blocks import block
 from caikit.core.blocks.base import BlockSaver
 from caikit.core.config import lib_config
 from caikit.core.toolkit.serializers import JSONSerializer
+
+# pylint: disable=import-error
+from sample_lib.blocks.sample_task import SampleBlock
+from sample_lib.data_model.sample import SampleInputType
 
 # Unit Test Infrastructure
 from tests.base import TestCaseBase

--- a/tests/core/data_model/streams/test_data_stream.py
+++ b/tests/core/data_model/streams/test_data_stream.py
@@ -15,13 +15,11 @@
 # Standard
 import os
 
-# Third Party
-from sample_lib.blocks.sample_task.sample_implementation import SampleBlock
-from sample_lib.data_model.sample import SampleInputType, SampleOutputType
-
 # Local
 from caikit.core import data_model as core_dm
 from caikit.core.augmentors import AugmentorBase
+from sample_lib.blocks.sample_task.sample_implementation import SampleBlock
+from sample_lib.data_model.sample import SampleInputType, SampleOutputType
 
 # Unit Test Infrastructure
 from tests.base import TestCaseBase

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -222,7 +222,7 @@ def test_dataobject_obj_refs():
     )
 
 
-def test_dataobject_obj_refs_with_optional_and_defaultable_types():
+def test_dataobject_obj_refs_with_optional_types():
     """Make sure that references to other data objects and enums work as
     expected
     """
@@ -256,6 +256,28 @@ def test_dataobject_obj_refs_with_optional_and_defaultable_types():
         assert check_field_enum_type(
             FooBar._proto_class, field, BarEnum._proto_enum.DESCRIPTOR
         )
+
+
+def test_dataobject_properties_needs_jtd_translation():
+    """Make sure shorthand get recognized as still needing jtd translation
+    when inside properties or optionalProperties
+    """
+
+    @dataobject(
+        schema={
+            "properties": {
+                "foo": int,
+            },
+            "optionalProperties": {
+                "bar": bool,
+            },
+        }
+    )
+    class FooBar:
+        pass
+
+    assert check_field_type(FooBar.get_proto_class(), "foo", "TYPE_INT64")
+    assert check_field_type(FooBar.get_proto_class(), "bar", "TYPE_BOOL")
 
 
 def test_dataobject_invalid_schema():

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -30,7 +30,6 @@ from caikit.core.data_model import enums
 from caikit.core.data_model.base import DataBase
 from caikit.core.data_model.dataobject import (
     _AUTO_GEN_PROTO_CLASSES,
-    Defaultable,
     render_dataobject_protos,
 )
 from caikit.core.toolkit.isa import isprotobufenum
@@ -236,27 +235,24 @@ def test_dataobject_obj_refs_with_optional_and_defaultable_types():
     class Foo:
         pass
 
-    # The dataobject in question: includes Optional[T] and Defaultable[T]
-    # for other object types
+    # The dataobject in question: includes Optional[T]
     @dataobject(
         schema={
             "foo": Foo,
             "optionalFoo": Optional[Foo],
-            "fooWithDefault": Defaultable[Foo],
             "bar": BarEnum,
             "optionalBar": Optional[BarEnum],
-            "barWithDefault": Defaultable[BarEnum],
         }
     )
     class FooBar:
         pass
 
     assert check_field_type(FooBar._proto_class, "foo", "TYPE_MESSAGE")
-    for field in ["foo", "optionalFoo", "fooWithDefault"]:
+    for field in ["foo", "optionalFoo"]:
         assert check_field_message_type(
             FooBar._proto_class, field, Foo._proto_class.DESCRIPTOR
         )
-    for field in ["bar", "optionalBar", "barWithDefault"]:
+    for field in ["bar", "optionalBar"]:
         assert check_field_enum_type(
             FooBar._proto_class, field, BarEnum._proto_enum.DESCRIPTOR
         )

--- a/tests/core/test_module.py
+++ b/tests/core/test_module.py
@@ -20,9 +20,6 @@ import tempfile
 import uuid
 
 # Third Party
-# pylint: disable=import-error
-from sample_lib.blocks.sample_task import SampleBlock
-from sample_lib.data_model.sample import SampleInputType
 import pytest
 
 # First Party
@@ -32,6 +29,10 @@ import aconfig
 from caikit.core import ModuleConfig, module
 from caikit.core.module_backend_config import get_backend
 from caikit.core.module_backends import backend_types
+
+# pylint: disable=import-error
+from sample_lib.blocks.sample_task import SampleBlock
+from sample_lib.data_model.sample import SampleInputType
 
 # Unit Test Infrastructure
 from tests.base import TestCaseBase

--- a/tests/core/test_module_metadata.py
+++ b/tests/core/test_module_metadata.py
@@ -23,15 +23,16 @@ import os
 import tempfile
 
 # Third Party
+import pytest
+
+# Local
+from caikit.core import toolkit
+
 # pylint: disable=import-error
 from sample_lib.blocks.sample_task import SampleBlock
 
 # pylint: disable=import-error
 from sample_lib.workflows.sample_task import SampleWorkflow
-import pytest
-
-# Local
-from caikit.core import toolkit
 
 # Unit Test Infrastructure
 from tests.base import TestCaseBase

--- a/tests/core/workflows/test_base.py
+++ b/tests/core/workflows/test_base.py
@@ -16,16 +16,15 @@
 import os
 import tempfile
 
-# Third Party
-# pylint: disable=import-error
-from sample_lib.blocks.sample_task import SampleBlock
-from sample_lib.data_model.sample import SampleInputType
-from sample_lib.workflows.sample_task import SampleWorkflow
-
 # Local
 from caikit.core.config import lib_config
 from caikit.core.workflows import workflow
 from caikit.core.workflows.base import WorkflowLoader, WorkflowSaver
+
+# pylint: disable=import-error
+from sample_lib.blocks.sample_task import SampleBlock
+from sample_lib.data_model.sample import SampleInputType
+from sample_lib.workflows.sample_task import SampleWorkflow
 
 # Unit Test Infrastructure
 from tests.base import TestCaseBase

--- a/tests/runtime/model_management/test_batcher.py
+++ b/tests/runtime/model_management/test_batcher.py
@@ -22,7 +22,6 @@ import threading
 import time
 
 # Third Party
-from sample_lib.data_model import SampleOutputType
 import pytest
 
 # First Party
@@ -30,6 +29,7 @@ import alog
 
 # Local
 from caikit.runtime.model_management.batcher import Batcher
+from sample_lib.data_model import SampleOutputType
 import caikit.core
 
 ## Helpers #####################################################################

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -19,8 +19,6 @@ import unittest
 import uuid
 
 # Third Party
-from sample_lib.blocks.sample_task import SampleBlock
-from sample_lib.data_model import SampleInputType, SampleOutputType
 import grpc
 import pytest
 
@@ -34,6 +32,8 @@ from caikit.runtime.model_management.batcher import Batcher
 from caikit.runtime.model_management.model_loader import ModelLoader
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.config_parser import ConfigParser
+from sample_lib.blocks.sample_task import SampleBlock
+from sample_lib.data_model import SampleInputType, SampleOutputType
 from tests.conftest import temp_config_parser
 from tests.fixtures import Fixtures
 

--- a/tests/runtime/service_generation/signature_parsing/test_docstrings.py
+++ b/tests/runtime/service_generation/signature_parsing/test_docstrings.py
@@ -1,0 +1,46 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""These are mostly some older tests that we wrote ad-hoc while throwing the inference proto-generation together
+
+Coverage is probably not the best
+"""
+# Standard
+from typing import List
+
+# Local
+from caikit.runtime.service_generation.signature_parsing.docstrings import (
+    _extract_nested_type,
+    _get_docstring_type,
+)
+from sample_lib.data_model import SampleInputType
+import sample_lib
+
+def test_get_docstring_type():
+    # TODO: fun edge case where producer word in description is found in types
+    assert (
+        _get_docstring_type(
+            candidate_type_names=["sample_lib.data_model.SampleOutputType"],
+        )
+        == sample_lib.data_model.SampleOutputType
+    )
+
+
+def test_extract_nested_type():
+    """
+    Test that this function returns the type of List[T], or None if it's not a nested type
+    """
+    assert _extract_nested_type("List[str]") == List[str]
+    assert _extract_nested_type("list(str)") == List[str]
+    assert _extract_nested_type("List(SampleInputType)") == List[SampleInputType]
+    assert _extract_nested_type("int") == None

--- a/tests/runtime/service_generation/signature_parsing/test_docstrings.py
+++ b/tests/runtime/service_generation/signature_parsing/test_docstrings.py
@@ -26,6 +26,7 @@ from caikit.runtime.service_generation.signature_parsing.docstrings import (
 from sample_lib.data_model import SampleInputType
 import sample_lib
 
+
 def test_get_docstring_type():
     # TODO: fun edge case where producer word in description is found in types
     assert (

--- a/tests/runtime/service_generation/signature_parsing/test_parsers.py
+++ b/tests/runtime/service_generation/signature_parsing/test_parsers.py
@@ -23,6 +23,7 @@ import inspect
 from caikit.runtime.service_generation.signature_parsing.parsers import (
     _get_dm_type_from_name,
     _snake_to_camel,
+    get_args_with_defaults,
     get_argument_types,
     get_output_type_name,
 )
@@ -99,3 +100,14 @@ def test_get_argument_type_from_malformed_docstring():
         pass
 
     assert get_argument_types(_run)["foo"] == sample_lib.data_model.SampleInputType
+
+
+def test_get_args_with_defaults():
+    """Check that we get arguments with any default value supplied"""
+
+    def _run(
+        a, b: bool, c: int = None, d: str = None, e: int = 5, f: float = 0.5, g=None
+    ):
+        pass
+
+    assert get_args_with_defaults(_run) == {"c", "d", "e", "f", "g"}

--- a/tests/runtime/service_generation/signature_parsing/test_parsers.py
+++ b/tests/runtime/service_generation/signature_parsing/test_parsers.py
@@ -19,16 +19,7 @@ Coverage is probably not the best
 from typing import List, Optional
 import inspect
 
-# Third Party
-from sample_lib.data_model import SampleInputType
-import sample_lib
-
 # Local
-from caikit.core.data_model.dataobject import Defaultable
-from caikit.runtime.service_generation.signature_parsing.docstrings import (
-    _extract_nested_type,
-    _get_docstring_type,
-)
 from caikit.runtime.service_generation.signature_parsing.parsers import (
     _get_dm_type_from_name,
     _snake_to_camel,
@@ -36,6 +27,7 @@ from caikit.runtime.service_generation.signature_parsing.parsers import (
     get_output_type_name,
 )
 import caikit.core
+import sample_lib
 
 ## Tests ########################################################################
 
@@ -91,25 +83,6 @@ def test_optional_type_annotation():
     assert get_argument_types(_run)["sample_input"] == Optional[int]
 
 
-def test_defaultable_type_annotation():
-    """Check that we keep the `Optional` wrapping on input types"""
-
-    def _run(sample_input=5):
-        pass
-
-    assert get_argument_types(_run)["sample_input"] == Defaultable[int]
-
-    def _run_with_anno(sample_input: int = 5):
-        pass
-
-    assert get_argument_types(_run_with_anno)["sample_input"] == Defaultable[int]
-
-    def _run_with_list(sample_list=(1, 2, 3)):
-        pass
-
-    assert get_argument_types(_run_with_list)["sample_list"] == Defaultable[List[int]]
-
-
 def test_get_argument_type_from_malformed_docstring():
     """This test tests docstring arg type parsing for docstrings in non-conforming styles
     where the actual type name is hidden in the description"""
@@ -126,26 +99,3 @@ def test_get_argument_type_from_malformed_docstring():
         pass
 
     assert get_argument_types(_run)["foo"] == sample_lib.data_model.SampleInputType
-
-
-# These tests are on private functions in docstrings
-
-
-def test_get_docstring_type():
-    # TODO: fun edge case where producer word in description is found in types
-    assert (
-        _get_docstring_type(
-            candidate_type_names=["sample_lib.data_model.SampleOutputType"],
-        )
-        == sample_lib.data_model.SampleOutputType
-    )
-
-
-def test_extract_nested_type():
-    """
-    Test that this function returns the type of List[T], or None if it's not a nested type
-    """
-    assert _extract_nested_type("List[str]") == List[str]
-    assert _extract_nested_type("list(str)") == List[str]
-    assert _extract_nested_type("List(SampleInputType)") == List[SampleInputType]
-    assert _extract_nested_type("int") == None

--- a/tests/runtime/service_generation/signature_parsing/test_parsers.py
+++ b/tests/runtime/service_generation/signature_parsing/test_parsers.py
@@ -16,7 +16,7 @@
 Coverage is probably not the best
 """
 # Standard
-from typing import List
+from typing import List, Optional
 import inspect
 
 # Third Party
@@ -24,6 +24,7 @@ from sample_lib.data_model import SampleInputType
 import sample_lib
 
 # Local
+from caikit.core.data_model.dataobject import Defaultable
 from caikit.runtime.service_generation.signature_parsing.docstrings import (
     _extract_nested_type,
     _get_docstring_type,
@@ -31,7 +32,7 @@ from caikit.runtime.service_generation.signature_parsing.docstrings import (
 from caikit.runtime.service_generation.signature_parsing.parsers import (
     _get_dm_type_from_name,
     _snake_to_camel,
-    get_argument_type,
+    get_argument_types,
     get_output_type_name,
 )
 import caikit.core
@@ -59,72 +60,82 @@ def test_get_dm_type_from_name():
     )
 
 
-def test_get_docstring_type():
-    # TODO: fun edge case where producer word in description is found in types
-    assert (
-        _get_docstring_type(
-            module_class=sample_lib.blocks.sample_task.SampleBlock,
-            candidate_type_names=["sample_lib.data_model.SampleOutputType"],
-        )
-        == sample_lib.data_model.SampleOutputType
-    )
-
-
-def test_get_argument_type_from_docstring():
-    """This tests docstring parsing only (note annotation=inspect.Parameter.empty)
-    The 'SampleBlock' has correctly formatted docstrings in Google style
-    """
-    assert (
-        get_argument_type(
-            arg=inspect.Parameter(
-                name="sample_input",
-                kind=inspect.Parameter.POSITIONAL_ONLY,
-                annotation=inspect.Parameter.empty,
-            ),
-            module_class=sample_lib.blocks.sample_task.SampleBlock,
-            module_method=sample_lib.blocks.sample_task.SampleBlock.run,
-        )
-        == sample_lib.data_model.SampleInputType
-    )
-
-
-def test_get_argument_type_from_malformed_docstring():
-    """This test tests docstring arg type parsing for docstrings in non-conforming styles
-    where the actual type name is hidden in the description"""
-
-    class TestClass:
-        def run(self, foo):
-            """
-
-            Args:
-                foo: yadda yadda blah sample_lib.data_model.SampleInputType
-
-            Returns:
-                None
-            """
-            pass
-
-    assert (
-        get_argument_type(
-            arg=inspect.Parameter(
-                name="foo",
-                kind=inspect.Parameter.POSITIONAL_ONLY,
-                annotation=inspect.Parameter.empty,
-            ),
-            module_class=TestClass,
-            module_method=TestClass.run,
-        )
-        == sample_lib.data_model.SampleInputType
-    )
-
-
 def test_get_output_type_name():
     run_sign = inspect.Signature(return_annotation=inspect.Signature.empty)
     assert (
         get_output_type_name(
             module_class=sample_lib.blocks.sample_task.SampleBlock,
             fn_signature=run_sign,
-            fn=getattr(sample_lib.blocks.sample_task.SampleBlock, "run"),
+            fn=sample_lib.blocks.sample_task.SampleBlock.run,
+        )
+        == sample_lib.data_model.SampleOutputType
+    )
+
+
+def test_get_argument_types_with_real_block():
+    """Quick check that we get the right type for our sample block"""
+    assert (
+        get_argument_types(sample_lib.blocks.sample_task.SampleBlock.run)[
+            "sample_input"
+        ]
+        == sample_lib.data_model.SampleInputType
+    )
+
+
+def test_optional_type_annotation():
+    """Check that we keep the `Optional` wrapping on input types"""
+
+    def _run(sample_input: Optional[int]):
+        pass
+
+    assert get_argument_types(_run)["sample_input"] == Optional[int]
+
+
+def test_defaultable_type_annotation():
+    """Check that we keep the `Optional` wrapping on input types"""
+
+    def _run(sample_input=5):
+        pass
+
+    assert get_argument_types(_run)["sample_input"] == Defaultable[int]
+
+    def _run_with_anno(sample_input: int = 5):
+        pass
+
+    assert get_argument_types(_run_with_anno)["sample_input"] == Defaultable[int]
+
+    def _run_with_list(sample_list=(1, 2, 3)):
+        pass
+
+    assert get_argument_types(_run_with_list)["sample_list"] == Defaultable[List[int]]
+
+
+def test_get_argument_type_from_malformed_docstring():
+    """This test tests docstring arg type parsing for docstrings in non-conforming styles
+    where the actual type name is hidden in the description"""
+
+    def _run(self, foo):
+        """
+
+        Args:
+            foo: yadda yadda blah sample_lib.data_model.SampleInputType
+
+        Returns:
+            None
+        """
+        pass
+
+    assert get_argument_types(_run)["foo"] == sample_lib.data_model.SampleInputType
+
+
+# These tests are on private functions in docstrings
+
+
+def test_get_docstring_type():
+    # TODO: fun edge case where producer word in description is found in types
+    assert (
+        _get_docstring_type(
+            candidate_type_names=["sample_lib.data_model.SampleOutputType"],
         )
         == sample_lib.data_model.SampleOutputType
     )
@@ -134,21 +145,7 @@ def test_extract_nested_type():
     """
     Test that this function returns the type of List[T], or None if it's not a nested type
     """
-    # TODO: I don't really get why the block ref has to be passed here :hmm:
-    assert (
-        _extract_nested_type(sample_lib.blocks.sample_task.SampleBlock, "List[str]")
-        == List[str]
-    )
-    assert (
-        _extract_nested_type(sample_lib.blocks.sample_task.SampleBlock, "list(str)")
-        == List[str]
-    )
-    assert (
-        _extract_nested_type(
-            sample_lib.blocks.sample_task.SampleBlock, "List(SampleInputType)"
-        )
-        == List[SampleInputType]
-    )
-    assert (
-        _extract_nested_type(sample_lib.blocks.sample_task.SampleBlock, "int") == None
-    )
+    assert _extract_nested_type("List[str]") == List[str]
+    assert _extract_nested_type("list(str)") == List[str]
+    assert _extract_nested_type("List(SampleInputType)") == List[SampleInputType]
+    assert _extract_nested_type("int") == None

--- a/tests/runtime/service_generation/test_create_service.py
+++ b/tests/runtime/service_generation/test_create_service.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Third Party
-import sample_lib
-
 # Local
 from caikit.runtime.service_generation.create_service import (
     create_inference_rpcs,
     create_training_rpcs,
 )
+import sample_lib
 
 ## Setup ########################################################################
 

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -6,7 +6,6 @@ import pickle
 import tempfile
 
 # Third Party
-from sample_lib.data_model.sample import SampleTrainingType
 import pytest
 
 # Local
@@ -18,6 +17,7 @@ from caikit.runtime.service_generation.data_stream_source import (
     make_data_stream_source,
 )
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+from sample_lib.data_model.sample import SampleTrainingType
 from tests.conftest import temp_config_parser
 import caikit
 

--- a/tests/runtime/service_generation/test_type_helpers.py
+++ b/tests/runtime/service_generation/test_type_helpers.py
@@ -15,9 +15,6 @@
 # Standard
 from typing import List, Optional, Union
 
-# Third Party
-import sample_lib
-
 # Local
 from caikit.core.data_model import DataStream
 from caikit.runtime.service_generation.type_helpers import (
@@ -25,6 +22,7 @@ from caikit.runtime.service_generation.type_helpers import (
     has_data_stream,
     is_model_type,
 )
+import sample_lib
 
 
 def test_data_stream_helpers():

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -21,17 +21,16 @@ import time
 import uuid
 
 # Third Party
-from sample_lib.blocks.sample_task import SampleBlock
-from sample_lib.data_model import SampleInputType, SampleOutputType
 import grpc
 import pytest
-import sample_lib
 
 # Local
 from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+from sample_lib.blocks.sample_task import SampleBlock
+from sample_lib.data_model import SampleInputType, SampleOutputType
 from tests.fixtures import Fixtures
-from tests.fixtures.protobufs import primitive_party_pb2
+import sample_lib
 
 
 def _random_test_id():

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -17,18 +17,18 @@ import time
 import uuid
 
 # Third Party
-from sample_lib.blocks.sample_task.sample_implementation import SampleBlock
-from sample_lib.data_model.sample import (
-    SampleInputType,
-    SampleOutputType,
-    SampleTrainingType,
-)
 import pytest
 
 # Local
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+from sample_lib.blocks.sample_task.sample_implementation import SampleBlock
+from sample_lib.data_model.sample import (
+    SampleInputType,
+    SampleOutputType,
+    SampleTrainingType,
+)
 from tests.conftest import temp_config_parser
 from tests.fixtures import Fixtures
 from tests.fixtures.protobufs import primitive_party_pb2

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -21,7 +21,6 @@ import uuid
 # Third Party
 import grpc
 import pytest
-import sample_lib
 
 # Local
 from caikit.interfaces.runtime.data_model import TrainingStatus
@@ -29,6 +28,7 @@ from caikit.runtime.protobufs import process_pb2
 from caikit.runtime.servicers.model_train_servicer import ModelTrainServicerImpl
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from tests.conftest import temp_config_parser
+import sample_lib
 
 
 @pytest.fixture

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from unittest import mock
 import json
 import os
-import tempfile
 import threading
 import time
 import uuid
@@ -135,14 +134,16 @@ def test_model_train(runtime_grpc_server):
     )
     assert response.status == TrainingStatus.COMPLETED
 
-    # make sure we wait for training to finish
+    # Make sure we wait for training to finish
     result = TrainingManager.get_instance().training_futures[training_id].result()
 
-    assert result.batch_size == 64
     assert (
         result.BLOCK_CLASS
         == "sample_lib.blocks.sample_task.sample_implementation.SampleBlock"
     )
+    # Fields with defaults have expected values
+    assert result.batch_size == 64
+    assert result.learning_rate == 0.0015
 
 
 def test_predict_fake_block_ok_response(

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -78,8 +78,6 @@ def is_good_train_response(actual_response, expected, model_name):
     assert actual_response.model_name == model_name
 
 
-# TODO: Fix this with optional fields support - https://github.com/IBM/jtd-to-proto/issues/34
-@pytest.mark.skip("Waiting for optional fields support")
 def test_model_train(runtime_grpc_server):
     """Test model train's RUN function"""
     model_train_stub = process_pb2_grpc.ProcessStub(
@@ -94,9 +92,15 @@ def test_model_train(runtime_grpc_server):
             "training_params": json.dumps(
                 {
                     "model_name": "abc",
-                    "training_data": [
-                        sample_lib.data_model.SampleTrainingType(number=1).to_dict()
-                    ],
+                    "training_data": {
+                        "jsondata": {
+                            "data": [
+                                sample_lib.data_model.SampleTrainingType(
+                                    number=1
+                                ).to_dict()
+                            ]
+                        },
+                    },
                 }
             ),
         },

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -25,15 +25,8 @@ import uuid
 
 # Third Party
 from grpc_health.v1 import health_pb2, health_pb2_grpc
-from sample_lib.data_model import (
-    OtherOutputType,
-    SampleInputType,
-    SampleOutputType,
-    SampleTrainingType,
-)
 import grpc
 import pytest
-import sample_lib
 import tls_test_tools
 
 # First Party
@@ -41,7 +34,6 @@ import alog
 
 # Local
 from caikit.interfaces.runtime.data_model import (
-    ModelPointer,
     TrainingInfoRequest,
     TrainingInfoResponse,
     TrainingJob,
@@ -58,9 +50,16 @@ from caikit.runtime.protobufs import (
 )
 from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
 from caikit.runtime.utils.config_parser import ConfigParser
+from sample_lib.data_model import (
+    OtherOutputType,
+    SampleInputType,
+    SampleOutputType,
+    SampleTrainingType,
+)
 from tests.conftest import temp_config_parser
 from tests.fixtures import Fixtures
 import caikit
+import sample_lib
 
 log = alog.use_channel("TEST-SERVE-I")
 

--- a/tests/runtime/utils/test_import_util.py
+++ b/tests/runtime/utils/test_import_util.py
@@ -108,7 +108,7 @@ def test_get_data_model_ok_on_lib_with_no_data_model():
 
 def test_get_data_model_is_accessible():
     """get_data_model should return the stuff in the `sample_lib.data_model` package"""
-    # Third Party
+    # Local
     import sample_lib
 
     cdm = get_data_model()

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -355,7 +355,7 @@ def test_global_train_build_caikit_library_request_dict_creates_caikit_core_run_
 
     # assert that even though not passed in, caikit.core_request now has training_data
     # because empty stream types get an empty steam initialized
-    # TODO: unclear if this behavior is correct, but okay
+    # TODO: will need additional tests for list arguments
     assert expected_arguments == set(caikit.core_request.keys())
     assert isinstance(
         caikit.core_request["training_data"], caikit.core.data_model.DataStream

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -221,10 +221,8 @@ def test_global_predict_build_caikit_library_request_dict_creates_caikit_core_ru
         sample_lib.blocks.sample_task.SampleBlock().run,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.SampleBlock().run.__code__.co_varnames
-    )
-    expected_arguments.remove("self")
+    # No self or "throw", throw was not set and the throw parameter contains a default value
+    expected_arguments = {"sample_input"}
 
     assert expected_arguments == set(request_dict.keys())
     assert isinstance(request_dict["sample_input"], SampleInputType)
@@ -242,10 +240,7 @@ def test_global_predict_build_caikit_library_request_dict_strips_invalid_run_kwa
         sample_lib.blocks.sample_task.SampleBlock().run,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.SampleBlock().run.__code__.co_varnames
-    )
-    expected_arguments.remove("self")
+    expected_arguments = {"sample_input"}
     assert expected_arguments == set(request_dict.keys())
     assert "int_type" not in request_dict.keys()
 
@@ -356,17 +351,15 @@ def test_global_train_build_caikit_library_request_dict_creates_caikit_core_run_
         sample_lib.blocks.sample_task.SampleBlock().train,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.SampleBlock().train.__code__.co_varnames
-    )
-    expected_arguments.remove("cls")
+    expected_arguments = {"training_data"}
 
-    # assert that even though not passed in, caikit.core_request now has both batch_size and training_data
+    # assert that even though not passed in, caikit.core_request now has training_data
+    # because empty stream types get an empty steam initialized
+    # TODO: unclear if this behavior is correct, but okay
     assert expected_arguments == set(caikit.core_request.keys())
     assert isinstance(
         caikit.core_request["training_data"], caikit.core.data_model.DataStream
     )
-    assert caikit.core_request["batch_size"] == 0
 
 
 def test_global_train_build_caikit_library_request_dict_strips_empty_list_from_request(
@@ -388,10 +381,8 @@ def test_global_train_build_caikit_library_request_dict_strips_empty_list_from_r
         sample_lib.blocks.sample_task.SampleBlock().train,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.SampleBlock().train.__code__.co_varnames
-    )
-    expected_arguments.remove("cls")
+    # model_name is not expected to be passed through
+    expected_arguments = {"training_data"}
 
     assert expected_arguments == set(caikit.core_request.keys())
 
@@ -414,13 +405,11 @@ def test_global_train_build_caikit_library_request_dict_works_for_repeated_field
         sample_lib.blocks.sample_task.ListBlock().train,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.ListBlock().train.__code__.co_varnames
-    )
-    expected_arguments.remove("cls")
+    # model_name is not expected to be passed through
+    expected_arguments = {"training_data", "poison_pills"}
 
     assert expected_arguments == set(caikit.core_request.keys())
-    assert len(caikit.core_request.keys()) == 3
+    assert len(caikit.core_request.keys()) == 2
     assert "poison_pills" in caikit.core_request
     assert isinstance(caikit.core_request["poison_pills"], list)
 
@@ -470,10 +459,8 @@ def test_global_train_build_caikit_library_request_dict_ok_with_data_stream_file
         sample_lib.blocks.sample_task.SampleBlock().train,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.SampleBlock().train.__code__.co_varnames
-    )
-    expected_arguments.remove("cls")
+    # model_name is not expected to be passed through
+    expected_arguments = {"training_data"}
 
     assert expected_arguments == set(caikit.core_request.keys())
 
@@ -497,13 +484,11 @@ def test_global_train_build_caikit_library_request_dict_ok_with_training_data_as
         sample_lib.blocks.sample_task.ListBlock().train,
     )
 
-    expected_arguments = set(
-        sample_lib.blocks.sample_task.ListBlock().train.__code__.co_varnames
-    )
-    expected_arguments.remove("cls")
+    # model_name is not expected to be passed through
+    expected_arguments = {"training_data", "poison_pills"}
 
     assert expected_arguments == set(caikit.core_request.keys())
-    assert len(caikit.core_request.keys()) == 3
+    assert len(caikit.core_request.keys()) == 2
     assert "training_data" in caikit.core_request
 
 

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -17,9 +17,7 @@ import os
 import tempfile
 
 # Third Party
-from sample_lib.data_model import SampleInputType, SampleTrainingType
 import pytest
-import sample_lib
 
 # Local
 from caikit.runtime.protobufs import model_runtime_pb2
@@ -34,10 +32,12 @@ from caikit.runtime.utils.servicer_util import (
     validate_caikit_library_class_method_exists,
     validate_data_model,
 )
+from sample_lib.data_model import SampleInputType
 from tests.fixtures import Fixtures
 from tests.fixtures.protobufs import primitive_party_pb2
 import caikit.core
 import caikit.interfaces
+import sample_lib
 
 
 # ---------------- Tests for validate_caikit_library_class_exists --------------------


### PR DESCRIPTION
This PR updates the service factory to specify request parameters as `optionalProperties` in jtd (rather than `properties`) if they either:
- Have type `Optional[T]`, meaning they can take values of `None`, or
- Have default values specified in the function signature (or at least one function signature, in the case of task RPCs wiht multiple concrete implementations)

Also included is a large amount of diff related to specifying `sample_lib` as `Local` in our `isort` config

This PR does not yet update the runtime behavior, so any optional properties that were not set by the user will continue to be dropped from the internal kwargs dict that is supplied to `model.run`. Future work is required to disambiguate `python - optional` (nullable) parameters vs. `defaulted` parameters, so that nullable parameters can correctly have `None` supplied instead of no value.

Our original design for this was to add a new sentinel `Defaultable[T]` type and inject that into the signature parsing. However that caused some cascading changes throughout the service generation code, and would have caused some more complex changes on the service side later. We instead store a set of parameter names that have default parameters with each RPC, so that on the service side we can easily say "hey does this param have a default?" instead of doing more type inspection. However, this did cause us to need to pass a new optional parameter into the `@dataobject` decorator to supply the parameter names to make optional.