### PR TITLE
:construction_worker: Enable daily dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily
+      interval: "daily"


### PR DESCRIPTION
With this PR, [Dependabot](https://dependabot.com/) can automatically scan the dependencies daily as described in `pyproject.toml` and create a PRif there is a newer version of the upstream package available.