### PR TITLE
🐛 fix none output type

### DIFF
--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -89,10 +89,6 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
     typing_origin = get_origin(arg_type)
     typing_args = get_args(arg_type)
 
-    # If it's none, return as none. Caikit checks for None later.
-    if arg_type is None:
-        return arg_type
-
     # If this is a data model type, no need to do anything
     if isinstance(arg_type, type) and issubclass(arg_type, DataBase):
         return arg_type
@@ -110,8 +106,10 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
             )
             return extract_data_model_type_from_union(dm_types[0])
 
-    # anything else is an invalid output type
-    raise RuntimeError(f"Invalid arg type for output : {arg_type}")
+    # if it's anything else we just return as is
+    # we don't actually want to throw errors from service generation
+    log.warning("Return type [%s] not a DM type, returning as is", arg_type)
+    return arg_type
 
 
 def is_primitive_method(

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -89,6 +89,10 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
     typing_origin = get_origin(arg_type)
     typing_args = get_args(arg_type)
 
+    # If it's none, return as none. Caikit checks for None later.
+    if arg_type is None:
+        return arg_type
+
     # If this is a data model type, no need to do anything
     if isinstance(arg_type, type) and issubclass(arg_type, DataBase):
         return arg_type

--- a/tests/runtime/service_generation/test_primitives.py
+++ b/tests/runtime/service_generation/test_primitives.py
@@ -11,6 +11,10 @@ from caikit.runtime.service_generation.primitives import (
 from sample_lib.data_model import SampleOutputType
 
 
+def test_to_output_dm_type_with_None():
+    assert extract_data_model_type_from_union(None) == None
+
+
 def test_to_output_dm_type_with_dm():
     assert extract_data_model_type_from_union(SampleOutputType) == SampleOutputType
 

--- a/tests/runtime/service_generation/test_primitives.py
+++ b/tests/runtime/service_generation/test_primitives.py
@@ -15,6 +15,10 @@ def test_to_output_dm_type_with_None():
     assert extract_data_model_type_from_union(None) == None
 
 
+def test_to_output_dm_type_with_raw_primitive():
+    assert extract_data_model_type_from_union(str) == str
+
+
 def test_to_output_dm_type_with_dm():
     assert extract_data_model_type_from_union(SampleOutputType) == SampleOutputType
 
@@ -31,8 +35,3 @@ def test_to_output_dm_type_with_union_optional_dm():
         extract_data_model_type_from_union(Union[Optional[SampleOutputType], str])
         == SampleOutputType
     )
-
-
-def test_to_output_dm_type_raises_primitive():
-    with pytest.raises(RuntimeError):
-        extract_data_model_type_from_union(str)


### PR DESCRIPTION
We don't want to throw in service generation even if the output type is not a DM object. 