### PR TITLE
♻️ warning message for missing train service

### DIFF
--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -355,7 +355,7 @@ def main():
             service_source,
         )
     except CaikitRuntimeException as e:
-        log.error("Cannot stand up training service, disabling training: %s", e)
+        log.warning("Cannot stand up training service, disabling training: %s", e)
         training_service = None
 
     server = RuntimeGRPCServer(

--- a/caikit/runtime/utils/import_util.py
+++ b/caikit/runtime/utils/import_util.py
@@ -164,7 +164,7 @@ def get_dynamic_module(module_name: str, module_dir: str = None) -> ModuleType:
     spec = importlib.util.find_spec(module_path)
     if not spec:
         message = "Unable to find spec for module: %s" % (module_path)
-        log.error("<RUN11991313E>", message)
+        log.warning("<RUN11991313E>", message)
         raise CaikitRuntimeException(StatusCode.NOT_FOUND, message)
     # Found spec - import the library
     if module_dir:

--- a/caikit/runtime/utils/import_util.py
+++ b/caikit/runtime/utils/import_util.py
@@ -164,6 +164,8 @@ def get_dynamic_module(module_name: str, module_dir: str = None) -> ModuleType:
     spec = importlib.util.find_spec(module_path)
     if not spec:
         message = "Unable to find spec for module: %s" % (module_path)
+        # TODO: figure out the better way of doing this
+        # https://github.com/caikit/caikit/pull/85#discussion_r1182890609
         log.warning("<RUN11991313W>", message)
         raise CaikitRuntimeException(StatusCode.NOT_FOUND, message)
     # Found spec - import the library

--- a/caikit/runtime/utils/import_util.py
+++ b/caikit/runtime/utils/import_util.py
@@ -164,7 +164,7 @@ def get_dynamic_module(module_name: str, module_dir: str = None) -> ModuleType:
     spec = importlib.util.find_spec(module_path)
     if not spec:
         message = "Unable to find spec for module: %s" % (module_path)
-        log.warning("<RUN11991313E>", message)
+        log.warning("<RUN11991313W>", message)
         raise CaikitRuntimeException(StatusCode.NOT_FOUND, message)
     # Found spec - import the library
     if module_dir:


### PR DESCRIPTION
2 changes:
1. `grpc_server.py`:
    Doesn't make sense to have `log.error` for this statement since we still go forward with the initialization of the grpc server even if train service doesn't exist?
2. `import_util.py`:
    Doesn't make sense to `log.error` _and_ throw an exception? 