### PR TITLE
🔥  remove grpc sleep interval

### DIFF
--- a/caikit/runtime/config/config.yml
+++ b/caikit/runtime/config/config.yml
@@ -127,7 +127,6 @@ server_shutdown_grace_period_seconds: 45
 # Per-environment configurations
 environment: prod
 test:
-    grpc_server_sleep_interval: 1
     find_available_port: true
     runtime_version: mock
     caikit_library: sample_lib
@@ -156,10 +155,8 @@ test:
         auto_load_trained_model: true
         output_dir: test/training_output
 dev:
-    grpc_server_sleep_interval: 45
     runtime_version: real_implementation
 prod:
-    grpc_server_sleep_interval: 45
     runtime_version: real
 
 # TLS configs

--- a/tests/runtime/utils/test_configs.py
+++ b/tests/runtime/utils/test_configs.py
@@ -60,7 +60,7 @@ class TestConfigs(unittest.TestCase):
             # PROD should set the grpc sleep setting up to 45
             os.environ["ENVIRONMENT"] = "PROD"
             c = ConfigParser()
-            self.assertEqual(45, c.grpc_server_sleep_interval)
+            self.assertEqual("real", c.runtime_version)
         finally:
             # Try to make sure we re-set this to not bork other tests
             os.environ["ENVIRONMENT"] = old_deploy_env
@@ -69,7 +69,7 @@ class TestConfigs(unittest.TestCase):
         delete_config_singleton()
         try:
             with TemporaryDirectory() as tempdir:
-                cfg = {"grpc_server_sleep_interval": 7, "new_key": "new_value"}
+                cfg = {"new_key": "new_value"}
                 path = os.path.join(tempdir, "new_config.yml")
                 with open(path, "w") as f:
                     yaml.dump(cfg, f)
@@ -77,7 +77,6 @@ class TestConfigs(unittest.TestCase):
                 os.environ["CONFIG_FILES"] = path
                 c = ConfigParser()
 
-                self.assertEqual(7, c.grpc_server_sleep_interval)
                 self.assertEqual("new_value", c.new_key)
         finally:
             os.environ["CONFIG_FILES"] = ""


### PR DESCRIPTION
legacy config that wasn't deleted when we deleted the server's busy loop