### PR TITLE
⬆️ expand protobuf range even further

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "grpcio>=1.35.0,<2.0",
     "ijson>=3.1.4,<3.2.0",
     "munch>=2.5.0,<3.0",
-    "protobuf>=3.20.1,<5",
+    "protobuf>=3.19.0,<5",
     "prometheus_client==0.12.0",
     "py-grpc-prometheus>=0.7.0,<0.8",
     "PyYAML>=6.0,<7.0",


### PR DESCRIPTION
To add compatibility against `tensorflow` versions in which they specify `protobuf - required: >=3.9.2,<3.20`