### PR TITLE
test: Add more sig_parsing tests

### DIFF
--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -33,11 +33,6 @@ KNOWN_ARG_TYPES = {
     "producer_id": "ProducerId",
 }
 
-KNOWN_OUTPUT_TYPES = {
-    "SampleTaskPredict": "SampleOutputType",
-    "OtherTaskPredict": "OtherOutputType",
-}
-
 
 @alog.logged_function(log.debug2)
 def get_output_type_name(
@@ -68,14 +63,11 @@ def get_output_type_name(
     if type_from_docstring:
         return type_from_docstring
 
-    # Check based on naming conventions and then known output types
-    module_parts = module_class.__module__.split(".")
-    log.debug3("Parent module parts for %s: %s", module_class.__name__, module_parts)
-
-    # TODO: this part needs a test (or consider deleting and say user needs to specify output type)
-    class_name = _snake_to_camel(module_parts[2]) + "Predict"
-    return _get_dm_type_from_name(class_name) or _get_dm_type_from_name(
-        KNOWN_OUTPUT_TYPES.get(class_name)
+    # If we get here, it means no annotation or docstring for type was provided
+    log.warning(
+        "Could not deduct output type from function %s for module class %s.",
+        fn_signature,
+        module_class.__name__,
     )
 
 

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -30,12 +30,13 @@ log = alog.use_channel("SIG-PARSING")
 
 # Constants ##################################
 KNOWN_ARG_TYPES = {
-    "syntax_doc": "SyntaxPrediction",
     "producer_id": "ProducerId",
-    "raw_document": "RawDocument",
 }
 
-KNOWN_OUTPUT_TYPES = {}
+KNOWN_OUTPUT_TYPES = {
+    "SampleTaskPredict": "SampleOutputType",
+    "OtherTaskPredict": "OtherOutputType",
+}
 
 
 @alog.logged_function(log.debug2)
@@ -47,7 +48,6 @@ def get_output_type_name(
     """Get the type for a return type based on the name of the module class and
     the Caikit library naming convention.
     """
-    extra_candidate_names = []
     log.debug(fn_signature)
     # Check type annotation first
     if fn_signature.return_annotation != fn_signature.empty:
@@ -60,12 +60,6 @@ def get_output_type_name(
                     fn_signature.return_annotation,
                 )
                 return module_class
-
-            log.debug(
-                "Adding %s to list of candidate type names to search for concrete types:",
-                fn_signature.return_annotation,
-            )
-            extra_candidate_names.append(fn_signature.return_annotation)
         else:
             return fn_signature.return_annotation
 
@@ -79,7 +73,7 @@ def get_output_type_name(
     log.debug3("Parent module parts for %s: %s", module_class.__name__, module_parts)
 
     # TODO: this part needs a test (or consider deleting and say user needs to specify output type)
-    class_name = _snake_to_camel(module_parts[2]) + "Prediction"
+    class_name = _snake_to_camel(module_parts[2]) + "Predict"
     return _get_dm_type_from_name(class_name) or _get_dm_type_from_name(
         KNOWN_OUTPUT_TYPES.get(class_name)
     )

--- a/tests/runtime/service_generation/signature_parsing/test_parsers.py
+++ b/tests/runtime/service_generation/signature_parsing/test_parsers.py
@@ -79,6 +79,7 @@ def test_get_output_type_name():
         == sample_lib.data_model.SampleOutputType
     )
 
+
 def test_get_argument_types_with_real_block():
     """Quick check that we get the right type for our sample block"""
     assert (
@@ -123,6 +124,7 @@ def test_get_argument_type_from_malformed_docstring():
         pass
 
     assert get_argument_types(_run)["foo"] == sample_lib.data_model.SampleInputType
+
 
 def test_get_args_with_no_annotation():
     """Check that we get arguments with known arg type supplied"""


### PR DESCRIPTION
For Issue #15 

What I assumed:
- We do not need "syntax_doc" and "raw_document" as KNOWN_ARG_TYPES
- I added "SampleOutputType" and "OtherOutputType" as KNOWN_OUTPUT_TYPES

This PR added more tests to increase the coverage for parsers.py

Before: 69%
![Screen Shot 2023-04-19 at 11 26 29 AM](https://user-images.githubusercontent.com/1454122/233155618-630c39b7-8d0e-4bdc-9229-03ad64fed8b8.png)
After this PR: 100%
![Screen Shot 2023-04-19 at 11 33 02 AM](https://user-images.githubusercontent.com/1454122/233155657-aeba69a9-d0f5-450d-923d-1f88dc6badf4.png)
