### PR TITLE
:sparkles: Add train process exit code handling

### DIFF
--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -360,6 +360,19 @@ class GlobalTrainServicer:
         proc.start()
         proc.join()
 
+        if proc.exitcode is not None:
+            # If process exited with a non-zero exit code
+            if proc.exitcode == 137:
+                raise CaikitRuntimeException(
+                    grpc.StatusCode.RESOURCE_EXHAUSTED,
+                    "Training process died with OOM error!"
+                )
+            else:
+                raise CaikitRuntimeException(
+                    grpc.StatusCode.UNKNOWN,
+                    f"Training process died with exit code {proc.exitcode}"
+                )
+
         # If an error occurred, reraise it here
         # TODO: Make sure the stack trace is preserved
         if proc.error is not None:

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -374,16 +374,16 @@ class GlobalTrainServicer:
             ) from proc.error
 
         # If process exited with a non-zero exit code
-        if proc.exitcode and proc.exitcode != 0:
+        if proc.exitcode and proc.exitcode != os.EX_OK:
             if proc.exitcode == OOM_EXIT_CODE:
                 raise CaikitRuntimeException(
                     grpc.StatusCode.RESOURCE_EXHAUSTED,
-                    "Training process died with OOM error!"
+                    "Training process died with OOM error!",
                 )
             else:
                 raise CaikitRuntimeException(
                     grpc.StatusCode.UNKNOWN,
-                    f"Training process died with exit code {proc.exitcode}"
+                    f"Training process died with exit code {proc.exitcode}",
                 )
 
     class _ErrorCaptureProcess(multiprocessing.get_context("fork").Process):

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -376,15 +376,16 @@ class GlobalTrainServicer:
         # If process exited with a non-zero exit code
         if proc.exitcode and proc.exitcode != os.EX_OK:
             if proc.exitcode == OOM_EXIT_CODE:
-                raise CaikitRuntimeException(
+                exception = CaikitRuntimeException(
                     grpc.StatusCode.RESOURCE_EXHAUSTED,
                     "Training process died with OOM error!",
                 )
             else:
-                raise CaikitRuntimeException(
+                exception = CaikitRuntimeException(
                     grpc.StatusCode.UNKNOWN,
                     f"Training process died with exit code {proc.exitcode}",
                 )
+            raise exception
 
     class _ErrorCaptureProcess(multiprocessing.get_context("fork").Process):
         """This class wraps a Process and keeps track of any errors that occur

--- a/tests/fixtures/sample_lib/blocks/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/blocks/sample_task/sample_implementation.py
@@ -1,6 +1,9 @@
 """
 A sample block for sample things!
 """
+# Standard
+import os
+
 # Local
 from ...data_model.sample import SampleInputType, SampleOutputType, SampleTrainingType
 from caikit.core.data_model import DataStream
@@ -65,8 +68,10 @@ class SampleBlock(caikit.core.BlockBase):
         """Sample training method that produces a trained model"""
 
         if oom_exit:
-            # exit with OOM code
-            exit(137)
+            # exit with OOM code. Note _exit method is used to exit the
+            # process with specified status without calling cleanup handlers
+            # to replicate OOM scenario
+            os._exit(137)
 
         if batch_size == cls.POISON_PILL_BATCH_SIZE:
             raise ValueError(

--- a/tests/fixtures/sample_lib/blocks/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/blocks/sample_task/sample_implementation.py
@@ -60,8 +60,14 @@ class SampleBlock(caikit.core.BlockBase):
         cls,
         training_data: DataStream[SampleTrainingType],
         batch_size: int = 64,
+        oom_exit: bool = False,
     ) -> "SampleBlock":
         """Sample training method that produces a trained model"""
+
+        if oom_exit:
+            # exit with OOM code
+            exit(137)
+
         if batch_size == cls.POISON_PILL_BATCH_SIZE:
             raise ValueError(
                 f"Batch size of {cls.POISON_PILL_BATCH_SIZE} is not allowed!"

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -396,6 +396,34 @@ def test_global_train_Edge_Case_Widget_should_raise_when_error_surfaces_from_blo
     assert f"This may be a problem with your input" in str(context.value.message)
 
 
+def test_global_train_returns_exit_code_with_oom(
+    sample_train_service, sample_train_servicer
+):
+    """Test that if block goes into OOM we are able to surface error code"""
+    stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
+    training_data = stream_type(
+        jsondata=stream_type.JsonData(data=[SampleTrainingType(1)])
+    ).to_proto()
+    train_request = (
+        sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
+            model_name="Foo Bar Training",
+            batch_size=42,
+            training_data=training_data,
+            oom_exit=True,
+        )
+    )
+
+    # Enable sub-processing for test
+    sample_train_servicer.use_subprocess = True
+
+    with pytest.raises(CaikitRuntimeException) as context:
+        training_response = sample_train_servicer.Train(train_request)
+        sample_train_servicer.training_map.get(
+            training_response.training_id
+        ).result()
+
+    assert f"Training process died with OOM error!" in str(context.value.message)
+
 #####################################################################
 
 # NOTE: This test was commented out in the original unittest.TestCase impl - leaving as is

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -413,9 +413,6 @@ def test_global_train_returns_exit_code_with_oom(
         )
     )
 
-    # Enable sub-processing for test
-    sample_train_servicer.use_subprocess = True
-
     with pytest.raises(CaikitRuntimeException) as context:
         training_response = sample_train_servicer.Train(train_request)
         sample_train_servicer.training_map.get(

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -413,13 +413,15 @@ def test_global_train_returns_exit_code_with_oom(
         )
     )
 
+    # Enable sub-processing for test
+    sample_train_servicer.use_subprocess = True
+
     with pytest.raises(CaikitRuntimeException) as context:
         training_response = sample_train_servicer.Train(train_request)
-        sample_train_servicer.training_map.get(
-            training_response.training_id
-        ).result()
+        sample_train_servicer.training_map.get(training_response.training_id).result()
 
     assert f"Training process died with OOM error!" in str(context.value.message)
+
 
 #####################################################################
 


### PR DESCRIPTION
### Changes
- Add subprocess exit code handling for training to allow capturing OOM type failures that kills the subprocess