### PR TITLE
Data object base

### DIFF
--- a/caikit/core/__init__.py
+++ b/caikit/core/__init__.py
@@ -30,7 +30,7 @@ _warnings.filterwarnings("ignore")
 # must import toolkit first since we need alog to be set up before it is used
 from . import blocks, data_model, module, module_config, resources, toolkit, workflows
 from .blocks.base import BlockBase, block
-from .data_model import dataobject
+from .data_model import DataObjectBase, dataobject
 from .model_manager import *
 from .module import *
 from .module_backend_config import configure as backend_configure

--- a/caikit/core/data_model/__init__.py
+++ b/caikit/core/data_model/__init__.py
@@ -18,7 +18,12 @@
 
 # Local
 from . import base, data_backends, enums, producer, protobufs
-from .dataobject import CAIKIT_DATA_MODEL, dataobject, render_dataobject_protos
+from .dataobject import (
+    CAIKIT_DATA_MODEL,
+    DataObjectBase,
+    dataobject,
+    render_dataobject_protos,
+)
 from .enums import *
 from .producer import PACKAGE_COMMON, ProducerId
 from .streams import data_stream

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -19,13 +19,8 @@ model objects inline without manually defining the protobufs representation
 
 # Standard
 from enum import Enum
-from functools import update_wrapper
-from types import ModuleType
 from typing import Any, Callable, List, Type, Union, get_args, get_origin
 import dataclasses
-import importlib
-import sys
-import types
 
 # Third Party
 from google.protobuf import message as _message

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -46,6 +46,9 @@ from .base import DataBase, _DataBaseMetaClass
 log = alog.use_channel("SCHEMA")
 error = error_handler.get(log)
 
+# Common package prefix
+CAIKIT_DATA_MODEL = "caikit_data_model"
+
 # Registry of auto-generated protos so that they can be rendered to .proto
 _AUTO_GEN_PROTO_CLASSES = []
 
@@ -54,8 +57,43 @@ _USER_DEFINED_DEFAULTS = "__user_defined_defaults__"
 
 ## Public ######################################################################
 
-# Common package prefix
-CAIKIT_DATA_MODEL = "caikit_data_model"
+
+class _DataObjectBaseMetaClass(_DataBaseMetaClass):
+    """This metaclass is used for the DataObject base class so that all data
+    objects can delay the creation of their proto class until after the
+    metaclass has been instantiated.
+    """
+
+    def __new__(mcs, name, bases, attrs):
+        """When instantiating a new DataObject class, the proto class will not
+        yet have been generated, but the set of fields will be known since the
+        class will be the raw input representation of a @dataclass
+        """
+
+        # Get the annotations that will go into the dataclass
+        if name != "DataObjectBase":
+            raw_field_names = attrs.get("__annotations__")
+            if raw_field_names is None:
+                raise TypeError(
+                    "All DataObjectBase classes must follow dataclass syntax"
+                )
+
+            # TODO: Sort out oneof field names
+            field_names = list(raw_field_names.keys())
+
+            # Add the forward declaration
+            attrs[_DataBaseMetaClass._FWD_DECL_FIELDS] = field_names
+
+        # Delegate to the base metaclass
+        return super().__new__(mcs, name, bases, attrs)
+
+
+class DataObjectBase(DataBase, metaclass=_DataObjectBaseMetaClass):
+    """A DataObject is a data model class that is backed by a @dataclass.
+
+    Data model classes that use the @dataobject decorator must derive from this
+    base class.
+    """
 
 
 def dataobject(*args, **kwargs) -> Callable[[Type], Type[DataBase]]:
@@ -65,7 +103,7 @@ def dataobject(*args, **kwargs) -> Callable[[Type], Type[DataBase]]:
 
     @dataobject("foo.bar")
     @dataclass
-    class MyDataObject:
+    class MyDataObject(DataObjectBase):
         '''My Custom Data Object'''
         foo: str
         bar: int
@@ -88,9 +126,9 @@ def dataobject(*args, **kwargs) -> Callable[[Type], Type[DataBase]]:
         # Make sure that the wrapped class does NOT inherit from DataBase
         error.value_check(
             "<COR95184230E>",
-            not issubclass(cls, DataBase),
-            "{} should not directly inherit from DataBase when using @schema",
+            issubclass(cls, (DataObjectBase, Enum)),
             cls.__name__,
+            msg="{} must inherit from DataObjectBase/Enum when using @dataobject",
         )
 
         # Add the package to the kwargs
@@ -150,27 +188,14 @@ def dataobject(*args, **kwargs) -> Callable[[Type], Type[DataBase]]:
         # Declare the merged class that binds DataBase to the wrapped class with
         # this generated proto class
         if isinstance(proto_class, type):
-            wrapper_class = _make_data_model_class(proto_class, cls)
+            setattr(cls, "_proto_class", proto_class)
+            cls = _make_data_model_class(proto_class, cls)
         else:
             enums.import_enum(proto_class, cls)
             setattr(cls, "_proto_enum", proto_class)
-            wrapper_class = cls
 
-        # Attach the proto class to the protobufs module
-        parent_mod_name = getattr(cls, "__module__", "").rpartition(".")[0]
-        log.debug2("Parent mod name: %s", parent_mod_name)
-        if parent_mod_name:
-            proto_mod_name = ".".join([parent_mod_name, "protobufs"])
-            try:
-                proto_mod = importlib.import_module(proto_mod_name)
-            except ImportError:
-                log.debug("Creating new protobufs module: %s", proto_mod_name)
-                proto_mod = ModuleType(proto_mod_name)
-                sys.modules[proto_mod_name] = proto_mod
-            setattr(proto_mod, cls.__name__, proto_class)
-
-        # Return the merged data class
-        return wrapper_class
+        # Return the decorated class
+        return cls
 
     # If called without the function invocation, fill in the default argument
     if args and callable(args[0]):
@@ -215,9 +240,11 @@ class _DataobjectConverter(DataclassConverter):
     def get_concrete_type(self, entry: Any) -> Any:
         """Also include data model classes and enums as concrete types"""
         unwrapped = self._resolve_wrapped_type(entry)
-        if (isinstance(unwrapped, type) and issubclass(unwrapped, DataBase)) or hasattr(
-            unwrapped, "_proto_enum"
-        ):
+        if (
+            isinstance(unwrapped, type)
+            and issubclass(unwrapped, DataBase)
+            and unwrapped._proto_class is not None
+        ) or hasattr(unwrapped, "_proto_enum"):
             return entry
         return super().get_concrete_type(entry)
 
@@ -270,31 +297,32 @@ def _get_all_enums(
     return all_enums
 
 
-def _make_data_model_class(proto_class, wrapped_cls):
-    wrapper_cls = _DataBaseMetaClass(
-        wrapped_cls.__name__,
-        tuple([DataBase, wrapped_cls]),
-        {"_proto_class": proto_class, **wrapped_cls.__dict__},
-    )
-    update_wrapper(wrapper_cls, wrapped_cls, updated=())
+def _make_data_model_class(proto_class, cls):
+    if issubclass(cls, DataObjectBase):
+        _DataBaseMetaClass.parse_proto_descriptor(cls)
 
     # Recursively make all nested message wrappers
     for nested_message_descriptor in proto_class.DESCRIPTOR.nested_types:
         nested_message_name = nested_message_descriptor.name
         nested_proto_class = getattr(proto_class, nested_message_name)
         setattr(
-            wrapper_cls,
+            cls,
             nested_message_name,
             _make_data_model_class(
                 nested_proto_class,
-                types.new_class(nested_message_name),
+                _DataBaseMetaClass.__new__(
+                    _DataBaseMetaClass,
+                    name=nested_message_name,
+                    bases=(DataBase,),
+                    attrs={"_proto_class": getattr(proto_class, nested_message_name)},
+                ),
             ),
         )
     for nested_enum_descriptor in proto_class.DESCRIPTOR.enum_types:
         setattr(
-            wrapper_cls,
+            cls,
             nested_enum_descriptor.name,
             getattr(enums, nested_enum_descriptor.name),
         )
 
-    return wrapper_cls
+    return cls

--- a/caikit/core/data_model/producer.py
+++ b/caikit/core/data_model/producer.py
@@ -16,13 +16,13 @@ Common data model objects used to identify the producer of a given output
 """
 
 # Local
-from .dataobject import CAIKIT_DATA_MODEL, dataobject
+from .dataobject import CAIKIT_DATA_MODEL, DataObjectBase, dataobject
 
 PACKAGE_COMMON = f"{CAIKIT_DATA_MODEL}.common"
 
 
 @dataobject(PACKAGE_COMMON)
-class ProducerId:
+class ProducerId(DataObjectBase):
     """Information about a data structure and the module that produced it."""
 
     name: str

--- a/caikit/interfaces/common/data_model/producer.py
+++ b/caikit/interfaces/common/data_model/producer.py
@@ -19,7 +19,12 @@ from typing import List
 import alog
 
 # Local
-from caikit.core.data_model import PACKAGE_COMMON, ProducerId, dataobject
+from caikit.core.data_model import (
+    PACKAGE_COMMON,
+    DataObjectBase,
+    ProducerId,
+    dataobject,
+)
 from caikit.core.toolkit.errors import error_handler
 
 log = alog.use_channel("DATAM")
@@ -27,7 +32,7 @@ error = error_handler.get(log)
 
 
 @dataobject(PACKAGE_COMMON)
-class ProducerPriority:
+class ProducerPriority(DataObjectBase):
     """An ordered list of ProducerId structures in descending order of priority.
     This is used when handling conflicts between multiple producers of the same
     data structure.

--- a/caikit/interfaces/runtime/data_model/training_management.py
+++ b/caikit/interfaces/runtime/data_model/training_management.py
@@ -19,8 +19,8 @@ from enum import Enum
 import alog
 
 # Local
+from caikit.core.data_model import DataObjectBase, dataobject
 from caikit.core.toolkit.wip_decorator import Action, WipCategory, work_in_progress
-import caikit.core
 
 log = alog.use_channel("MDLOPS")
 
@@ -28,26 +28,26 @@ RUNTIME_PACKAGE = "caikit_data_model.runtime"
 
 
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
-@caikit.core.dataobject(RUNTIME_PACKAGE)
-class TrainingInfoRequest:
+@dataobject(RUNTIME_PACKAGE)
+class TrainingInfoRequest(DataObjectBase):
     training_id: str
 
 
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
-@caikit.core.dataobject(RUNTIME_PACKAGE)
-class TrainingJob:
+@dataobject(RUNTIME_PACKAGE)
+class TrainingJob(DataObjectBase):
     training_id: str
     model_name: str
 
 
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
-@caikit.core.dataobject(RUNTIME_PACKAGE)
-class ModelPointer:
+@dataobject(RUNTIME_PACKAGE)
+class ModelPointer(DataObjectBase):
     model_id: str
 
 
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
-@caikit.core.dataobject(RUNTIME_PACKAGE)
+@dataobject(RUNTIME_PACKAGE)
 class TrainingStatus(Enum):
     NOT_STARTED = 0
     HALTED = 1
@@ -59,8 +59,8 @@ class TrainingStatus(Enum):
 
 
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
-@caikit.core.dataobject(RUNTIME_PACKAGE)
-class TrainingInfoResponse:
+@dataobject(RUNTIME_PACKAGE)
+class TrainingInfoResponse(DataObjectBase):
     training_id: str
     status: TrainingStatus
     submission_timestamp: str

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -41,8 +41,12 @@ import alog
 
 # Local
 from caikit import get_config
-from caikit.core import dataobject
 from caikit.core.data_model.base import DataBase
+from caikit.core.data_model.dataobject import (
+    DataObjectBase,
+    _DataObjectBaseMetaClass,
+    dataobject,
+)
 from caikit.core.module import ModuleBase
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,
@@ -350,7 +354,12 @@ class ServicePackageFactory:
                 continue
 
             decorator = dataobject(package=package_name)
-            cls_ = type(task.request.name, (object,), attrs)
+            cls_ = _DataObjectBaseMetaClass.__new__(
+                _DataObjectBaseMetaClass,
+                name=task.request.name,
+                bases=(DataObjectBase,),
+                attrs=attrs,
+            )
             decorated_cls = decorator(cls_)
             data_model_classes.append(decorated_cls)
 

--- a/tests/core/data_model/test_base.py
+++ b/tests/core/data_model/test_base.py
@@ -87,8 +87,8 @@ def test_derived_class_no_proto_class():
                 )
             )
 
-        # Make sure an AttributeError is raised when the import is tried
-        with pytest.raises(AttributeError):
+        # Make sure an ValueError is raised when the import is tried
+        with pytest.raises(ValueError):
             importlib.import_module(".".join([mod_name, "object"]))
 
 
@@ -110,8 +110,8 @@ def test_derived_class_no_proto_mod():
                 )
             )
 
-        # Make sure an AttributeError is raised when the import is tried
-        with pytest.raises(AttributeError):
+        # Make sure an ValueError is raised when the import is tried
+        with pytest.raises(ValueError):
             importlib.import_module(".".join([mod_name, "object"]))
 
 

--- a/tests/core/data_model/test_base.py
+++ b/tests/core/data_model/test_base.py
@@ -144,8 +144,10 @@ def test_derived_class_no_import_side_effects():
             handle.write(
                 justify_script_string(
                     """
+                    from . import protobufs
                     from caikit.core.data_model import base
                     class Object(base.DataBase):
+                        _proto_class = protobufs.Object
                         def __init__(self, foo):
                             self.foo = foo
                     """

--- a/tests/data_model_helpers.py
+++ b/tests/data_model_helpers.py
@@ -154,14 +154,15 @@ def make_proto_def(message_specs: Dict[str, dict], pkg_suffix: str = None) -> st
     package_name = f"{caikit.core.data_model.CAIKIT_DATA_MODEL}.{pkg_suffix}"
     out = justify_script_string(
         """
-        from dataclasses import dataclass
         from typing import Dict, List
-        import caikit.core
+        from caikit.core.data_model import DataObjectBase, dataobject
 
         """
     )
     for message_name, message_spec in message_specs.items():
-        msg_str = f'\n@caikit.core.dataobject("{package_name}")\n@dataclass\nclass {message_name}:\n'
+        msg_str = (
+            f'\n@dataobject("{package_name}")\nclass {message_name}(DataObjectBase):\n'
+        )
         for field_name, field_type in message_spec.items():
             msg_str += f"    {field_name}: {_get_proto_val_name(field_type)}\n"
         msg_str += "\n"

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -1,41 +1,35 @@
 """
 Dummy data model object for testing
 """
-# Standard
-from dataclasses import dataclass
 
 # Local
-import caikit.core
+from caikit.core.data_model import DataObjectBase, dataobject
 
 
-@caikit.core.dataobject(package="caikit_data_model.sample_lib")
-@dataclass
-class SampleInputType:
+@dataobject(package="caikit_data_model.sample_lib")
+class SampleInputType(DataObjectBase):
     """A sample `domain primitive` input type for this library.
     The analog to a `Raw Document` for the `Natural Language Processing` domain."""
 
     name: str
 
 
-@caikit.core.dataobject(package="caikit_data_model.sample_lib")
-@dataclass
-class SampleOutputType:
+@dataobject(package="caikit_data_model.sample_lib")
+class SampleOutputType(DataObjectBase):
     """A simple return type for the `sample_task` task"""
 
     greeting: str
 
 
-@caikit.core.dataobject(package="caikit_data_model.sample_lib")
-@dataclass
-class OtherOutputType:
+@dataobject(package="caikit_data_model.sample_lib")
+class OtherOutputType(DataObjectBase):
     """A simple return type for the `other_task` task"""
 
     farewell: str
 
 
-@caikit.core.dataobject(package="caikit_data_model.sample_lib")
-@dataclass
-class SampleTrainingType:
+@dataobject(package="caikit_data_model.sample_lib")
+class SampleTrainingType(DataObjectBase):
     """A sample `training data` type for the `sample_task` task."""
 
     number: int

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -10,6 +10,7 @@ import tempfile
 import pytest
 
 # Local
+from caikit.core.data_model import DataObjectBase, dataobject
 from caikit.core.data_model.streams.data_stream import DataStream
 from caikit.runtime.service_generation.data_stream_source import (
     DataStreamSourceBase,
@@ -183,9 +184,8 @@ def test_pickle_round_trip_data_model():
     cleanly with pickle
     """
 
-    @caikit.core.dataobject
-    @dataclass
-    class Foo:
+    @dataobject
+    class Foo(DataObjectBase):
         foo: int
         bar: str
 


### PR DESCRIPTION
## Description

The [discussion on the `dataclass_to_proto` PR](https://github.com/caikit/caikit/pull/86#discussion_r1183077788) brought up a really interesting point that injecting base classes with a decorator is confusing at best and an anti-pattern at worst.

This PR attempts to fix that by having a new base class for all data model classes that use `@dataobject`: `DataObjectBase`.

## Details

The crux of this PR is lifting the logic for parsing the protobuf descriptor out of the `__new__` function on `_DataBaseMetaClass` and allowing it to be called from within `@dataobject` once the proto class has been generated. This required some fancy footwork with a new `metaclass`/base class pair: `_DataObjectBaseMetaClass`/`DataObjectBase`. The only logic that couldn't be hoisted out of `_DataBaseMetaClass.__new__` was the initialization of the class attributes, and in particular `__slots__` which needs to know the names of the fields that will eventually be valid on an instance of the class. To get around this, `_DataObjectBaseMetaClass` uses a special "forward declaration" attribute that is popped out of the class attrs by `_DataBaseMetaClass` which contains the names of the fields discovered from the `__annotations__` that will be used as input to the `@dataclass` call.

## Fallout

* With this change, all uses of `@dataobject` must inherit from `DataObjectBase` OR follow the special hackery to use `schema`
* If using a JTD `schema`, the class must also use annotations to declare the fields so that the forward-declaration stuff doesn't explode.
    * This is _only_ done to avoid having this PR encapsulate the changes needed to support `oneofs` robustly. These semantics are needed in `DataStreamSource`, so once `oneof` is properly supported, we can move that implementation off of `schema` and fully remove the JTD style of `@dataobject`
* The clause in `dataobject` that auto-created a special `"protobufs"` module was removed as unnecessary and unused (or so I thought)
* The removal of the special `"protobufs"` auto-gen module triggered issues in the special logic to find a precompiled protobuf in `_DataBaseMetaClass.__new__`. Rather than further patch around this, I (with input from @joerunde) decided to fully remove this "automagic" logic and instead require that anyone using precompiled protos explicitly declare the correlation between the data model class and the proto class by setting `_proto_class` as a class attribute on the data model class pointing to the proto class.