### PR TITLE
test: Docstrings module tests

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -256,7 +256,7 @@ class _DataBaseMetaClass(type):
     def _make_property_getter(mcs, field):
         """This helper creates an @property attribute getter for the given field
 
-        NOTE: This needs to live as a standalone funciton in order for the given
+        NOTE: This needs to live as a standalone function in order for the given
             field name to be properly bound to the closure for the attrs
         """
         private_name = f"_{field}"

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -123,11 +123,12 @@ def _remove_non_primitive_modules(
     # If the module is not "primitive" we won't include it
     for ck_module in modules:
         signature = CaikitCoreModuleMethodSignature(ck_module, "run")
-        if not is_primitive_method(signature, primitive_data_model_types):
-            log.debug("Skipping non-primitive module %s", ck_module)
-            continue
+        if signature.parameters and signature.return_type:
+            if not is_primitive_method(signature, primitive_data_model_types):
+                log.debug("Skipping non-primitive module %s", ck_module)
+                continue
 
-        primitive_modules.append(ck_module)
+            primitive_modules.append(ck_module)
     return primitive_modules
 
 

--- a/caikit/runtime/service_generation/signature_parsing/docstrings.py
+++ b/caikit/runtime/service_generation/signature_parsing/docstrings.py
@@ -21,12 +21,14 @@ import sys
 
 # Third Party
 import docstring_parser
+import grpc
 
 # First Party
 import alog
 
 # Local
 from caikit.core.data_model.base import DataBase
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import caikit.core
 
 log = alog.use_channel("DOCSTRINGS")
@@ -44,9 +46,11 @@ def get_return_type(fn: Callable) -> Optional[Type]:
     """
     try:
         docstring = docstring_parser.parse(fn.__doc__)
-    except docstring_parser.ParseError:
-        log.warning("Failed to parse the docstring for %s", fn.__name__)
-        return None
+    except Exception as exc:
+        raise CaikitRuntimeException(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            f"ParseError when parsing docstring for function: {fn.__name__}",
+        ) from exc
 
     type_names, desc_names = _get_candidate_type_names_from_docstring(docstring.returns)
 
@@ -71,9 +75,11 @@ def is_optional(fn: Callable, arg_name: str) -> bool:
     """
     try:
         docstring = docstring_parser.parse(fn.__doc__)
-    except docstring_parser.ParseError:
-        log.warning("Failed to parse the docstring for %s", fn.__name__)
-        return None
+    except Exception as exc:
+        raise CaikitRuntimeException(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            f"ParseError when parsing docstring for function: {fn.__name__}",
+        ) from exc
 
     ds_param = [param for param in docstring.params if param.arg_name == arg_name]
     if ds_param:
@@ -107,9 +113,11 @@ def get_arg_type(fn: Callable, arg_name: str) -> Optional[Type]:
 
     try:
         docstring = docstring_parser.parse(fn.__doc__)
-    except docstring_parser.ParseError:
-        log.warning("Failed to parse the docstring for %s", fn.__name__)
-        return None
+    except Exception as exc:
+        raise CaikitRuntimeException(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            f"ParseError when parsing docstring for function: {fn.__name__}",
+        ) from exc
 
     ds_param = [param for param in docstring.params if param.arg_name == arg_name]
     if ds_param:

--- a/caikit/runtime/service_generation/signature_parsing/docstrings.py
+++ b/caikit/runtime/service_generation/signature_parsing/docstrings.py
@@ -42,9 +42,10 @@ def get_return_type(fn: Callable) -> Optional[Type]:
     Returns:
         The return type of `fn`, if it can be parsed from the docstring. Otherwise, None
     """
-    docstring = docstring_parser.parse(fn.__doc__)
-    if not docstring:
-        log.warning("Failed to parse the docstring")
+    try:
+        docstring = docstring_parser.parse(fn.__doc__)
+    except docstring_parser.ParseError:
+        log.warning("Failed to parse the docstring for %s", fn.__name__)
         return None
 
     type_names, desc_names = _get_candidate_type_names_from_docstring(docstring.returns)
@@ -68,10 +69,11 @@ def is_optional(fn: Callable, arg_name: str) -> bool:
         arg_name: The name of the parameter that we should try to get the type of
             e.g. "raw_document"
     """
-    docstring = docstring_parser.parse(fn.__doc__)
-    if not docstring:
+    try:
+        docstring = docstring_parser.parse(fn.__doc__)
+    except docstring_parser.ParseError:
         log.warning("Failed to parse the docstring for %s", fn.__name__)
-        return False
+        return None
 
     ds_param = [param for param in docstring.params if param.arg_name == arg_name]
     if ds_param:
@@ -88,6 +90,7 @@ def is_optional(fn: Callable, arg_name: str) -> bool:
                     return True
 
         return False
+    return False
 
 
 def get_arg_type(fn: Callable, arg_name: str) -> Optional[Type]:
@@ -102,9 +105,10 @@ def get_arg_type(fn: Callable, arg_name: str) -> Optional[Type]:
         The return type of `fn`, if it can be parsed from the docstring. Otherwise, None
     """
 
-    docstring = docstring_parser.parse(fn.__doc__)
-    if not docstring:
-        log.warning("Failed to parse the docstring for function %s", fn.__name__)
+    try:
+        docstring = docstring_parser.parse(fn.__doc__)
+    except docstring_parser.ParseError:
+        log.warning("Failed to parse the docstring for %s", fn.__name__)
         return None
 
     ds_param = [param for param in docstring.params if param.arg_name == arg_name]
@@ -196,7 +200,7 @@ def _get_docstring_type(
             log.debug2(f"Found valid candidate type on sys.modules: {candidate_type}")
             continue
 
-        # If the type was not fully qualified (like a `RawDocument`), look in a couple well known
+        # If the type was not fully qualified (like a `ProducerId`), look in a couple well known
         # places - the caikit core data model itself
         candidate_type = _extract_type_from_pymodule(
             caikit.interfaces.common.data_model, type_name

--- a/caikit/runtime/service_generation/signature_parsing/parsers.py
+++ b/caikit/runtime/service_generation/signature_parsing/parsers.py
@@ -25,6 +25,7 @@ import alog
 from . import docstrings
 from caikit.core.data_model.base import DataBase
 from caikit.core.module import ModuleBase
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("SIG-PARSING")
 
@@ -59,7 +60,12 @@ def get_output_type_name(
             return fn_signature.return_annotation
 
     # Check the docstring
-    type_from_docstring = docstrings.get_return_type(fn)
+    type_from_docstring = None
+    try:
+        type_from_docstring = docstrings.get_return_type(fn)
+    except CaikitRuntimeException:
+        log.warning("Failed to parse the docstring for %s", fn)
+
     if type_from_docstring:
         return type_from_docstring
 
@@ -133,7 +139,11 @@ def _get_argument_type(
         return dm_type_from_known_arg_types
 
     # Check docstring for optional arg
-    optional_arg = docstrings.is_optional(module_method, arg.name)
+    optional_arg = False
+    try:
+        optional_arg = docstrings.is_optional(module_method, arg.name)
+    except CaikitRuntimeException:
+        log.warning("Failed to parse the docstring for %s", module_method)
 
     # Look for a type annotation
     if arg.annotation != inspect.Parameter.empty:
@@ -150,8 +160,11 @@ def _get_argument_type(
         return default_type
 
     # Parse docstring
-
-    type_from_docstring = docstrings.get_arg_type(module_method, arg.name)
+    type_from_docstring = None
+    try:
+        type_from_docstring = docstrings.get_arg_type(module_method, arg.name)
+    except CaikitRuntimeException:
+        log.warning("Failed to parse the docstring for %s", module_method)
     if type_from_docstring:
         if optional_arg:
             return Optional[type_from_docstring]

--- a/tests/runtime/service_generation/signature_parsing/test_docstrings.py
+++ b/tests/runtime/service_generation/signature_parsing/test_docstrings.py
@@ -31,6 +31,7 @@ from caikit.runtime.service_generation.signature_parsing.docstrings import (
     get_return_type,
     is_optional,
 )
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.data_model import SampleInputType
 import caikit
 import sample_lib
@@ -107,9 +108,17 @@ def test_is_optional_works_on_corner_cases_docstrings():
 
     assert is_optional(_fn, "some_input") == True
 
-    # test if docstring_parser.parse throws an exception, we return None
+    # test if docstring_parser.parse throws an exception, we throw an exception
     with patch("docstring_parser.parse", side_effect=ParseError("mocked error")):
-        assert is_optional(_fn, "some_input") == None
+        with pytest.raises(CaikitRuntimeException) as e:
+            is_optional(_fn, "some_input")
+        assert "ParseError when parsing docstring for function: _fn" in e.value.message
+
+    def _fn(input):
+        pass
+
+    # test is_optional works on empty docstring
+    assert is_optional(_fn, "input") == False
 
 
 def test_get_arg_type_works_on_corner_cases_docstrings():
@@ -134,9 +143,17 @@ def test_get_arg_type_works_on_corner_cases_docstrings():
 
     assert get_arg_type(_fn, "some_input") == int
 
-    # test if docstring_parser.parse throws an exception, we return None
+    # test if docstring_parser.parse throws an exception, we throw an exception
     with patch("docstring_parser.parse", side_effect=ParseError("mocked error")):
-        assert get_arg_type(_fn, "some_input") == None
+        with pytest.raises(CaikitRuntimeException) as e:
+            get_arg_type(_fn, "some_input")
+        assert "ParseError when parsing docstring for function: _fn" in e.value.message
+
+    # test get_arg_type works on empty docstring
+    def _fn_no_docstring(input):
+        pass
+
+    assert get_arg_type(_fn_no_docstring, "input") == None
 
 
 def test_get_return_type_corner_case_with_exception():
@@ -146,6 +163,8 @@ def test_get_return_type_corner_case_with_exception():
     # test get_return_type works on empty docstring
     assert get_return_type(_fn) == None
 
-    # test if docstring_parser.parse throws an exception, we return None
+    # test if docstring_parser.parse throws an exception, we throw an exception
     with patch("docstring_parser.parse", side_effect=ParseError("mocked error")):
-        assert get_return_type(_fn) == None
+        with pytest.raises(CaikitRuntimeException) as e:
+            get_return_type(_fn)
+        assert "ParseError when parsing docstring for function: _fn" in e.value.message

--- a/tests/runtime/service_generation/signature_parsing/test_docstrings.py
+++ b/tests/runtime/service_generation/signature_parsing/test_docstrings.py
@@ -16,24 +16,64 @@
 Coverage is probably not the best
 """
 # Standard
-from typing import List
+from typing import List, Optional, Union
+from unittest.mock import patch
+
+# Third Party
+from docstring_parser import ParseError
+import pytest
 
 # Local
 from caikit.runtime.service_generation.signature_parsing.docstrings import (
     _extract_nested_type,
     _get_docstring_type,
+    get_arg_type,
+    get_return_type,
+    is_optional,
 )
 from sample_lib.data_model import SampleInputType
+import caikit
 import sample_lib
 
 
 def test_get_docstring_type():
     # TODO: fun edge case where producer word in description is found in types
+    # works on a sample_lib type
     assert (
         _get_docstring_type(
             candidate_type_names=["sample_lib.data_model.SampleOutputType"],
         )
         == sample_lib.data_model.SampleOutputType
+    )
+
+    # works on nested type
+    assert (
+        _get_docstring_type(
+            candidate_type_names=["List(int)"],
+        )
+        == List[int]
+    )
+
+    # works on a well known type
+    assert (
+        _get_docstring_type(
+            candidate_type_names=["ProducerId"],
+        )
+        == caikit.core.data_model.ProducerId
+    )
+
+    # returns a Union on valid types
+    assert (
+        _get_docstring_type(
+            candidate_type_names=[
+                "SampleInputType",
+                "sample_lib.data_model.SampleOutputType",
+            ],
+        )
+        == Union[
+            sample_lib.data_model.SampleOutputType,
+            sample_lib.data_model.SampleInputType,
+        ]
     )
 
 
@@ -45,3 +85,67 @@ def test_extract_nested_type():
     assert _extract_nested_type("list(str)") == List[str]
     assert _extract_nested_type("List(SampleInputType)") == List[SampleInputType]
     assert _extract_nested_type("int") == None
+
+
+def test_is_optional_works_on_corner_cases_docstrings():
+    """
+    Test that is_optional works on different corner cases of docstrings for an optional field
+    """
+    # test docstring with multiple params of the same name still works, but
+    # evaluated whether "optional" on the first description
+    def _fn(self, some_input: Optional[int]):
+        """
+        Args:
+            some_input: yadda yadda blah int
+                optional int for input
+            some_input: I repeat myself
+
+        Returns:
+            None
+        """
+        pass
+
+    assert is_optional(_fn, "some_input") == True
+
+    # test if docstring_parser.parse throws an exception, we return None
+    with patch("docstring_parser.parse", side_effect=ParseError("mocked error")):
+        assert is_optional(_fn, "some_input") == None
+
+
+def test_get_arg_type_works_on_corner_cases_docstrings():
+    """
+    Test that get_arg_type works on different corner cases of docstrings
+    """
+    # test docstring with multiple params of the same name still works, but
+    # evaluated the type on the first description
+    def _fn(self, some_input: str):
+        """
+
+        Args:
+            some_input: yadda yadda blah int
+                int for input
+            some_input: I repeat myself but type str here
+                str for input
+
+        Returns:
+            None
+        """
+        pass
+
+    assert get_arg_type(_fn, "some_input") == int
+
+    # test if docstring_parser.parse throws an exception, we return None
+    with patch("docstring_parser.parse", side_effect=ParseError("mocked error")):
+        assert get_arg_type(_fn, "some_input") == None
+
+
+def test_get_return_type_corner_case_with_exception():
+    def _fn():
+        pass
+
+    # test get_return_type works on empty docstring
+    assert get_return_type(_fn) == None
+
+    # test if docstring_parser.parse throws an exception, we return None
+    with patch("docstring_parser.parse", side_effect=ParseError("mocked error")):
+        assert get_return_type(_fn) == None

--- a/tests/runtime/service_generation/test_create_service.py
+++ b/tests/runtime/service_generation/test_create_service.py
@@ -29,6 +29,15 @@ untrainable_module_class = sample_lib.blocks.sample_task.SamplePrimitiveBlock
 ### create_inference_rpcs tests #################################################
 
 
+def test_create_inference_rpcs_for_module_with_no_run_function():
+    class Foo:
+        def __init__(self):
+            pass
+
+    rpcs = create_inference_rpcs([Foo])
+    assert len(rpcs) == 0
+
+
 def test_create_inference_rpcs():
     rpcs = create_inference_rpcs([widget_class])
     assert len(rpcs) == 1
@@ -76,6 +85,21 @@ def test_create_inference_rpcs_remove_non_primitive_modules():
 
 
 ### create_training_rpcs tests #################################################
+
+
+def test_create_inference_rpcs_for_module_with_no_train_function():
+    class Foo:
+        def __init__(self):
+            pass
+
+        def run(self):
+            pass
+
+        def train_in_progress(self):
+            pass
+
+    rpcs = create_inference_rpcs([Foo])
+    assert len(rpcs) == 0
 
 
 def test_create_training_rpcs():


### PR DESCRIPTION
This PR is part of Issue #15

- refactors the 3 methods in `docstrings.py` that use 3rd party `docstring_parser.parse` [function](https://github.com/rr-/docstring_parser/blob/master/docstring_parser/parser.py#L23) to instead of checking for None, handle the `ParseError` exception. 
- adjusts the tests to mock the exception raised. I don't think we ever get this exception because we call `docstring_parser.parse` with Auto style, we always get a Docstring object back, albeit a Docstring object with empty params.
- add more tests to increase docstring test coverage:
![Screen Shot 2023-04-26 at 3 18 01 PM](https://user-images.githubusercontent.com/1454122/234706956-b0b1b66f-336c-41c7-aebe-932ab0212b34.png)


**Updated:**
- When handling `ParseError` exception, this PR adds a raise for `CaikitRuntimeException` and lets the callers of those 3 methods in `parsers.py` decide what to do with that exception. In this case, these callers log a warning that the docstring was not parseable and continue their type deduction task without docstring.
- Also figured I'd add tests to cover the rest of `module_signature.py` file to bring the coverage of `signature_parsing` module to 100%
![Screen Shot 2023-04-27 at 4 19 53 PM](https://user-images.githubusercontent.com/1454122/235004229-649a7254-750c-4f94-9aa3-20ac48aaa74c.png)
