### PR TITLE
:bug: add second argument to interrupt()

### DIFF
--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -224,7 +224,7 @@ class RuntimeGRPCServer:
         if blocking:
             self.server.wait_for_termination(None)
 
-    def interrupt(self, signal_):
+    def interrupt(self, signal_, _stack_frame):
         """Interrupt the server. Implements the interface for Python signal.signal
 
         Reference: https://docs.python.org/3/library/signal.html#signal.signal

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -712,7 +712,7 @@ def test_metrics_stored_after_server_interrupt(
         )
 
         # Interrupt server
-        server.interrupt(None)
+        server.interrupt(None, None)
 
         # Assertions on the created metrics file
         with open(server._global_predict_servicer.rpc_meter.file_path) as f:


### PR DESCRIPTION
The `signal.signal` interface has a second argument:

> The handler is called with two arguments: the signal number and the current stack frame

REF: https://docs.python.org/3/library/signal.html#signal.signal

Without this change, sending a signal to the server process results in a stack trace with:
```
TypeError: interrupt() takes 2 positional arguments but 3 were given
```