### PR TITLE
✨ 💥   Add shared train/load backends

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -23,9 +23,6 @@ load_path: null
 
 # Configuration for training/loading via module backends
 module_backends:
-    # Toggle distributed training/loading globally
-    #DEBUG -- This is only used in runtime currently!!!!!!
-    enabled: true
     # Local is always enabled unless explicitly disabled
     disable_local: false
     # Configuration for distributed loading and training. Each has an ordered

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -24,7 +24,8 @@ load_path: null
 # Configuration for training/loading via module backends
 module_backends:
     # Toggle distributed training/loading globally
-    enabled: false
+    #DEBUG -- This is only used in runtime currently!!!!!!
+    enabled: true
     # Local is always enabled unless explicitly disabled
     disable_local: false
     # Configuration for distributed loading and training. Each has an ordered
@@ -44,12 +45,10 @@ module_backends:
     #   name: BackupFoo
     #   config:
     #       bar: 42
-    load:
-        priority:
-            - type: LOCAL
-    train:
-        priority:
-            - type: LOCAL
+    load_priority:
+        - type: LOCAL
+    train_priority:
+        - type: LOCAL
 
 log:
     # Default level for all python loggers

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -21,20 +21,35 @@ enable_error_checks: true
 max_exception_log_messages: 4
 load_path: null
 
-# Configuration for loading alternate module implementations via
-# distributed backends
+# Configuration for training/loading via module backends
 module_backends:
-    # Toggle distributed loading globally
+    # Toggle distributed training/loading globally
     enabled: false
     # Local is always enabled unless explicitly disabled
     disable_local: false
-    # Configuration overrides for distributed backends configuration.
-    # Specific fields that may be of interest:
+    # Configuration for distributed loading and training. Each has an ordered
+    # list of backends in priority order. Each entry is a mapping with a "type"
+    # field and optionally a "config" field that maps to a blob of config for
+    # the backend instance. Entries may also have a "name" field that must be
+    # unique among entries, allowing for multiple instances of the same type.
+    # For example:
     #
-    # priority: List for the order that backend implementations should be used
-    priority:
-        - LOCAL
-    configs: {}
+    # - type: FOO
+    #   config:
+    #       foo: 123
+    # - type: BAR
+    #   config:
+    #       bar: 456
+    # - type: FOO
+    #   name: BackupFoo
+    #   config:
+    #       bar: 42
+    load:
+        priority:
+            - type: LOCAL
+    train:
+        priority:
+            - type: LOCAL
 
 log:
     # Default level for all python loggers

--- a/caikit/core/blocks/base.py
+++ b/caikit/core/blocks/base.py
@@ -25,13 +25,14 @@ import alog
 
 # Local
 from .. import module as mod
+from ..module_type import module_type
 from ..toolkit.errors import error_handler
 
 log = alog.use_channel("BLBASE")
 error = error_handler.get(log)
 
 
-@mod.module_type("block")
+@module_type("block")
 # pylint: disable=abstract-method
 class BlockBase(mod.ModuleBase):
     """Abstract base class for creating Blocks. Inherits from ModuleBase."""

--- a/caikit/core/data_model/__init__.py
+++ b/caikit/core/data_model/__init__.py
@@ -18,6 +18,7 @@
 
 # Local
 from . import base, data_backends, enums, producer, protobufs
+from .base import DataBase
 from .dataobject import (
     CAIKIT_DATA_MODEL,
     DataObjectBase,

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -187,6 +187,12 @@ class ModelManager:
                             module_path,
                             load_backend.name,
                         )
+                        error.type_check(
+                            "<COR76726077E>",
+                            ModuleBase,
+                            model=model,
+                        )
+
                         loaded_model = model
                         model.set_load_backend(load_backend)
                         break

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -178,6 +178,7 @@ class ModelManager:
             # directly. If not, parse the module config and look to see if there is
             # a version of the module available for the given backend
             loaded_model = None
+            log.debug("Available load backends: %s", configured_load_backends)
             for load_backend in configured_load_backends:
                 # If this is a shared loader, try loading the model directly
                 if isinstance(load_backend, SharedLoadBackendBase):

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -155,6 +155,8 @@ class ModelManager:
 
             # Using the module_path as a key, look for an instance preloaded in the
             # singleton cache if desired
+            # 🌶🌶🌶 This doesn't work for nested blocks
+            # TODO: think about bringing back the `unique_hash` or `tracking_id`
             if singleton_entry := (
                 load_singleton and self.singleton_module_cache.get(module_path)
             ):

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -166,7 +166,7 @@ class ModelManager:
             if not configured_load_backends:
                 log.info(
                     "<COR56759744I>",
-                    "No backend configured! Trying to configure using default config file.",
+                    "No backends configured! Configuring backends with current configuration",
                 )
                 module_backend_config.configure()
                 configured_load_backends = (

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -148,7 +148,9 @@ class ModelManager:
 
             # Using the module_path as a key, look for an instance preloaded in the
             # singleton cache if desired
-            if singleton_entry := self.singleton_module_cache.get(module_path):
+            if singleton_entry := (
+                load_singleton and self.singleton_module_cache.get(module_path)
+            ):
                 log.debug("Found %s in the singleton cache", module_path)
                 return singleton_entry
 

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -34,11 +34,12 @@ from .module import (
     _MODULE_TYPES,
     MODULE_BACKEND_REGISTRY,
     MODULE_REGISTRY,
-    SUPPORTED_LOAD_BACKENDS_VAR_NAME,
     ModuleBase,
     ModuleConfig,
 )
-from .module_backends import SharedLoadBackendBase, backend_types
+from .module_backends import backend_types
+from .module_backends.base import SharedLoadBackendBase
+from .module_type import SUPPORTED_LOAD_BACKENDS_VAR_NAME
 from .toolkit.errors import error_handler
 from caikit.config import get_config
 

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -17,7 +17,9 @@
 """
 
 # Standard
+from contextlib import contextmanager
 from io import BytesIO
+from threading import Lock
 from typing import Union
 import os
 import tempfile
@@ -27,7 +29,7 @@ import zipfile
 import alog
 
 # Local
-from . import module_backend_config as backend_config
+from . import module_backend_config
 from .module import (
     _MODULE_TYPES,
     MODULE_BACKEND_REGISTRY,
@@ -36,7 +38,7 @@ from .module import (
     ModuleBase,
     ModuleConfig,
 )
-from .module_backends import backend_types
+from .module_backends import SharedLoadBackendBase, backend_types
 from .toolkit.errors import error_handler
 from caikit.config import get_config
 
@@ -67,6 +69,7 @@ class ModelManager:
         """Initialize ModelManager."""
         # Map to store module caches, to be used for singleton model lookups
         self.singleton_module_cache = {}
+        self._singleton_lock = Lock()
 
     # make load function available from top-level of library
     def load(self, module_path, *args, load_singleton=False, **kwargs):
@@ -137,150 +140,139 @@ class ModelManager:
             subclass of blocks.base.BlockBase
                 Model object that is loaded, configured, and ready for prediction.
         """
-        module_config = ModuleConfig.load(module_path)
+        # If this is a singleton load, the entire body of this function needs to
+        # be locked to avoid concurrent loads on the same model. Otherwise, we
+        # can freely load in parallel.
+        with self.singleton_lock(load_singleton):
 
-        # Check if the model is being loaded in singleton fashion. If so,
-        # then fetch they hash for the module from config and use it as key.
-        key = module_config.unique_hash
-        if load_singleton and key is not None and key in self.singleton_module_cache:
-            # return model back from singleton cache
-            return self.singleton_module_cache[key]
+            # Using the module_path as a key, look for an instance preloaded in the
+            # singleton cache if desired
+            if singleton_entry := self.singleton_module_cache.get(module_path):
+                log.debug("Found %s in the singleton cache", module_path)
+                return singleton_entry
 
-        # retrive and validate the module class to initialize based on the
-        # module_id retrieved from the configuration (which is dynamically set
-        # based on either a block_id or workflow_id in the config.yml), looking up
-        # the corresponding MODULE_ID (BLOCK_ID/WORKFLOW_ID) of the module class
-        # in the ModuleBase class registry
-        module_id = module_config["module_id"]
-        module_class = MODULE_REGISTRY.get(module_id)
+            # Get the set of configured loaders
+            configured_load_backends = module_backend_config.configured_load_backends()
+            if not configured_load_backends:
+                log.info(
+                    "<COR56759744I>",
+                    "No backend configured! Trying to configure using default config file.",
+                )
+                module_backend_config.configure()
+                configured_load_backends = (
+                    module_backend_config.configured_load_backends()
+                )
 
-        if module_class is None:
-            error(
-                "<COR50207494E>",
-                ValueError(
-                    "could not find class with MODULE_ID of `{}`".format(module_id)
-                ),
-            )
+            # Pre-initialize variables that will be parsed lazily from the
+            # ModuleConfig if needed. This is done lazily so that loaders which
+            # don't require a config.yml can take precedence over those that do
+            # require one.
+            module_id = None
+            module_implementations = None
+            model_creation_backend = None
 
-        if not issubclass(module_class, ModuleBase):
-            error(
-                "<COR18830919E>",
-                TypeError(
-                    "class `{}` is not a valid module for module load".format(
-                        module_class.__name__
+            # For each backend, if it's a shared loader, attempt to load the model
+            # directly. If not, parse the module config and look to see if there is
+            # a version of the module available for the given backend
+            loaded_model = None
+            for load_backend in configured_load_backends:
+                # If this is a shared loader, try loading the model directly
+                if isinstance(load_backend, SharedLoadBackendBase):
+                    log.debug("Trying shared backend loader")
+                    model = load_backend.load(module_path, *args, **kwargs)
+                    if model is not None:
+                        log.debug2(
+                            "Successfully loaded %s with loader %s",
+                            module_path,
+                            load_backend.name,
+                        )
+                        loaded_model = model
+                        model.set_load_backend(load_backend)
+                        break
+                    else:
+                        log.debug3(
+                            "Could not load %s with loader %s",
+                            module_path,
+                            load_backend.name,
+                        )
+
+                # If this is not a shared loader, look for an implementation of the
+                # model's module that works with this backend
+                else:
+                    # If this is the first time parsing the module config, do so
+                    if module_id is None:
+                        log.debug2("Loading ModuleConfig from %s", module_path)
+                        module_config = ModuleConfig.load(module_path)
+                        module_id = module_config.module_id
+                        module_implementations = MODULE_BACKEND_REGISTRY.get(
+                            module_id, {}
+                        )
+                        log.debug2(
+                            "Number of available backend implementations for %s found: %d",
+                            module_id,
+                            len(module_implementations),
+                        )
+                        # Look up the backend that this model was created with
+                        model_creation_backend = module_config.get(
+                            "model_backend", backend_types.LOCAL
+                        )
+
+                    # Look in the module's implementations for this backend type
+                    backend_impl_obj = module_implementations.get(
+                        load_backend.backend_type
                     )
-                ),
-            )
+                    if backend_impl_obj is None:
+                        log.debug3(
+                            "Module %s does not support loading with %s",
+                            module_id,
+                            load_backend.backend_type,
+                        )
+                        continue
 
-        ## TODO: Should backend lookup be optional?
-        log.debug2("Looking for available backends for module_id %s", module_id)
+                    # Grab the concrete module class for this backend and check to
+                    # see if this model's artifacts were created with a version of
+                    # the module that can be loaded with this backend.
+                    module_backend_impl = backend_impl_obj.impl_class
+                    supported_load_backends = self._get_supported_load_backends(
+                        module_backend_impl
+                    )
+                    if model_creation_backend in supported_load_backends:
+                        log.debug3(
+                            "Attempting to load %s (module_id %s) with backend %s and class %s",
+                            module_path,
+                            module_id,
+                            load_backend.backend_type,
+                            module_backend_impl.__name__,
+                        )
+                        loaded_model = module_backend_impl.load(
+                            module_path,
+                            *args,
+                            **kwargs,
+                        )
+                        if loaded_model is not None:
+                            log.debug2(
+                                "Successfully loaded %s with backend %s",
+                                module_path,
+                                load_backend.backend_type,
+                            )
+                            loaded_model.set_load_backend(load_backend)
+                            break
 
-        # NOTE: module_id is going to be same for all the backends
-        # Thus it is not possible to know which backend this model was saved with from the
-        # module_id alone. We could look at the *_class field, like `block_class`.
-        # but then we have to look at various fields and that also doesn't guarantee the
-        # support for those backend in the current code of the backend.
-
-        model_backend = module_config.model_backend or backend_types.LOCAL
-
-        log.debug2("model trained on backend: %s", model_backend)
-
-        # Get the mapping of available implementations for this module
-        configured_backends = backend_config.configured_backends()
-
-        if len(configured_backends) == 0:
-            log.warning(
-                "<COR56759744W>",
-                "No backend configured! Trying to configure using default config file.",
-            )
-            backend_config.configure()
-            configured_backends = backend_config.configured_backends()
-
-        # If configured backends is empty, add LOCAL backend to it
-        local_enabled = backend_types.LOCAL in configured_backends
-
-        # NOTE: Local backend can be disabled via `config.yml` but its enabled
-        # by default
-
-        log.debug2("Local enabled? %s", local_enabled)
-        module_implementations = MODULE_BACKEND_REGISTRY.get(
-            module_id, {backend_types.LOCAL: None} if local_enabled else {}
-        )
-        log.debug2(
-            "Number of available backend implementations found: %d",
-            len(module_implementations),
-        )
-
-        error.value_check(
-            "<COR84094427E>",
-            len(module_implementations) > 0,
-            "No implementation of {} available. You may need to `pip install {}`",
-            module_config.module_id,
-            self.get_module_class_from_config(module_config),
-        )
-
-        loaded_artifact = None
-        # instantiate object and return to user
-        log.debug("Loading the artifact!")
-
-        # Go through each configured backend in priority order and look for an
-        # implementation that matches
-        # NOTE: backend priority can be configured while configuring backend
-        for backend in configured_backends:
-            # NOTE: what if we have multiple backends available,
-            # this will currently only return 1st one of those
-            # based on priority
-            backend_impl_obj = module_implementations.get(backend)
-            # NOTE: LOCAL may not be marked as a specific implementation, thus skip this
-            # or if no implementation available of the provided backend, continue
-            if backend == backend_types.LOCAL or backend_impl_obj is None:
-                continue
-
-            backend_impl = backend_impl_obj.impl_class
-
-            # A particular model can be supported by multiple backends, i.e
-            # a model trained on LOCAL backend might be able to get loaded with
-            # Spark or Ray backend implementations of the same block.
-            # Here, we will try to get the list of supported load backends for
-            # each of the backend_types and check if they contain the
-            # backend type of the current model
-            supported_load_backends = self._get_supported_load_backends(backend_impl)
-
-            # Check if the module actually supports this backend for load
-            if model_backend in supported_load_backends:
-                log.debug(
-                    "%s backend implementation found for backend [%s]",
-                    backend_impl.__name__,
-                    backend,
+            # If no model successfully loaded, it's an error
+            if loaded_model is None:
+                error(
+                    "<COR50207494E>",
+                    ValueError(
+                        f"Unable to load model from {module_path} with MODULE_ID {module_id}"
+                    ),
                 )
-                loaded_artifact: ModuleBase = backend_impl.load(
-                    module_path, *args, **kwargs
-                )
-                break
 
-        # If model not able to load still, it is a model that probably
-        # does not define the "backend_type" or "supported_load_backends".
-        # These would all be 'LOCAL' backend model, thus try to load with that
-        if not loaded_artifact and local_enabled:
-            module_class = MODULE_REGISTRY.get(module_id)
-            loaded_artifact: ModuleBase = module_class.load(
-                module_path, *args, **kwargs
-            )
+            # If loading as a singleton, populate the cache
+            if load_singleton:
+                self.singleton_module_cache[module_path] = loaded_model
 
-        ### END Backend distribution
-
-        error.value_check(
-            "<COR24332812E>",
-            loaded_artifact is not None,
-            "No available implementation for provided model!",
-        )
-
-        # if singleton loading is enabled, and module unique hash is available,
-        # save the module in singleton map
-        if load_singleton and key is not None:
-            self.singleton_module_cache[key] = loaded_artifact
-
-        return loaded_artifact
+            # Return successfully!
+            return loaded_model
 
     def _load_from_zipfile(self, module_path, load_singleton, *args, **kwargs):
         """Load a model from a zip archive.
@@ -448,7 +440,19 @@ class ModelManager:
         Returns:
             None
         """
-        self.singleton_module_cache = {}
+        with self._singleton_lock:
+            self.singleton_module_cache.clear()
+
+    @contextmanager
+    def singleton_lock(self, load_singleton: bool):
+        """Helper contextmanager that will only lock the singleton cache if this
+        load is a singleton load
+        """
+        if load_singleton:
+            with self._singleton_lock:
+                yield
+        else:
+            yield
 
     def _get_supported_load_backends(self, backend_impl: ModuleBase):
         """Function to get a list of supported load backends

--- a/caikit/core/module.py
+++ b/caikit/core/module.py
@@ -337,7 +337,8 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
                 Minimum number of seconds to run timed_run over. Will most likely be more than this
                 value due to its waiting for the each call to `self.run` to finish.
             num_iterations:  int
-                Minimum number of iterations to run timed_run over. Will run exactly this many times.
+                Minimum number of iterations to run timed_run over. Will run exactly this many
+                times.
             **kwargs:  dict
                 Will be passed to `self.run`.
 

--- a/caikit/core/module.py
+++ b/caikit/core/module.py
@@ -90,6 +90,8 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         # - populated with metadata from `config.yml` files on `load`, and
         # - saved back to `config.yml` files on `save`
         self._metadata = {}
+        # Keep an indicator of the backend used to load this model
+        self._load_backend = None
 
     #############
     ## Utility ##
@@ -108,6 +110,20 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         if not hasattr(self, "_metadata") or self._metadata is None:
             self._metadata = {}
         return self._metadata
+
+    def set_load_backend(self, load_backend):
+        """Method used by the model manager to indicate the load backend that
+        was used to load this module
+        """
+        self._load_backend = load_backend
+
+    @property
+    def load_backend(self):
+        """Get the backend instance used to load this module. This can be used
+        in module implementations that require use of a specific backend at
+        inference time.
+        """
+        return self._load_backend
 
     ###################
     ## Instantiation ##

--- a/caikit/core/module.py
+++ b/caikit/core/module.py
@@ -25,7 +25,7 @@
 # Standard
 from importlib import metadata
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Union
 import collections
 import datetime
 import os
@@ -35,9 +35,6 @@ import time
 import types
 import uuid
 
-# Third Party
-import semver
-
 # First Party
 import alog
 
@@ -45,7 +42,6 @@ import alog
 from .. import core
 from . import data_model as dm
 from .data_model import DataStream
-from .module_backends import backend_types
 from .module_config import ModuleConfig
 from .module_meta import _ModuleBaseMeta
 from .toolkit import ObjectSerializer, fileio
@@ -67,7 +63,8 @@ __all__ = [
 ]
 
 # This private registry is used to define types of modules that have been
-# defined using the @module_type decorator
+# defined using the @module_type decorator. It is owned here along with the
+# other registries to avoid circular dependencies
 _MODULE_TYPES = []
 
 # Single base global registry of all modules
@@ -75,10 +72,6 @@ MODULE_REGISTRY = {}
 
 # Global module backend registry dict
 MODULE_BACKEND_REGISTRY = {}
-
-# This is used by individual caikit.module implementations, like a block
-# to define what backend type models they can support at load time.
-SUPPORTED_LOAD_BACKENDS_VAR_NAME = "SUPPORTED_LOAD_BACKENDS"
 
 
 class ModuleBase(metaclass=_ModuleBaseMeta):
@@ -1051,293 +1044,3 @@ class ModuleSaver:
             return
 
         ModuleConfig(self.config).save(self.model_path)
-
-
-def register_module_implementation(
-    implementation_class: type,
-    backend_type: int,
-    module_id: str,
-    backend_config_override: Dict = None,
-):
-    """This function will register the mapping for the given module_id and
-    backend_type to the implementation class
-
-    Args:
-        implementation_class:  type
-            The class that is used to implement this backend type for the given
-            module_id
-        backend_type:  int
-            Value from MODULE_BACKEND_TYPES that indicates the backend
-            that this class implements
-        module_id:  str
-            The module_id from the caikit.core module registry that this class
-            overloads
-        backend_config_override: Dict
-            Dictionary containing essential overrides for the backend config.
-            This will get stored with the implementation_class class name and will automatically
-            get picked up and merged with other such configs for a specific backend
-
-    """
-
-    backend_config_override = backend_config_override or {}
-
-    log.debug(
-        "Registering backend [%s] implementation for module [%s]",
-        backend_type,
-        module_id,
-    )
-
-    error.value_check(
-        "<COR86780140E>",
-        backend_type in backend_types.MODULE_BACKEND_TYPES,
-        "Cannot override implementation of {} for unkonwn backend type {}",
-        module_id,
-        backend_type,
-    )
-
-    core_class = MODULE_REGISTRY.get(module_id)
-    if core_class is None:
-        # TODO! Inject a dummy entry that will raise on usage
-        pass  # pragma: no cover
-
-    # Do the registration!
-    module_type_mapping = MODULE_BACKEND_REGISTRY.setdefault(module_id, {})
-
-    # Make sure this is not an overwrite of an existing registration
-    existing_type = module_type_mapping.get(backend_type)
-    assert (
-        existing_type is None or existing_type is implementation_class
-    ), f"Registration conflict! ({module_id}, {backend_type}) already registered as {existing_type}"
-
-    BackendConfig = collections.namedtuple(
-        "BackendConfig", "impl_class backend_config_override"
-    )
-
-    module_type_mapping[backend_type] = BackendConfig(
-        impl_class=implementation_class, backend_config_override=backend_config_override
-    )
-
-
-# pylint: disable=redefined-outer-name
-def module_type(module_type):
-    """This encapsulates the logic of creating a derived module subtype
-    (e.g. block). It is intended to decorate a class which inherits from
-    ModuleBase. The wrapped class is augmented in the following ways:
-
-    * A new class-attribute is defined named `module_type` which is itself a
-        decorator that concrete implementations of this module type can use to
-        bind a module id, description, and version (e.g. @BlockBase.block).
-    * A new class attribute is added as a global registry that the above
-        decorator will use to store all registered concrete implementations of
-        the module type
-
-    These above class attributes can be further hoisted to free attributes in
-    the python module where the module type is defined (e.g. @block).
-    """
-
-    # Add this module type to the global list of module types
-    # pylint: disable=global-variable-not-assigned
-    global _MODULE_TYPES
-
-    module_type_name = module_type.upper()
-
-    _MODULE_TYPES.append(module_type_name)
-
-    def module_type_decorator(cls):
-        # Perform top-level imports here for places that the the new module type
-        # will need to be added. This is done to avoid circular dependencies
-        # since these top-level imports are only needed where the decorator is
-        # used.
-        # Local
-        # pylint C0415: Import outside toplevel (import-outside-toplevel)
-        # pylint: disable=import-outside-toplevel
-        from caikit.core import model_manager
-
-        # Add the registry dict and decorate the top-level module
-        registry_name = f"{module_type_name}_REGISTRY"
-        impl_registry = {}
-        error.value_check(
-            "<COR68254470E>",
-            not hasattr(core, registry_name),
-            "Cannot re-declare module type {}",
-            module_type,
-        )
-        setattr(core, registry_name, impl_registry)
-        setattr(model_manager, registry_name, impl_registry)
-        setattr(cls, "REGISTRY", impl_registry)
-
-        # Define the module implementation decorator
-        # pylint: disable=redefined-builtin,pointless-statement
-        def _module_impl_decorator(
-            id=None,
-            name=None,
-            version=None,
-            backend_type=backend_types.LOCAL,
-            base_module: Union[str, Type[ModuleBase]] = None,
-            backend_config_override: Optional[Dict] = None,
-        ):
-            f"""Apply this decorator to any class that should be treated as a {module_type} (i.e.,
-            extends
-            `{cls.__name__}) and registered with caikit.core so that the library "knows" the class
-            is a
-            {module_type} and is capable of loading instances of the {module_type}.
-
-            Args:
-                id:  str
-                    A UUID to use when registering this {module_type} with caikit.core
-                    Not required if based on another caikit module using `base_module`
-                name:  str
-                    A human-readable name for the {module_type}
-                    Not required if based on another caikit module using `base_module`
-                version:  str
-                    A SemVer for the {module_type}
-                    Not required if based on another caikit module using `base_module`
-                backend_type: backend_type
-                    Associated backend type for the module.
-                    Default: `LOCAL`
-                base_module: str | ModuleBase
-                    If this module is based on a different caikit module, provide name
-                    of the base module.
-                    Default: None
-                backend_config_override: Dict
-                    Dictionary containing configuration required for the specific backend.
-                    Default: None
-
-            Returns:
-                A decorated version of the class to which it was applied, after registering the
-                class as a valid {module_type} with caikit.core
-            """
-            base_module_class = None
-            # Flag to store if the current module is a backend implementation
-            # of an existing module or not
-            backend_module_impl = False
-
-            # No mutable default
-            backend_config_override = backend_config_override or {}
-
-            if any([id is None, version is None or name is None]):
-                error.type_check(
-                    "<COR87944440E>",
-                    str,
-                    type(ModuleBase),
-                    allow_none=False,
-                    base_module=base_module,
-                )
-                error.type_check(
-                    "<COR60584425E>",
-                    dict,
-                    allow_none=True,
-                    backend_config_override=backend_config_override,
-                )
-
-                # If the base_module is a string, assume that it is the module_id of the
-                # base module
-                if isinstance(base_module, str):
-                    module_id = base_module
-                    error.value_check(
-                        "<COR09479833E>",
-                        module_id in MODULE_REGISTRY,
-                        "Unknown base module id: {}",
-                        module_id,
-                    )
-                    base_module_class = MODULE_REGISTRY[module_id]
-
-                # If base_module is a type, validate that it derives from ModuleBase and
-                # use its MODULE_ID
-                elif isinstance(base_module, type):
-                    if not issubclass(base_module, ModuleBase):
-                        error(
-                            "<COR20161747E>",
-                            f"base_module [{base_module}] does not derive from ModuleBase",
-                        )
-
-                    base_module_class = base_module
-
-                # TODO: Add support for inheritance of backend implementation
-                # i.e if a module inherits from base_module
-
-                id = base_module_class.MODULE_ID
-                version = base_module_class.MODULE_VERSION
-                name = base_module_class.MODULE_NAME
-                backend_module_impl = True
-
-            error.type_check("<COR54118928E>", str, id=id, name=name, version=version)
-
-            semver.VersionInfo.parse(version)  # Make sure this is a valid SemVer
-
-            def decorator(cls_):
-                # Verify this is a valid module type (inherits from the wrapped
-                # base class)
-
-                if backend_module_impl and not issubclass(base_module_class, cls):
-                    error(
-                        "<COR32401861E>",
-                        TypeError(
-                            f"`{base_module_class.__name__}` does not extend `{cls.__name__}`",
-                        ),
-                    )
-                elif not backend_module_impl and not issubclass(cls_, cls):
-                    error(
-                        "<COR68265482E>",
-                        TypeError(
-                            f"`{cls_.__name__}` does not extend `{cls.__name__}`",
-                        ),
-                    )
-
-                # Add attributes to the implementation class
-                setattr(cls_, f"{module_type_name}_ID", id)
-                cls_.MODULE_ID = id  # Module ID == Module Type ID
-                setattr(cls_, f"{module_type_name}_NAME", name)
-                cls_.MODULE_NAME = name  # Module Name == Module Type Name
-                setattr(cls_, f"{module_type_name}_VERSION", version)
-                cls_.MODULE_VERSION = version  # Module Version == Module Type Version
-                classname = f"{cls_.__module__}.{cls_.__qualname__}"
-                setattr(cls_, f"{module_type_name}_CLASS", classname)
-                cls_.MODULE_CLASS = classname
-                cls_.PRODUCER_ID = dm.ProducerId(cls_.MODULE_NAME, cls_.MODULE_VERSION)
-
-                # Set module type as attribute of the class
-                # pylint: disable=global-variable-not-assigned
-                cls_.MODULE_TYPE = module_type_name
-
-                # If no backend support described in the class, add current backend
-                # as the only backend that can load models trained by this module
-                cls_.SUPPORTED_LOAD_BACKENDS = getattr(
-                    cls_, SUPPORTED_LOAD_BACKENDS_VAR_NAME, [backend_type]
-                )
-
-                # Set its own backend_type as an attribute
-                setattr(cls_, "BACKEND_TYPE", backend_type)
-
-                # Verify UUID and add this block to the module and block registries
-                global MODULE_REGISTRY
-                current_class = MODULE_REGISTRY.get(cls_.MODULE_ID)
-                if not backend_module_impl:
-                    if current_class is not None:
-                        error(
-                            "<COR30607646E>",
-                            RuntimeError(
-                                "BLOCK_ID `{}` conflicts for classes `{}` and `{}`".format(
-                                    cls_.MODULE_ID,
-                                    cls_.__name__,
-                                    MODULE_REGISTRY[cls_.MODULE_ID].__name__,
-                                )
-                            ),
-                        )
-                    MODULE_REGISTRY[cls_.MODULE_ID] = cls_
-                    impl_registry[cls_.MODULE_ID] = cls_
-
-                # Register backend
-                register_module_implementation(
-                    cls_, backend_type, cls_.MODULE_ID, backend_config_override
-                )
-
-                return cls_
-
-            return decorator
-
-        # Add this decorator to the wrapped class
-        setattr(cls, module_type, _module_impl_decorator)
-        return cls
-
-    return module_type_decorator

--- a/caikit/core/module_backend_config.py
+++ b/caikit/core/module_backend_config.py
@@ -40,12 +40,12 @@ def start_backends() -> None:
     Returns:
         None
     """
-    for backend_name, backend in _CONFIGURED_LOAD_BACKENDS.items():
-        with _BACKEND_START_LOCKS[backend_name]:
+    for backend in _CONFIGURED_LOAD_BACKENDS:
+        with _BACKEND_START_LOCKS[backend.name]:
             if not backend.is_started:
                 backend.start()
-    for backend_name, backend in _CONFIGURED_TRAIN_BACKENDS.items():
-        with _BACKEND_START_LOCKS[backend_name]:
+    for backend in _CONFIGURED_TRAIN_BACKENDS:
+        with _BACKEND_START_LOCKS[backend.name]:
             if not backend.is_started:
                 backend.start()
 

--- a/caikit/core/module_backend_config.py
+++ b/caikit/core/module_backend_config.py
@@ -107,8 +107,8 @@ def configure():
 
     # Configure both train and load backends
     for backend_priority, registry in [
-        (config_object.load.priority, _CONFIGURED_LOAD_BACKENDS),
-        (config_object.train.priority, _CONFIGURED_TRAIN_BACKENDS),
+        (config_object.load_priority, _CONFIGURED_LOAD_BACKENDS),
+        (config_object.train_priority, _CONFIGURED_TRAIN_BACKENDS),
     ]:
         backend_priority = backend_priority or []
         error.type_check("<COR46006487E>", list, backend_priority=backend_priority)

--- a/caikit/core/module_backend_config.py
+++ b/caikit/core/module_backend_config.py
@@ -66,7 +66,7 @@ def get_train_backend(backend_name: str) -> BackendBase:
 
 def configured_load_backends() -> List[BackendBase]:
     """This function returns the mapping of named"""
-    return copy.copy(_CONFIGURED_TRAIN_BACKENDS)
+    return copy.copy(_CONFIGURED_LOAD_BACKENDS)
 
 
 def configured_train_backends() -> List[BackendBase]:
@@ -85,9 +85,9 @@ def configure():
     log.debug3("Full Config: %s", config_object)
 
     # Configure both train and load backends
-    for backend_priority, registry in [
-        (config_object.load_priority, _CONFIGURED_LOAD_BACKENDS),
-        (config_object.train_priority, _CONFIGURED_TRAIN_BACKENDS),
+    for backend_priority, registry, registry_name in [
+        (config_object.load_priority, _CONFIGURED_LOAD_BACKENDS, "load"),
+        (config_object.train_priority, _CONFIGURED_TRAIN_BACKENDS, "train"),
     ]:
         backend_priority = backend_priority or []
         error.type_check("<COR46006487E>", list, backend_priority=backend_priority)
@@ -178,7 +178,7 @@ def configure():
             registry.append(backend_instance)
             _BACKEND_START_LOCKS[backend_name] = threading.Lock()
 
-        log.debug2("All configured backends: %s", registry)
+        log.debug2("All configured %s backends: %s", registry_name, registry)
 
 
 ## Implementation Details ######################################################

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -20,7 +20,6 @@ from typing import Optional, Type
 import abc
 
 # Local
-from ..data_model import DataBase
 from ..module import ModuleBase
 
 

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -27,7 +27,8 @@ from ..module import ModuleBase
 class BackendBase(abc.ABC):
     """Interface for creating configuration setup for backends"""
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, name: str, config=None) -> None:
+        self.name = name
         self.config = config or {}
         self._started = False
 

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -16,7 +16,12 @@
 """
 
 # Standard
+from typing import Optional, Type
 import abc
+
+# Local
+from ..data_model import DataBase
+from ..module import ModuleBase
 
 
 class BackendBase(abc.ABC):
@@ -54,3 +59,70 @@ class BackendBase(abc.ABC):
     def stop(self):
         """Function to stop a distributed backend. This function
         should set self._started variable to False"""
+
+
+class UniversalTrainBackendBase(BackendBase, abc.ABC):
+    """Interface for a backend that can perform train on any given module
+
+    A Universal backend is one that treats the given module as a black box and
+    delegates the execution of that module's functionality to an alternate
+    execution engine.
+    """
+
+    @abc.abstractmethod
+    def train(self, module_class: Type[ModuleBase], *args, **kwargs) -> ModuleBase:
+        """Perform the given module's train operation and return the trained
+        module instance.
+
+        TODO: The return type here might be problematic in the case where the
+            server performing the train operation is just a proxy for both train
+            and inference. Consider some kind of lazy load proxy that would not
+            require the model to be held in memory.
+
+        Args:
+            module_class (Type[ModuleBase]): The module class to train
+            *args, **kwargs: The args to pass through to training
+
+        Returns:
+            model (ModuleBase): The in-memory instance of the trained
+                module
+        """
+
+
+class UniversalLoadBackendBase(BackendBase, abc.ABC):
+    """Interface for a backend that can perform load/unload on any given model
+
+    A Universal backend is one that treats the given module as a black box and
+    delegates the execution of that module's functionality to an alternate
+    execution engine.
+
+    The module returned by a universal manager must be capable of having run
+    called locally and delegating the execution of the underlying module to the
+    backend's framework.
+    """
+
+    @abc.abstractmethod
+    def load(
+        self, module_id: str, model_path: str, *args, **kwargs
+    ) -> Optional[ModuleBase]:
+        """Load the model stored at the given path into the backend
+
+        This function is responsible for loading a model in a way that the
+        backend is then able to execute it.
+
+        Universal loaders will be configured in a priority sequence. If a higher
+        priority loader fails to load a given model, the next one is attempted
+        until the model is loaded or no loaders are left.
+
+        Args:
+            module_id (str): The unique id of the module to load
+            model_path (str): Path to directory or zip file holding the model
+                with the config.yml and any artifacts
+            *args, **kwargs: Additional args to pass through to the module's
+                load function
+
+        Returns:
+            model (Optional[ModuleBase]): A runnable model if one could be
+                loaded, otherwise None. Such a model may be a wrapper that
+                delegates execution to the concrete model loaded elsewhere.
+        """

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -61,10 +61,10 @@ class BackendBase(abc.ABC):
         should set self._started variable to False"""
 
 
-class UniversalTrainBackendBase(BackendBase, abc.ABC):
+class SharedTrainBackendBase(BackendBase, abc.ABC):
     """Interface for a backend that can perform train on any given module
 
-    A Universal backend is one that treats the given module as a black box and
+    A Shared backend is one that treats the given module as a black box and
     delegates the execution of that module's functionality to an alternate
     execution engine.
     """
@@ -89,10 +89,10 @@ class UniversalTrainBackendBase(BackendBase, abc.ABC):
         """
 
 
-class UniversalLoadBackendBase(BackendBase, abc.ABC):
+class SharedLoadBackendBase(BackendBase, abc.ABC):
     """Interface for a backend that can perform load/unload on any given model
 
-    A Universal backend is one that treats the given module as a black box and
+    A Shared backend is one that treats the given module as a black box and
     delegates the execution of that module's functionality to an alternate
     execution engine.
 
@@ -110,7 +110,7 @@ class UniversalLoadBackendBase(BackendBase, abc.ABC):
         This function is responsible for loading a model in a way that the
         backend is then able to execute it.
 
-        Universal loaders will be configured in a priority sequence. If a higher
+        Shared loaders will be configured in a priority sequence. If a higher
         priority loader fails to load a given model, the next one is attempted
         until the model is loaded or no loaders are left.
 

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -103,9 +103,7 @@ class SharedLoadBackendBase(BackendBase, abc.ABC):
     """
 
     @abc.abstractmethod
-    def load(
-        self, module_id: str, model_path: str, *args, **kwargs
-    ) -> Optional[ModuleBase]:
+    def load(self, model_path: str, *args, **kwargs) -> Optional[ModuleBase]:
         """Load the model stored at the given path into the backend
 
         This function is responsible for loading a model in a way that the
@@ -116,7 +114,6 @@ class SharedLoadBackendBase(BackendBase, abc.ABC):
         until the model is loaded or no loaders are left.
 
         Args:
-            module_id (str): The unique id of the module to load
             model_path (str): Path to directory or zip file holding the model
                 with the config.yml and any artifacts
             *args, **kwargs: Additional args to pass through to the module's

--- a/caikit/core/module_backends/local_backend.py
+++ b/caikit/core/module_backends/local_backend.py
@@ -15,22 +15,26 @@
 """This module implements a LOCAL backend configuration
 """
 # Standard
-from typing import Type
+from typing import Optional, Type
+
+# Third Party
+import yaml
 
 # First Party
 import alog
 
 # Local
 from ..module import MODULE_REGISTRY, ModuleBase
+from ..module_config import ModuleConfig
 from ..toolkit.errors import error_handler
 from .backend_types import register_backend_type
-from .base import UniversalLoadBackendBase, UniversalTrainBackendBase
+from .base import SharedLoadBackendBase, SharedTrainBackendBase
 
 log = alog.use_channel("LCLBKND")
 error = error_handler.get(log)
 
 
-class LocalBackend(UniversalLoadBackendBase, UniversalTrainBackendBase):
+class LocalBackend(SharedLoadBackendBase, SharedTrainBackendBase):
     backend_type = "LOCAL"
 
     def register_config(self, config) -> None:
@@ -55,11 +59,23 @@ class LocalBackend(UniversalLoadBackendBase, UniversalTrainBackendBase):
         with alog.ContextTimer(log.info, "Finished local training in: "):
             return module_class.train(*args, **kwargs)
 
-    def load(self, module_id: str, model_path: str, *args, **kwargs) -> ModuleBase:
+    def load(self, model_path: str, *args, **kwargs) -> Optional[ModuleBase]:
         """Look up the given module in the module registry and load it if found"""
+        try:
+            model_config = ModuleConfig.load(model_path)
+        except (FileNotFoundError, KeyError, yaml.parser.ParserError):
+            log.debug("Unable to load local model config from [%s]", model_path)
+            return None
+        module_id = model_config.module_id
         module_class = MODULE_REGISTRY.get(module_id)
         if module_class is not None:
             return module_class.load(model_path, *args, **kwargs)
+        log.warning(
+            "<COR14661026W>",
+            "Could not load MODULE_ID %s with %s",
+            module_id,
+            self.backend_type,
+        )
 
 
 # Register local backend

--- a/caikit/core/module_config.py
+++ b/caikit/core/module_config.py
@@ -90,7 +90,7 @@ class ModuleConfig(aconfig.Config):
         """
         error.type_check("<COR71170339E>", str, model_path=model_path)
 
-        # validate config.yml
+        # Validate config.yml
         config_path = os.path.join(model_path, "config.yml")
         if not (os.path.exists(config_path) and os.path.isfile(config_path)):
             # NOTE: Do not log this out with error handler, as we might try this function multiple
@@ -101,10 +101,10 @@ class ModuleConfig(aconfig.Config):
                 )
             )
 
-        # read the yaml to dict and construct a new config object
+        # Read the yaml to dict and construct a new config object
         config = cls(toolkit.load_yaml(config_path))
 
-        # error if add model_path was in the config
+        # Error if model_path was in the config
         if config.model_path is not None:
             error(
                 "<COR80166142E>",
@@ -114,8 +114,15 @@ class ModuleConfig(aconfig.Config):
                 ),
             )
 
-        # add the model path to the config object
+        # Mdd the model path to the config object
         config["model_path"] = model_path
+
+        # Make sure module_id is found
+        if config.module_id is None:
+            error(
+                "<COR82701436E>",
+                KeyError(f"No module_id found in config at {model_path}"),
+            )
 
         return config
 

--- a/caikit/core/module_type.py
+++ b/caikit/core/module_type.py
@@ -83,11 +83,10 @@ def module_type(module_type_name):
             base_module: Union[str, Type[ModuleBase]] = None,
             backend_config_override: Optional[Dict] = None,
         ):
-            f"""Apply this decorator to any class that should be treated as a {module_type_name} (i.e.,
-            extends
-            `{cls.__name__}) and registered with caikit.core so that the library "knows" the class
-            is a
-            {module_type_name} and is capable of loading instances of the {module_type_name}.
+            f"""Apply this decorator to any class that should be treated as a {module_type_name}
+             (i.e., extends`{cls.__name__}) and registered with caikit.core so that the library
+             "knows" the class is a {module_type_name} and is capable of loading instances of the
+             {module_type_name}.
 
             Args:
                 id:  str
@@ -173,19 +172,10 @@ def module_type(module_type_name):
             semver.VersionInfo.parse(version)  # Make sure this is a valid SemVer
 
             def decorator(cls_):
-                # Verify this is a valid module type (inherits from the wrapped
-                # base class)
-
-                if backend_module_impl and not issubclass(base_module_class, cls):
+                # Verify this is a valid module type (inherits from the wrapped base class)
+                if not issubclass(cls_, cls):
                     error(
                         "<COR32401861E>",
-                        TypeError(
-                            f"`{base_module_class.__name__}` does not extend `{cls.__name__}`",
-                        ),
-                    )
-                elif not backend_module_impl and not issubclass(cls_, cls):
-                    error(
-                        "<COR68265482E>",
                         TypeError(
                             f"`{cls_.__name__}` does not extend `{cls.__name__}`",
                         ),

--- a/caikit/core/module_type.py
+++ b/caikit/core/module_type.py
@@ -1,3 +1,16 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 This module holds the module_type decorator which is used to declare subtypes
 of ModuleBase (e.g. Block)

--- a/caikit/core/module_type.py
+++ b/caikit/core/module_type.py
@@ -1,0 +1,316 @@
+"""
+This module holds the module_type decorator which is used to declare subtypes
+of ModuleBase (e.g. Block)
+"""
+
+# Standard
+from typing import Dict, Optional, Type, Union
+
+# Third Party
+import semver
+
+# First Party
+import alog
+
+# Local
+from .. import core
+from .module import _MODULE_TYPES, MODULE_BACKEND_REGISTRY, MODULE_REGISTRY, ModuleBase
+from .module_backends import backend_types
+from .toolkit.errors import error_handler
+
+log = alog.use_channel("MODTYP")
+error = error_handler.get(log)
+
+
+# This is used by individual caikit.module implementations, like a block
+# to define what backend type models they can support at load time.
+SUPPORTED_LOAD_BACKENDS_VAR_NAME = "SUPPORTED_LOAD_BACKENDS"
+
+
+def module_type(module_type_name):
+    """This encapsulates the logic of creating a derived module subtype
+    (e.g. block). It is intended to decorate a class which inherits from
+    ModuleBase. The wrapped class is augmented in the following ways:
+
+    * A new class-attribute is defined named `module_type` which is itself a
+        decorator that concrete implementations of this module type can use to
+        bind a module id, description, and version (e.g. @BlockBase.block).
+    * A new class attribute is added as a global registry that the above
+        decorator will use to store all registered concrete implementations of
+        the module type
+
+    These above class attributes can be further hoisted to free attributes in
+    the python module where the module type is defined (e.g. @block).
+    """
+    assert (
+        module_type_name == module_type_name.lower()
+    ), "All module types must be lowercase"
+    module_type_name_upper = module_type_name.upper()
+    _MODULE_TYPES.append(module_type_name_upper)
+
+    def module_type_decorator(cls):
+        # Perform top-level imports here for places that the the new module type
+        # will need to be added. This is done to avoid circular dependencies
+        # since these top-level imports are only needed where the decorator is
+        # used.
+        # Local
+        # pylint C0415: Import outside toplevel (import-outside-toplevel)
+        # pylint: disable=import-outside-toplevel
+        from caikit.core import model_manager
+
+        # Add the registry dict and decorate the top-level module
+        registry_name = f"{module_type_name_upper}_REGISTRY"
+        impl_registry = {}
+        error.value_check(
+            "<COR68254470E>",
+            not hasattr(core, registry_name),
+            "Cannot re-declare module type {}",
+            module_type_name,
+        )
+        setattr(core, registry_name, impl_registry)
+        setattr(model_manager, registry_name, impl_registry)
+        setattr(cls, "REGISTRY", impl_registry)
+
+        # Define the module implementation decorator
+        # pylint: disable=redefined-builtin,pointless-statement
+        def _module_impl_decorator(
+            id=None,
+            name=None,
+            version=None,
+            backend_type=backend_types.LOCAL,
+            base_module: Union[str, Type[ModuleBase]] = None,
+            backend_config_override: Optional[Dict] = None,
+        ):
+            f"""Apply this decorator to any class that should be treated as a {module_type_name} (i.e.,
+            extends
+            `{cls.__name__}) and registered with caikit.core so that the library "knows" the class
+            is a
+            {module_type_name} and is capable of loading instances of the {module_type_name}.
+
+            Args:
+                id:  str
+                    A UUID to use when registering this {module_type_name} with caikit.core
+                    Not required if based on another caikit module using `base_module`
+                name:  str
+                    A human-readable name for the {module_type_name}
+                    Not required if based on another caikit module using `base_module`
+                version:  str
+                    A SemVer for the {module_type_name}
+                    Not required if based on another caikit module using `base_module`
+                backend_type: backend_type
+                    Associated backend type for the module.
+                    Default: `LOCAL`
+                base_module: str | ModuleBase
+                    If this module is based on a different caikit module, provide name
+                    of the base module.
+                    Default: None
+                backend_config_override: Dict
+                    Dictionary containing configuration required for the specific backend.
+                    Default: None
+
+            Returns:
+                A decorated version of the class to which it was applied, after registering the
+                class as a valid {module_type_name} with caikit.core
+            """
+            base_module_class = None
+            # Flag to store if the current module is a backend implementation
+            # of an existing module or not
+            backend_module_impl = False
+
+            # No mutable default
+            backend_config_override = backend_config_override or {}
+
+            if any([id is None, version is None or name is None]):
+                error.type_check(
+                    "<COR87944440E>",
+                    str,
+                    type(ModuleBase),
+                    allow_none=False,
+                    base_module=base_module,
+                )
+                error.type_check(
+                    "<COR60584425E>",
+                    dict,
+                    allow_none=True,
+                    backend_config_override=backend_config_override,
+                )
+
+                # If the base_module is a string, assume that it is the module_id of the
+                # base module
+                if isinstance(base_module, str):
+                    module_id = base_module
+                    error.value_check(
+                        "<COR09479833E>",
+                        module_id in MODULE_REGISTRY,
+                        "Unknown base module id: {}",
+                        module_id,
+                    )
+                    base_module_class = MODULE_REGISTRY[module_id]
+
+                # If base_module is a type, validate that it derives from ModuleBase and
+                # use its MODULE_ID
+                elif isinstance(base_module, type):
+                    if not issubclass(base_module, ModuleBase):
+                        error(
+                            "<COR20161747E>",
+                            f"base_module [{base_module}] does not derive from ModuleBase",
+                        )
+
+                    base_module_class = base_module
+
+                # TODO: Add support for inheritance of backend implementation
+                # i.e if a module inherits from base_module
+
+                id = base_module_class.MODULE_ID
+                version = base_module_class.MODULE_VERSION
+                name = base_module_class.MODULE_NAME
+                backend_module_impl = True
+
+            error.type_check("<COR54118928E>", str, id=id, name=name, version=version)
+
+            semver.VersionInfo.parse(version)  # Make sure this is a valid SemVer
+
+            def decorator(cls_):
+                # Verify this is a valid module type (inherits from the wrapped
+                # base class)
+
+                if backend_module_impl and not issubclass(base_module_class, cls):
+                    error(
+                        "<COR32401861E>",
+                        TypeError(
+                            f"`{base_module_class.__name__}` does not extend `{cls.__name__}`",
+                        ),
+                    )
+                elif not backend_module_impl and not issubclass(cls_, cls):
+                    error(
+                        "<COR68265482E>",
+                        TypeError(
+                            f"`{cls_.__name__}` does not extend `{cls.__name__}`",
+                        ),
+                    )
+
+                # Add attributes to the implementation class
+                setattr(cls_, f"{module_type_name_upper}_ID", id)
+                cls_.MODULE_ID = id  # Module ID == Module Type ID
+                setattr(cls_, f"{module_type_name_upper}_NAME", name)
+                cls_.MODULE_NAME = name  # Module Name == Module Type Name
+                setattr(cls_, f"{module_type_name_upper}_VERSION", version)
+                cls_.MODULE_VERSION = version  # Module Version == Module Type Version
+                classname = f"{cls_.__module__}.{cls_.__qualname__}"
+                setattr(cls_, f"{module_type_name_upper}_CLASS", classname)
+                cls_.MODULE_CLASS = classname
+                cls_.PRODUCER_ID = dm.ProducerId(cls_.MODULE_NAME, cls_.MODULE_VERSION)
+
+                # Set module type as attribute of the class
+                # pylint: disable=global-variable-not-assigned
+                cls_.MODULE_TYPE = module_type_name_upper
+
+                # If no backend support described in the class, add current backend
+                # as the only backend that can load models trained by this module
+                cls_.SUPPORTED_LOAD_BACKENDS = getattr(
+                    cls_, SUPPORTED_LOAD_BACKENDS_VAR_NAME, [backend_type]
+                )
+
+                # Set its own backend_type as an attribute
+                setattr(cls_, "BACKEND_TYPE", backend_type)
+
+                # Verify UUID and add this block to the module and block registries
+                global MODULE_REGISTRY
+                current_class = MODULE_REGISTRY.get(cls_.MODULE_ID)
+                if not backend_module_impl:
+                    if current_class is not None:
+                        error(
+                            "<COR30607646E>",
+                            RuntimeError(
+                                "BLOCK_ID `{}` conflicts for classes `{}` and `{}`".format(
+                                    cls_.MODULE_ID,
+                                    cls_.__name__,
+                                    MODULE_REGISTRY[cls_.MODULE_ID].__name__,
+                                )
+                            ),
+                        )
+                    MODULE_REGISTRY[cls_.MODULE_ID] = cls_
+                    impl_registry[cls_.MODULE_ID] = cls_
+
+                # Register backend
+                _register_module_implementation(
+                    cls_, backend_type, cls_.MODULE_ID, backend_config_override
+                )
+
+                return cls_
+
+            return decorator
+
+        # Add this decorator to the wrapped class
+        setattr(cls, module_type_name, _module_impl_decorator)
+        return cls
+
+    return module_type_decorator
+
+
+## Implementation Details ######################################################
+
+
+def _register_module_implementation(
+    implementation_class: type,
+    backend_type: str,
+    module_id: str,
+    backend_config_override: Dict = None,
+):
+    """This function will register the mapping for the given module_id and
+    backend_type to the implementation class
+
+    Args:
+        implementation_class:  type
+            The class that is used to implement this backend type for the given
+            module_id
+        backend_type:  str
+            Value from MODULE_BACKEND_TYPES that indicates the backend
+            that this class implements
+        module_id:  str
+            The module_id from the caikit.core module registry that this class
+            overloads
+        backend_config_override: Dict
+            Dictionary containing essential overrides for the backend config.
+            This will get stored with the implementation_class class name and will automatically
+            get picked up and merged with other such configs for a specific backend
+
+    """
+
+    backend_config_override = backend_config_override or {}
+
+    log.debug(
+        "Registering backend [%s] implementation for module [%s]",
+        backend_type,
+        module_id,
+    )
+
+    error.value_check(
+        "<COR86780140E>",
+        backend_type in backend_types.MODULE_BACKEND_TYPES,
+        "Cannot override implementation of {} for unkonwn backend type {}",
+        module_id,
+        backend_type,
+    )
+
+    core_class = MODULE_REGISTRY.get(module_id)
+    if core_class is None:
+        # TODO! Inject a dummy entry that will raise on usage
+        pass  # pragma: no cover
+
+    # Do the registration!
+    module_type_mapping = MODULE_BACKEND_REGISTRY.setdefault(module_id, {})
+
+    # Make sure this is not an overwrite of an existing registration
+    existing_type = module_type_mapping.get(backend_type)
+    assert (
+        existing_type is None or existing_type is implementation_class
+    ), f"Registration conflict! ({module_id}, {backend_type}) already registered as {existing_type}"
+
+    BackendConfig = collections.namedtuple(
+        "BackendConfig", "impl_class backend_config_override"
+    )
+
+    module_type_mapping[backend_type] = BackendConfig(
+        impl_class=implementation_class, backend_config_override=backend_config_override
+    )

--- a/caikit/core/module_type.py
+++ b/caikit/core/module_type.py
@@ -5,6 +5,7 @@ of ModuleBase (e.g. Block)
 
 # Standard
 from typing import Dict, Optional, Type, Union
+import collections
 
 # Third Party
 import semver
@@ -14,6 +15,7 @@ import alog
 
 # Local
 from .. import core
+from . import data_model as dm
 from .module import _MODULE_TYPES, MODULE_BACKEND_REGISTRY, MODULE_REGISTRY, ModuleBase
 from .module_backends import backend_types
 from .toolkit.errors import error_handler

--- a/caikit/core/module_type.py
+++ b/caikit/core/module_type.py
@@ -227,7 +227,7 @@ def module_type(module_type_name):
                         error(
                             "<COR30607646E>",
                             RuntimeError(
-                                "BLOCK_ID `{}` conflicts for classes `{}` and `{}`".format(
+                                "MODULE_ID `{}` conflicts for classes `{}` and `{}`".format(
                                     cls_.MODULE_ID,
                                     cls_.__name__,
                                     MODULE_REGISTRY[cls_.MODULE_ID].__name__,

--- a/caikit/core/resources/base.py
+++ b/caikit/core/resources/base.py
@@ -22,13 +22,14 @@ import alog
 
 # Local
 from .. import module as mod
+from ..module_type import module_type
 from ..toolkit.errors import error_handler
 
 log = alog.use_channel("RSRCBASE")
 error = error_handler.get(log)
 
 
-@mod.module_type("resource")
+@module_type("resource")
 class ResourceBase(mod.ModuleBase):
     """Abstract base class for creating Resource Types.  Inherits from ModuleBase."""
 

--- a/caikit/core/workflows/base.py
+++ b/caikit/core/workflows/base.py
@@ -27,13 +27,14 @@ import alog
 # Local
 from ... import core
 from .. import module as mod
+from ..module_type import module_type
 from ..toolkit.errors import error_handler
 
 log = alog.use_channel("WFBASE")
 error = error_handler.get(log)
 
 
-@mod.module_type("workflow")
+@module_type("workflow")
 class WorkflowBase(mod.ModuleBase):
     """Abstract base class for creating Workflows.  Inherits from ModuleBase."""
 

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -58,7 +58,7 @@ class ModelLoader:
 
         Args:
             model_id (string):  Model ID string for the model to load.
-            local_model_path (string): Path to COS to load the model from.
+            local_model_path (string): local filesystem path to load the model from.
             model_type (string): Type of the model to load.
         Returns:
             model (LoadedModel) : The model that was loaded

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -58,7 +58,7 @@ class ModelLoader:
 
         Args:
             model_id (string):  Model ID string for the model to load.
-            local_model_path (string): local filesystem path to load the model from.
+            local_model_path (string): Local filesystem path to load the model from.
             model_type (string): Type of the model to load.
         Returns:
             model (LoadedModel) : The model that was loaded

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -24,7 +24,6 @@ import alog
 # Local
 from caikit.config import get_config
 from caikit.core import MODEL_MANAGER
-from caikit.core.module_backend_config import configure
 from caikit.runtime.model_management.batcher import Batcher
 from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
@@ -49,14 +48,9 @@ class ModelLoader:
         # Re-instantiating this is a programming error
         assert self.__class__.__instance is None, "This class is a singleton!"
         ModelLoader.__instance = self
-        # We will call get_config() each time in case there are updates since this
-        # class is a singleton
-
-        # If backends loading is enabled, set up the loader
-        if get_config().module_backends.enabled:
-            log.info("<RUN89711118I>", "Configuring for backends loading")
-            log.debug("Backends config: %s", get_config().module_backends)
-            configure()
+        # Instead of storing self.config = get_config(), we will call get_config() everywhere
+        # since this class is a singleton and configuration may be updated during its
+        # lifetime
 
     def load_model(self, model_id, local_model_path, model_type) -> LoadedModel:
         """Load a model using model_path (in Cloud Object Storage) & give it a model ID.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,7 +196,7 @@ def temp_config(config_overrides: dict):
             else:
                 # or just slap some random uuids in there. Barf, but we need to call `.configure()`
                 caikit.configure(config_dict={str(uuid.uuid4()): str(uuid.uuid4())})
-            # Yield to the test with the new overriden config
+            # Yield to the test with the new overridden config
             yield get_config()
 
 
@@ -252,6 +252,31 @@ def sample_int_file() -> str:
         handle.write(content)
         handle.flush()
         yield handle.name
+
+
+@pytest.fixture
+def fixtures_dir():
+    yield os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
+
+
+@pytest.fixture
+def block_fixtures_dir(fixtures_dir):
+    yield os.path.join(fixtures_dir, "blocks")
+
+
+@pytest.fixture
+def resource_fixtures_dir(fixtures_dir):
+    yield os.path.join(fixtures_dir, "resources")
+
+
+@pytest.fixture
+def workflow_fixtures_dir(fixtures_dir):
+    yield os.path.join(fixtures_dir, "workflows")
+
+
+@pytest.fixture
+def toolkit_fixtures_dir(fixtures_dir):
+    yield os.path.join(fixtures_dir, "toolkit")
 
 
 # IMPLEMENTATION DETAILS ############################################################

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,9 @@ import sample_lib
 logging.configure()
 
 
+def random_test_id():
+    return "test-any-model-" + _random_id()
+
 @pytest.fixture(autouse=True, scope="session")
 def test_environment():
     """The most important fixture: This runs caikit configuration with the base test config overrides"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ logging.configure()
 def random_test_id():
     return "test-any-model-" + _random_id()
 
+
 @pytest.fixture(autouse=True, scope="session")
 def test_environment():
     """The most important fixture: This runs caikit configuration with the base test config overrides"""

--- a/tests/core/blocks/test_base.py
+++ b/tests/core/blocks/test_base.py
@@ -43,7 +43,7 @@ class TestBlockBase(TestCaseBase):
         self.dummy_block_instance = self.dummy_block_class(self.dummy_model_path)
 
     def test_init_available(self):
-        model = caikit.core.BlockBase([0, 1, 2], kw1=0, kw2=1, kw3=2)
+        model = caikit.core.BlockBase()
         self.assertIsInstance(model, caikit.core.BlockBase)
 
     def test_load_not_implemented(self):

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -480,9 +480,6 @@ def test_dataobject_with_discriminator():
 #             Annotated[Bat, OneofField("bat")],
 #         ]
 
-#     #DEBUG -------------- SOMETHING BROKEN HERE!!!
-#     breakpoint()
-
 #     # proto tests
 #     foo1 = BazObj(foo=BazObj.Foo(data=["hello"]))
 #     proto_repr_foo = foo1.to_proto()

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -58,7 +58,7 @@ def temp_dpool():
 
 
 @pytest.fixture(autouse=True)
-def reset_globals():
+def reset_global_protobuf_registry():
     """Reset the global registry of generated protos"""
     prev_auto_gen_proto_classes = copy.copy(_AUTO_GEN_PROTO_CLASSES)
     prev_class_registry = copy.copy(_DataBaseMetaClass.class_registry)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -45,6 +45,9 @@ class MockBackend(BackendBase):
         self._started = False
 
 
+backend_types.register_backend_type(MockBackend)
+
+
 @pytest.fixture
 def reset_backend_types():
     """Fixture that will reset the backend types if a test modifies them"""
@@ -86,7 +89,7 @@ def reset_configured_backends():
     train_backends_list = copy.copy(_CONFIGURED_TRAIN_BACKENDS)
     _CONFIGURED_LOAD_BACKENDS.clear()
     _CONFIGURED_TRAIN_BACKENDS.clear()
-    backend_types.register_backend_type(MockBackend)
+    # backend_types.register_backend_type(MockBackend)
     yield
     _CONFIGURED_LOAD_BACKENDS.clear()
     _CONFIGURED_LOAD_BACKENDS.extend(load_backends_list)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -31,8 +31,8 @@ from caikit.core.module_backends import BackendBase, backend_types
 class MockBackend(BackendBase):
     backend_type = "MOCK"
 
-    def __init__(self, config=...) -> None:
-        super().__init__(config)
+    def __init__(self, name, config=...) -> None:
+        super().__init__(name, config)
         self._started = False
 
     def start(self):
@@ -84,11 +84,14 @@ def reset_configured_backends():
     """Fixture that will reset the configured backends"""
     load_backends_list = copy.copy(_CONFIGURED_LOAD_BACKENDS)
     train_backends_list = copy.copy(_CONFIGURED_TRAIN_BACKENDS)
+    _CONFIGURED_LOAD_BACKENDS.clear()
+    _CONFIGURED_TRAIN_BACKENDS.clear()
+    backend_types.register_backend_type(MockBackend)
     yield
     _CONFIGURED_LOAD_BACKENDS.clear()
-    _CONFIGURED_LOAD_BACKENDS.update(load_backends_list)
+    _CONFIGURED_LOAD_BACKENDS.extend(load_backends_list)
     _CONFIGURED_TRAIN_BACKENDS.clear()
-    _CONFIGURED_TRAIN_BACKENDS.update(train_backends_list)
+    _CONFIGURED_TRAIN_BACKENDS.extend(train_backends_list)
 
 
 @pytest.fixture

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -65,8 +65,6 @@ class TestLoader(SharedLoadBackendBase):
                 return None
         # use the "Local" loader to actually load the model
         model = LocalBackend(name="test").load(model_path)
-        # Let tests know which loader was used
-        setattr(model, "loader_name", self.name)
         return model
 
     def register_config(self, config):

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Standard
+import copy
+
 # Third Party
 import pytest
 
 # Local
 from caikit.core.module import MODULE_BACKEND_REGISTRY, MODULE_REGISTRY
-from caikit.core.module_backend_config import _CONFIGURED_BACKENDS
+from caikit.core.module_backend_config import (
+    _CONFIGURED_LOAD_BACKENDS,
+    _CONFIGURED_TRAIN_BACKENDS,
+)
 from caikit.core.module_backends import BackendBase, backend_types
 
 
@@ -56,7 +62,7 @@ def reset_backend_types():
 
 
 @pytest.fixture
-def reset_module_BACKEND_registry():
+def reset_module_backend_registry():
     """Fixture that will reset the module distribution registry if a test modifies them"""
     module_registry = {key: val for key, val in MODULE_BACKEND_REGISTRY.items()}
     yield
@@ -76,10 +82,13 @@ def reset_module_registry():
 @pytest.fixture
 def reset_configured_backends():
     """Fixture that will reset the configured backends"""
-    backends_list = _CONFIGURED_BACKENDS
+    load_backends_list = copy.copy(_CONFIGURED_LOAD_BACKENDS)
+    train_backends_list = copy.copy(_CONFIGURED_TRAIN_BACKENDS)
     yield
-    _CONFIGURED_BACKENDS.clear()
-    _CONFIGURED_BACKENDS.update(backends_list)
+    _CONFIGURED_LOAD_BACKENDS.clear()
+    _CONFIGURED_LOAD_BACKENDS.update(load_backends_list)
+    _CONFIGURED_TRAIN_BACKENDS.clear()
+    _CONFIGURED_TRAIN_BACKENDS.update(train_backends_list)
 
 
 @pytest.fixture
@@ -87,6 +96,6 @@ def reset_globals(
     reset_backend_types,
     reset_configured_backends,
     reset_module_registry,
-    reset_module_BACKEND_registry,
+    reset_module_backend_registry,
 ):
     """Fixture that will reset the backend types and module registries if a test modifies them"""

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -61,9 +61,8 @@ class TestLoader(SharedLoadBackendBase):
         # allow config.model_type to control whether this loader barfs
         if "model_type" in self.config and "model_type" in kwargs:
             if self.config["model_type"] != kwargs["model_type"]:
-                raise ValueError(
-                    f"test loader refusing to load model type {kwargs['model_type']}"
-                )
+                # Don't load in this loader
+                return None
         # use the "Local" loader to actually load the model
         model = LocalBackend(name="test").load(model_path)
         # Let tests know which loader was used

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -89,7 +89,6 @@ def reset_configured_backends():
     train_backends_list = copy.copy(_CONFIGURED_TRAIN_BACKENDS)
     _CONFIGURED_LOAD_BACKENDS.clear()
     _CONFIGURED_TRAIN_BACKENDS.clear()
-    # backend_types.register_backend_type(MockBackend)
     yield
     _CONFIGURED_LOAD_BACKENDS.clear()
     _CONFIGURED_LOAD_BACKENDS.extend(load_backends_list)

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -503,7 +503,7 @@ def test_non_local_supported_backend(reset_globals):
 
 def test_load_must_return_model():
     """Make sure that the return type of load is checked to be an instance of
-    ModuleBase
+    ModuleBase, and will raise TypeError if it is not.
     """
 
     @caikit.core.block("00110203-baad-beef-0809-0a0b0c0d0e0f", "FunkyBlock", "0.0.1")

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -162,7 +162,7 @@ class TestModelManager(TestCaseBase):
     def test_load_invalid_zip_file(self):
         """Test that loading a zip archive not containing a model fails gracefully."""
         model_path = os.path.join(self.fixtures_dir, "invalid.zip")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FileNotFoundError):
             caikit.core.load(model_path)
 
     @pytest.mark.usefixtures("global_load_path")
@@ -392,18 +392,10 @@ def test_fall_back_to_local(reset_globals):
     """Make sure that if LOCAL is enabled and a given module doesn't have any
     registered backends, the default caikit.core.load is used.
     """
-    with temp_config(
-        {
-            "module_backends": {
-                "priority": [],
-            }
-        }
-    ):
-        configure()
-        with temp_saved_model(NonDistributedBlock()) as model_path:
-            model = caikit.core.load(model_path)
+    with temp_saved_model(NonDistributedBlock()) as model_path:
+        model = caikit.core.load(model_path)
 
-        assert isinstance(model, NonDistributedBlock)
+    assert isinstance(model, NonDistributedBlock)
 
 
 def test_no_local_if_disabled(reset_globals):
@@ -454,8 +446,11 @@ def test_preferred_backend_disabled(reset_globals):
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.LOCAL],
-                "configs": {},
+                "load_priority": [
+                    {
+                        "type": backend_types.LOCAL
+                    }
+                ],
             }
         }
     ):

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -25,6 +25,7 @@ from caikit.core.module_backend_config import configure
 from caikit.core.module_backends import LocalBackend
 
 # Unit Test Infrastructure
+from sample_lib.blocks.sample_task import SampleBlock
 from tests.base import TestCaseBase
 from tests.conftest import temp_config
 
@@ -528,3 +529,22 @@ def test_non_local_supported_backend(reset_globals):
         dummy_model_path = os.path.join(TEST_DATA_PATH, DUMMY_BACKEND_MODEL_NAME)
         model = caikit.core.load(dummy_model_path)
         assert isinstance(model, DummyBaz)
+
+
+def test_load_must_return_model():
+    """Make sure that the return type of load is checked to be an instance of
+    ModuleBase
+    """
+
+    @caikit.core.block("00110203-baad-beef-0809-0a0b0c0d0e0f", "FunkyBlock", "0.0.1")
+    class _FunkyModel(SampleBlock):
+        @classmethod
+        def load(cls, model_path):
+            return (super().load(model_path), "something else")
+
+    model = _FunkyModel()
+    with tempfile.TemporaryDirectory() as tempdir:
+        # NOTE: the module will get detected as tests since _FunkyModel is defined here
+        model.save(tempdir)
+        with pytest.raises(TypeError):
+            caikit.core.load(tempdir)

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -446,11 +446,7 @@ def test_preferred_backend_disabled(reset_globals):
     with temp_config(
         {
             "module_backends": {
-                "load_priority": [
-                    {
-                        "type": backend_types.LOCAL
-                    }
-                ],
+                "load_priority": [{"type": backend_types.LOCAL}],
             }
         }
     ):

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -499,8 +499,9 @@ def test_non_local_supported_backend(reset_globals):
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK2],
-                "configs": {},
+                "load_priority": [{
+                    "type": backend_types.MOCK2
+                }],
             }
         }
     ):

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -486,9 +486,6 @@ def test_non_local_supported_backend(reset_globals):
         def load(self, *args, **kwargs):
             return DummyBaz()
 
-    print(dir(DummyBaz))
-    print(dir(DummyBaz()))
-
     with temp_config(
         {
             "module_backends": {

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -21,7 +21,6 @@ import os
 import tempfile
 
 # Local
-from caikit.config import get_config
 from caikit.core.module_backend_config import configure
 from caikit.core.module_backends import LocalBackend
 

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -78,34 +78,14 @@ class TestModelManager(TestCaseBase):
         self.assertIsInstance(model, caikit.core.BlockBase)
 
     def test_load_can_load_a_block_as_a_singleton(self):
-        # load a model with no hash config
-        no_hashed_model = caikit.core.load(
-            self.non_singleton_model_path, load_singleton=True
-        )
-        self.assertIsInstance(no_hashed_model, caikit.core.BlockBase)
-
+        model1 = caikit.core.load(self.singleton_model_path, load_singleton=True)
         model2 = caikit.core.load(self.singleton_model_path, load_singleton=True)
-        model3 = caikit.core.load(self.singleton_model_path, load_singleton=True)
-
-        # Pointer should be equal
-        self.assertEqual(id(model2), id(model3))
-
-        # Pointer should not be equal
-        self.assertNotEqual(id(no_hashed_model), id(model3))
+        assert model1 is model2
 
     def test_load_can_load_a_block_with_singleton_disabled(self):
-        # load a model with no hash config
-        no_hashed_model = caikit.core.load(
-            self.non_singleton_model_path, load_singleton=True
-        )
-        self.assertIsInstance(no_hashed_model, caikit.core.BlockBase)
-
+        model1 = caikit.core.load(self.singleton_model_path, load_singleton=True)
         model2 = caikit.core.load(self.singleton_model_path, load_singleton=False)
-        model3 = caikit.core.load(self.singleton_model_path, load_singleton=False)
-
-        # Pointer should not be equal
-        self.assertNotEqual(id(model2), id(model3))
-        self.assertNotEqual(id(no_hashed_model), id(model3))
+        assert model1 is not model2
 
     def test_singleton_cache_can_be_cleared(self):
         model = caikit.core.load(self.singleton_model_path, load_singleton=True)

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -404,6 +404,7 @@ def test_no_local_if_disabled(reset_globals):
     """
     _ = setup_saved_model(MockBackend)
     # 🌶️ TODO: remove the `disable_local` flag
+    # ...if LOCAL can always be supplied in the caikit base config
     with temp_config(
         {
             "module_backends": {

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -539,7 +539,7 @@ def test_load_with_new_shared_backend(good_model_path, reset_globals):
     ):
         configure()
         model = caikit.core.load(good_model_path)
-        assert model.loader_name == loader_name
+        assert model.load_backend.name == loader_name
 
 
 def test_load_with_two_shared_loaders_of_the_same_type(good_model_path, reset_globals):
@@ -566,11 +566,11 @@ def test_load_with_two_shared_loaders_of_the_same_type(good_model_path, reset_gl
         configure()
         # plain model load should use first loader
         model = caikit.core.load(good_model_path)
-        assert model.loader_name == "loader one"
+        assert model.load_backend.name == "loader one"
 
         # model load that fails in the first loader will use the second
         model = caikit.core.load(good_model_path, model_type="model two")
-        assert model.loader_name == "loader two"
+        assert model.load_backend.name == "loader two"
 
 
 def test_load_does_not_read_config_yml_if_loader_does_not_require_it(

--- a/tests/core/test_module.py
+++ b/tests/core/test_module.py
@@ -27,8 +27,9 @@ import aconfig
 
 # Local
 from caikit.core import ModuleConfig, module
-from caikit.core.module_backend_config import get_backend
+from caikit.core.module_backend_config import get_load_backend
 from caikit.core.module_backends import backend_types
+from caikit.core.module_type import module_type
 
 # pylint: disable=import-error
 from sample_lib.blocks.sample_task import SampleBlock
@@ -218,7 +219,7 @@ class TestModuleTypeDecorator(TestCaseBase):
         if hasattr(caikit.core, "TESTMOD_REGISTRY"):
             delattr(caikit.core, "TESTMOD_REGISTRY")
 
-    @module.module_type("testmod")
+    @module_type("testmod")
     class TestModBase(module.ModuleBase):
         """Derived module type"""
 
@@ -332,7 +333,7 @@ def configure_alternate_backend_impl():
     @caikit.core.blocks.block(base_module=DummyFoo, backend_type=backend_types.MOCK)
     class DummyBar:
         def test_fetching_backend(self):
-            return get_backend(backend_types.MOCK)
+            return get_load_backend(backend_types.MOCK)
 
     return DummyFoo, DummyBar
 

--- a/tests/core/test_module.py
+++ b/tests/core/test_module.py
@@ -158,12 +158,10 @@ def test_init_and_members():
     assert isinstance(config.integer, int)
     assert config.integer == 1
     assert isinstance(config.float, float)
-    # DEBUG
     assert config.float == 0.5
     assert isinstance(config.nested, dict)
     assert config.nested.string == "world"
     assert config.nested.integer == 2
-    # DEBUG
     assert config.nested.float == -0.123
 
 

--- a/tests/core/test_module.py
+++ b/tests/core/test_module.py
@@ -74,7 +74,7 @@ def configure_alternate_backend_impl():
     backend_types.register_backend_type(MockBackend)
 
     @caikit.core.blocks.block(base_module=DummyFoo, backend_type=backend_types.MOCK)
-    class DummyBar:
+    class DummyBar(caikit.core.blocks.base.BlockBase):
         def test_fetching_backend(self):
             return get_load_backend(backend_types.MOCK)
 
@@ -300,7 +300,7 @@ def test_duplicate_registration_raises(reset_globals):
     with pytest.raises(AssertionError):
 
         @caikit.core.blocks.block(base_module=DummyFoo, backend_type=backend_types.MOCK)
-        class DummyBat:
+        class DummyBat(caikit.core.blocks.base.BlockBase):
             pass
 
 
@@ -379,7 +379,7 @@ def test_override_load_supported_backend(reset_globals):
     supported_backends = [backend_types.BAZ, backend_types.FOO]
 
     @caikit.core.blocks.block(base_module=DummyFoo, backend_type=backend_types.BAZ)
-    class DummyBaz:
+    class DummyBaz(caikit.core.blocks.base.BlockBase):
         SUPPORTED_LOAD_BACKENDS = supported_backends
 
     assert hasattr(DummyBaz, SUPPORTED_LOAD_BACKENDS_VAR_NAME)
@@ -404,13 +404,13 @@ def test_base_module_in_decorator(reset_globals):
         pass
 
     @caikit.core.blocks.block(backend_type=backend_types.BAZ, base_module=DummyLocal)
-    class DummyBaz(caikit.core.ModuleBase):
+    class DummyBaz(caikit.core.blocks.base.BlockBase):
         pass
 
     @caikit.core.blocks.block(
         backend_type=backend_types.FOO, base_module=DummyLocal.MODULE_ID
     )
-    class DummyFoo(caikit.core.ModuleBase):
+    class DummyFoo(caikit.core.blocks.base.BlockBase):
         pass
 
     assert DummyLocal in list(caikit.core.MODULE_REGISTRY.values())

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -19,8 +19,6 @@ Tests for the backend configuration framework
 # Local
 from caikit.core.blocks import base, block
 from caikit.core.module_backend_config import (
-    _CONFIGURED_LOAD_BACKENDS,
-    _CONFIGURED_TRAIN_BACKENDS,
     configure,
     configured_load_backends,
     configured_train_backends,
@@ -43,21 +41,62 @@ def test_configure_with_module(reset_globals):
     """Test that configuring with a configured backend type that has a
     configuration module obj works
     """
-    backend_types.register_backend_type(MockBackend)
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK],
-                "configs": {"mock": foo_cfg},
+                "load_priority": [
+                    {
+                        "type": backend_types.MOCK,
+                        "config": foo_cfg,
+                    }
+                ],
+                "train_priority": [
+                    {
+                        "type": backend_types.MOCK,
+                        "config": foo_cfg,
+                    }
+                ],
             }
         }
     ):
         configure()
-        assert "MOCK" in configured_backends()
-        assert (
-            _CONFIGURED_BACKENDS[backend_types.MOCK].backend_type == backend_types.MOCK
-        )
-        assert foo_cfg == _CONFIGURED_BACKENDS[backend_types.MOCK].config
+
+        # Test load backend config
+        mock_load_backend = get_load_backend(backend_types.MOCK)
+        assert mock_load_backend.backend_type == backend_types.MOCK
+        assert foo_cfg == mock_load_backend.config
+
+        # Test train backend config
+        mock_train_backend = get_train_backend(backend_types.MOCK)
+        assert mock_train_backend.backend_type == backend_types.MOCK
+        assert foo_cfg == mock_train_backend.config
+
+
+def test_configure_load_only(reset_globals):
+    """Test that train and load backends can be configured independently"""
+    with temp_config(
+        {
+            "module_backends": {
+                "load_priority": [
+                    {
+                        "type": backend_types.MOCK,
+                        "config": foo_cfg,
+                    }
+                ],
+                "train_priority": [],
+            }
+        }
+    ):
+        configure()
+
+        # Test load backend config
+        mock_load_backend = get_load_backend(backend_types.MOCK)
+        assert mock_load_backend.backend_type == backend_types.MOCK
+        assert foo_cfg == mock_load_backend.config
+
+        # Test train backend config
+        with pytest.raises(ValueError):
+            get_train_backend(backend_types.MOCK)
 
 
 def test_non_supported_backend_raises():
@@ -66,7 +105,7 @@ def test_non_supported_backend_raises():
     with temp_config(
         {
             "module_backends": {
-                "priority": ["unsupported"],
+                "load_priority": [{"type": "unsupported"}],
             }
         }
     ):
@@ -76,54 +115,118 @@ def test_non_supported_backend_raises():
 
 def test_disabling_local_backend(reset_globals):
     """Test that disabling local backend does not add it to priority automatically"""
-    backend_types.register_backend_type(MockBackend)
-    with temp_config(
-        {"module_backends": {"priority": [backend_types.MOCK], "disable_local": True}}
-    ):
-        configure()
-        assert "LOCAL" not in configured_backends()
-
-
-def test_duplicate_config_raises(reset_globals):
-    """Test that duplicate configuration of a backend raises"""
-    backend_types.register_backend_type(MockBackend)
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK],
+                "disable_local": True,
+                "load_priority": [{"type": backend_types.MOCK}],
+                "train_priority": [{"type": backend_types.MOCK}],
             }
         }
     ):
         configure()
-        with pytest.raises(AssertionError):
+        assert get_load_backend(backend_types.MOCK)
+        assert get_train_backend(backend_types.MOCK)
+        with pytest.raises(ValueError):
+            get_load_backend(backend_types.LOCAL)
+        with pytest.raises(ValueError):
+            get_train_backend(backend_types.LOCAL)
+
+
+def test_duplicate_config_raises(reset_globals):
+    """Test that duplicate configuration of a backend raises"""
+    with temp_config(
+        {
+            "module_backends": {
+                "load_priority": [
+                    {"type": backend_types.MOCK},
+                ],
+            }
+        }
+    ):
+        configure()
+        with pytest.raises(ValueError):
             configure()
+
+
+def test_duplicate_implied_names_raise(reset_globals):
+    """Test that duplicate entries with the same name implied from type raises"""
+    with temp_config(
+        {
+            "module_backends": {
+                "load_priority": [
+                    {"type": backend_types.MOCK},
+                    {"type": backend_types.MOCK},
+                ],
+            }
+        }
+    ):
+        with pytest.raises(ValueError):
+            configure()
+
+
+def test_duplicate_explicit_names_raise(reset_globals):
+    """Test that duplicate entries with the same name given explicitly from
+    raises
+    """
+    with temp_config(
+        {
+            "module_backends": {
+                "load_priority": [
+                    {"type": backend_types.MOCK, "name": "foo"},
+                    {"type": backend_types.MOCK, "name": "foo"},
+                ],
+            }
+        }
+    ):
+        with pytest.raises(ValueError):
+            configure()
+
+
+def test_duplicate_type_name_disambig(reset_globals):
+    """Test that multiple instances of the same type can be configured with
+    different names
+    """
+    with temp_config(
+        {
+            "module_backends": {
+                "load_priority": [
+                    {"type": backend_types.MOCK},
+                    {"type": backend_types.MOCK, "name": "foo"},
+                ],
+            }
+        }
+    ):
+        configure()
 
 
 def test_one_configured_backend_can_start(reset_globals):
     """Test that the configured backend can be started"""
-    backend_types.register_backend_type(MockBackend)
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK],
-                "configs": {"mock": foo_cfg},
+                "load_priority": [
+                    {
+                        "type": backend_types.MOCK,
+                        "config": foo_cfg,
+                    }
+                ],
             }
         }
     ):
         configure()
         start_backends()
+
         # This is configured to be True in helpers
-        assert (
-            _CONFIGURED_BACKENDS[backend_types.MOCK].backend_type == backend_types.MOCK
-        )
-        assert _CONFIGURED_BACKENDS[backend_types.MOCK].is_started
+        mock_load_backend = get_load_backend(backend_types.MOCK)
+        assert mock_load_backend.backend_type == backend_types.MOCK
+        assert mock_load_backend.is_started
 
 
 def test_multiple_module_same_backend_configures(reset_globals):
     """Test to check if multiple modules for same backend
     can override backend configurations"""
     # Register backend type
-    backend_types.register_backend_type(MockBackend)
 
     @block(id="foo", name="dummy base", version="0.0.1")
     class DummyFoo(base.BlockBase):
@@ -156,30 +259,25 @@ def test_multiple_module_same_backend_configures(reset_globals):
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK],
+                "load_priority": [{"type": backend_types.MOCK}],
             }
         }
     ):
         configure()
-        assert "MOCK" in configured_backends()
-        assert (
-            _CONFIGURED_BACKENDS[backend_types.MOCK].backend_type == backend_types.MOCK
-        )
-        assert "bar1" in _CONFIGURED_BACKENDS[backend_types.MOCK].config
-        assert "bar2" in _CONFIGURED_BACKENDS[backend_types.MOCK].config
-        assert _CONFIGURED_BACKENDS[backend_types.MOCK].config["bar1"] == 1
+        mock_load_backend = get_load_backend(backend_types.MOCK)
+        assert mock_load_backend.backend_type == backend_types.MOCK
+        assert "bar1" in mock_load_backend.config
+        assert "bar2" in mock_load_backend.config
+        assert mock_load_backend.config["bar1"] == 1
 
 
 def test_get_backend_starts_backend(reset_globals):
     """Test that fetching a handle to a backend with get_backend ensures that it
     is started
     """
-    backend_types.register_backend_type(MockBackend)
     with temp_config(
-        {"module_backends": {"priority": [backend_types.MOCK], "disable_local": True}}
+        {"module_backends": {"train_priority": [{"type": backend_types.MOCK}]}}
     ):
         configure()
-        assert not _CONFIGURED_BACKENDS[backend_types.MOCK].is_started
-        backend = get_backend(backend_types.MOCK)
-        assert backend.is_started
-        assert _CONFIGURED_BACKENDS[backend_types.MOCK].is_started
+        mock_train_backend = get_train_backend(backend_types.MOCK)
+        assert mock_train_backend.is_started

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -19,10 +19,13 @@ Tests for the backend configuration framework
 # Local
 from caikit.core.blocks import base, block
 from caikit.core.module_backend_config import (
-    _CONFIGURED_BACKENDS,
+    _CONFIGURED_LOAD_BACKENDS,
+    _CONFIGURED_TRAIN_BACKENDS,
     configure,
-    configured_backends,
-    get_backend,
+    configured_load_backends,
+    configured_train_backends,
+    get_load_backend,
+    get_train_backend,
     start_backends,
 )
 from caikit.core.module_backends import backend_types

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -144,6 +144,8 @@ def test_duplicate_config_raises(reset_globals):
             }
         }
     ):
+        # The mock backend is already registered for tests in the core
+        # see tests/core/helpers.py
         configure()
         with pytest.raises(ValueError):
             configure()

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -238,7 +238,7 @@ def test_multiple_module_same_backend_configures(reset_globals):
         backend_type=backend_types.MOCK,
         backend_config_override={"bar1": 1},
     )
-    class DummyBar:
+    class DummyBar(base.BlockBase):
         pass
 
     @block(id="foo2", name="dummy base", version="0.0.1")
@@ -251,7 +251,7 @@ def test_multiple_module_same_backend_configures(reset_globals):
         backend_type=backend_types.MOCK,
         backend_config_override={"bar2": 2},
     )
-    class DummyBar:
+    class DummyBar(base.BlockBase):
         pass
 
     # Initiate configuration

--- a/tests/core/test_module_metadata.py
+++ b/tests/core/test_module_metadata.py
@@ -174,20 +174,6 @@ def test_block_metadata_is_saved_into_a_workflow(sample_model_path):
     _check_dicts_equal(resaved_metadata, initial_metadata, fields_to_not_check)
 
 
-def test_models_with_funky_load_do_not_throw():
-    @caikit.core.block("00110203-baad-beef-0809-0a0b0c0d0e0f", "FunkyBlock", "0.0.1")
-    class _FunkyModel(SampleBlock):
-        @classmethod
-        def load(cls, model_path):
-            return (super().load(model_path), "something else")
-
-    model = _FunkyModel()
-    with tempfile.TemporaryDirectory() as tempdir:
-        # NOTE: the module will get detected as tests since _FunkyModel is defined here
-        model.save(tempdir)
-        caikit.core.load(tempdir)
-
-
 # pylint: disable=redefined-outer-name
 def test_load_can_be_called_directly_with_non_standard_kwargs(sample_model_path):
     initial_metadata = _load_model_metadata(sample_model_path)

--- a/tests/core/test_module_type.py
+++ b/tests/core/test_module_type.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for the @module_type decorator
+"""
+# Standard
+import abc
+import copy
+import uuid
+
+# Third Party
+import pytest
+
+# Local
+from caikit.core import module
+from caikit.core.module_type import module_type
+from sample_lib.blocks.sample_task import SampleBlock
+import caikit.core
+
+## Helpers #####################################################################
+
+
+@pytest.fixture
+def TestModBase():
+    prev_module_types = copy.copy(module._MODULE_TYPES)
+
+    @module_type("testmod")
+    class TestModBase(module.ModuleBase):
+        """Derived module type"""
+
+    yield TestModBase
+
+    module._MODULE_TYPES.clear()
+    module._MODULE_TYPES.extend(prev_module_types)
+    if hasattr(caikit.core, "TESTMOD_REGISTRY"):
+        delattr(caikit.core, "TESTMOD_REGISTRY")
+
+
+## Tests #######################################################################
+
+
+def test_module_type_new_type(TestModBase):
+    """Make sure that the newly declared module type can be used just like a
+    first-class module type such as block
+    """
+    assert hasattr(caikit.core, "TESTMOD_REGISTRY")
+    assert "TESTMOD" in module._MODULE_TYPES
+    assert caikit.core.TESTMOD_REGISTRY == {}
+
+    # Add a new derived testmod
+    mod_id = str(uuid.uuid4())
+
+    @TestModBase.testmod(id=mod_id, name="Sample tesmod", version="1.2.3")
+    class SampleTestmod(TestModBase):
+        """A sample test mod"""
+
+    # Make sure that the test mod was added to the registry
+    assert caikit.core.TESTMOD_REGISTRY == {mod_id: SampleTestmod}
+
+    # Make sure module type is set as attribute of sample module
+    assert hasattr(SampleTestmod, "MODULE_TYPE")
+    assert SampleTestmod.MODULE_TYPE == "TESTMOD"
+
+
+def test_module_type_missing_base_class(TestModBase):
+    """Make sure that if a derived class misses the inheritance from the
+    right base class, an exception is raised
+    """
+    mod_id = str(uuid.uuid4())
+    with pytest.raises(TypeError):
+        # pylint: disable=unused-variable
+        @TestModBase.testmod(id=mod_id, name="Sample tesmod", version="1.2.3")
+        class SampleBadTestmod:
+            """A sample test mod that is missing the base class"""
+
+
+def test_module_type_wrong_base_class(TestModBase):
+    """Make sure that if a derived class inherits from the wrong module type
+    an exception is raised
+    """
+    mod_id = str(uuid.uuid4())
+    with pytest.raises(TypeError):
+        # pylint: disable=unused-variable
+        @TestModBase.testmod(id=mod_id, name="Sample tesmod", version="1.2.3")
+        class SampleBadTestmod(caikit.core.BlockBase):
+            """A sample test mod that is missing the base class"""
+
+
+def test_module_no_reused_ids(TestModBase):
+    """Make sure that module ids can't be reused, even across module types"""
+    with pytest.raises(RuntimeError):
+
+        @TestModBase.testmod(
+            id=SampleBlock.MODULE_ID,
+            name="Sample tesmod",
+            version="1.2.3",
+        )
+        # pylint: disable=unused-variable
+        class SampleTestmod(TestModBase):
+            """A sample test mod"""
+
+
+def test_intermediate_metabase():
+    """Make sure that an abc.ABC can be declared that derives from ModuleBase"""
+
+    class Intermediate(caikit.core.blocks.base.BlockBase, abc.ABC):
+        """Sample intermediate base class"""
+
+        @abc.abstractmethod
+        def foobar(self, arg):
+            """Got to define foobar!"""
+
+    @caikit.core.block("asdf-qwer-zxcv", "FooBar", "0.0.1")
+    class Derived(Intermediate):
+        def foobar(self, arg):
+            return arg + 1
+
+    d = Derived()
+    assert d.foobar(1) == 2

--- a/tests/core/workflows/test_base.py
+++ b/tests/core/workflows/test_base.py
@@ -42,7 +42,7 @@ class TestWorkflowBase(TestCaseBase):
         self.NO_OP_WORKFLOW_CLASS = SampleWorkflow
 
     def test_init_available(self):
-        model = caikit.core.WorkflowBase([0, 1, 2], kw1=0, kw2=1, kw3=2)
+        model = caikit.core.WorkflowBase()
         self.assertIsInstance(model, caikit.core.WorkflowBase)
 
     def test_load_not_implemented(self):

--- a/tests/fixtures/config/config.yml
+++ b/tests/fixtures/config/config.yml
@@ -18,3 +18,9 @@ runtime:
 inference_plugin:
     model_mesh:
         runtime_version: mock
+
+module_backends:
+    load_priority:
+        # There is a 'MOCK' backend type defined in our test helpers
+        - type: MOCK
+        - type: LOCAL

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -16,7 +16,6 @@ from contextlib import contextmanager
 from unittest import mock
 import copy
 import tempfile
-import uuid
 
 # Third Party
 import grpc
@@ -26,8 +25,7 @@ import pytest
 from caikit.config import get_config
 from caikit.core import ModuleConfig
 from caikit.core.blocks import base, block
-from caikit.core.module_backends import BackendBase, backend_types
-from caikit.core.module_backends.backend_types import register_backend_type
+from caikit.core.module_backends import backend_types
 from caikit.runtime.model_management.batcher import Batcher
 from caikit.runtime.model_management.model_loader import ModelLoader
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -34,16 +34,12 @@ from caikit.runtime.model_management.model_loader import ModelLoader
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.blocks.sample_task import SampleBlock
 from sample_lib.data_model import SampleInputType, SampleOutputType
-from tests.conftest import temp_config
+from tests.conftest import temp_config, random_test_id
 from tests.fixtures import Fixtures
 from tests.core.helpers import MockBackend
 import caikit.core.blocks
 
 ## Helpers #####################################################################
-
-
-def _random_test_id():
-    return "test-any-model-" + str(uuid.uuid4())
 
 
 @contextmanager
@@ -95,7 +91,7 @@ def test_load_model_archive(model_loader):
 
 def test_load_model_error_not_found_response(model_loader):
     """Test load model's model does not exist error response"""
-    model_id = _random_test_id()
+    model_id = random_test_id()
     with pytest.raises(CaikitRuntimeException) as context:
         model_loader.load_model(
             model_id=model_id,
@@ -108,7 +104,7 @@ def test_load_model_error_not_found_response(model_loader):
 
 def test_load_invalid_model_error_response(model_loader):
     """Test load invalid model error response"""
-    model_id = _random_test_id()
+    model_id = random_test_id()
     with pytest.raises(CaikitRuntimeException) as context:
         model_loader.load_model(
             model_id=model_id,

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 # Standard
 from contextlib import contextmanager
-import copy
 import tempfile
-import unittest
 import uuid
 
 # Third Party
@@ -26,16 +24,15 @@ import pytest
 from caikit.config import get_config
 from caikit.core import ModuleConfig
 from caikit.core.blocks import base, block
-from caikit.core.module_backend_config import _CONFIGURED_BACKENDS, configure
 from caikit.core.module_backends import BackendBase, backend_types
 from caikit.core.module_backends.backend_types import register_backend_type
-from caikit.runtime.model_management import model_loader
 from caikit.runtime.model_management.batcher import Batcher
 from caikit.runtime.model_management.model_loader import ModelLoader
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.blocks.sample_task import SampleBlock
 from sample_lib.data_model import SampleInputType, SampleOutputType
 from tests.conftest import temp_config
+from tests.core.helpers import reset_globals
 from tests.fixtures import Fixtures
 
 ## Helpers #####################################################################
@@ -54,17 +51,9 @@ def temp_model_loader():
     ModelLoader._ModelLoader__instance = real_singleton
 
 
-@contextmanager
-def reset_distributed_config():
-    """Temporarily overwrite the configuration for backends"""
-    prev_config_backends = copy.copy(_CONFIGURED_BACKENDS)
-    _CONFIGURED_BACKENDS.clear()
-    yield
-    _CONFIGURED_BACKENDS.clear()
-    configure()
-    _CONFIGURED_BACKENDS.clear()
-    for key, value in prev_config_backends.items():
-        _CONFIGURED_BACKENDS[key] = value
+@pytest.fixture
+def model_loader():
+    return ModelLoader.get_instance()
 
 
 class TestBackend(BackendBase):
@@ -113,198 +102,198 @@ class DistributedGadget:
 ## Tests #######################################################################
 
 
-class MyTestCase(unittest.TestCase):
-    def setUp(self):
-        """This method runs before each test begins to run"""
-        self.model_loader = ModelLoader.get_instance()
+def test_load_model_ok_response(model_loader):
+    """Test that we can load up a valid model folder"""
+    model_id = "happy_load_test"
+    loaded_model = model_loader.load_model(
+        model_id=model_id,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert loaded_model.module() is not None
+    assert isinstance(loaded_model.module(), base.BlockBase)
+    assert model_id == loaded_model.id()
+    assert Fixtures.get_good_model_type() == loaded_model.type()
+    assert Fixtures.get_good_model_path() == loaded_model.path()
 
-    def test_load_model_ok_response(self):
-        """Test that we can load up a valid model folder"""
-        model_id = "happy_load_test"
-        loaded_model = self.model_loader.load_model(
+    # Models are not sized by the loader
+    assert loaded_model.size() == 0
+
+
+def test_load_model_archive(model_loader):
+    """Test that we can load up a valid model archive"""
+    model_id = "happy_load_test"
+    loaded_model = model_loader.load_model(
+        model_id=model_id,
+        local_model_path=Fixtures.get_good_model_archive_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert loaded_model.module() is not None
+    assert isinstance(loaded_model.module(), base.BlockBase)
+
+
+def test_load_model_error_not_found_response(model_loader):
+    """Test load model's model does not exist error response"""
+    model_id = _random_test_id()
+    with pytest.raises(CaikitRuntimeException) as context:
+        model_loader.load_model(
             model_id=model_id,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
+            local_model_path="test/this/does/not/exist.zip",
+            model_type="categories_esa",
         )
-        self.assertIsNotNone(loaded_model.module())
-        self.assertIsInstance(loaded_model.module(), base.BlockBase)
-        self.assertEqual(model_id, loaded_model.id())
-        self.assertEqual(Fixtures.get_good_model_type(), loaded_model.type())
-        self.assertEqual(Fixtures.get_good_model_path(), loaded_model.path())
+    assert context.value.status_code == grpc.StatusCode.NOT_FOUND
+    assert model_id in context.value.message
 
-        # Models are not sized by the loader
-        self.assertEqual(loaded_model.size(), 0)
 
-    def test_load_model_archive(self):
-        """Test that we can load up a valid model archive"""
-        model_id = "happy_load_test"
-        loaded_model = self.model_loader.load_model(
+def test_load_invalid_model_error_response(model_loader):
+    """Test load invalid model error response"""
+    model_id = _random_test_id()
+    with pytest.raises(CaikitRuntimeException) as context:
+        model_loader.load_model(
             model_id=model_id,
-            local_model_path=Fixtures.get_good_model_archive_path(),
-            model_type=Fixtures.get_good_model_type(),
+            local_model_path=Fixtures.get_bad_model_archive_path(),
+            model_type="not_real",
         )
-        self.assertIsNotNone(loaded_model.module())
-        self.assertIsInstance(loaded_model.module(), base.BlockBase)
+    assert context.value.status_code == grpc.StatusCode.INTERNAL
+    assert model_id in context.value.message
 
-    def test_load_model_error_not_found_response(self):
-        """Test load model's model does not exist error response"""
-        model_id = _random_test_id()
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_loader.load_model(
-                model_id=model_id,
-                local_model_path="test/this/does/not/exist.zip",
-                model_type="categories_esa",
-            )
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
-        self.assertIn(model_id, context.exception.message)
 
-    def test_load_invalid_model_error_response(self):
-        """Test load invalid model error response"""
-        model_id = _random_test_id()
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_loader.load_model(
-                model_id=model_id,
-                local_model_path=Fixtures.get_bad_model_archive_path(),
-                model_type="not_real",
-            )
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.INTERNAL)
-        self.assertIn(model_id, context.exception.message)
+def test_it_can_load_more_than_one_model(model_loader):
+    """Make sure we can load multiple models without side effects"""
+    # TODO: change test to load multiple models
 
-    def test_it_can_load_more_than_one_model(self):
-        """Make sure we can load multiple models without side effects"""
-        # TODO: change test to load multiple models
+    model_id = "concurrent_load_test"
+    model_1 = model_loader.load_model(
+        model_id,
+        Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    model_id = "concurrent_load_test_2"
+    model_2 = model_loader.load_model(
+        model_id,
+        Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
 
-        model_id = "concurrent_load_test"
-        model_1 = self.model_loader.load_model(
+    assert model_1 is not None
+    assert model_2 is not None
+    # Different refs
+    assert model_1 != model_2
+
+
+def test_nonzip_extract_fails(model_loader):
+    """Check that we raise an error if we throw in an archive that isn't really an archive"""
+    model_id = "will_not_be_created"
+
+    with pytest.raises(CaikitRuntimeException) as context:
+        model_loader.load_model(
             model_id,
+            Fixtures.get_invalid_model_archive_path(),
+            Fixtures.get_good_model_type(),
+        )
+    # This ends up returning a FileNotFoundError from caikit core.
+    # maybe not the best? But it does include an error message at least
+    assert (
+        context.value.status_code == grpc.StatusCode.NOT_FOUND
+    ), "Non-zip file did not raise an error"
+    assert Fixtures.get_invalid_model_archive_path() in context.value.message
+    assert "config.yml" in context.value.message
+
+
+def test_no_double_instantiation():
+    """Make sure trying to re-instantiate this singleton raises"""
+    with pytest.raises(Exception):
+        ModelLoader()
+
+
+def test_with_batching(model_loader):
+    """Make sure that loading with batching configuration correctly wraps a
+    Batcher around the model.
+    """
+    model = model_loader.load_model(
+        "load_with_batch",
+        Fixtures.get_good_model_path(),
+        model_type="fake_batch_block",
+    ).module()
+    assert isinstance(model, Batcher)
+    assert model._batch_size == get_config().runtime.batching.fake_batch_block.size
+
+    # Make sure another model loads without batching
+    model = model_loader.load_model(
+        "load_without_batch",
+        Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    ).module()
+    assert not isinstance(model, Batcher)
+
+
+def test_with_batching_by_default(model_loader):
+    """Make sure that a model type without specific batching enabled will
+    load with a batcher if default is enabled
+    """
+    with temp_config({"runtime": {"batching": {"default": {"size": 10}}}}) as cfg:
+        model = model_loader.load_model(
+            "load_with_batch_default",
             Fixtures.get_good_model_path(),
             model_type=Fixtures.get_good_model_type(),
-        )
-        model_id = "concurrent_load_test_2"
-        model_2 = self.model_loader.load_model(
-            model_id,
-            Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-
-        self.assertIsNotNone(model_1)
-        self.assertIsNotNone(model_2)
-        # Different refs
-        self.assertNotEqual(model_1, model_2)
-
-    def test_nonzip_extract_fails(self):
-        """Check that we raise an error if we throw in an archive that isn't really an archive"""
-        model_id = "will_not_be_created"
-
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_loader.load_model(
-                model_id,
-                Fixtures.get_invalid_model_archive_path(),
-                Fixtures.get_good_model_type(),
-            )
-        # This ends up returning a FileNotFoundError from caikit core.
-        # maybe not the best? But it does include an error message at least
-        self.assertEqual(
-            context.exception.status_code,
-            grpc.StatusCode.NOT_FOUND,
-            msg="Non-zip file did not raise an error",
-        )
-        self.assertIn(
-            Fixtures.get_invalid_model_archive_path(), context.exception.message
-        )
-        self.assertIn("config.yml", context.exception.message)
-
-    def test_no_double_instantiation(self):
-        """Make sure trying to re-instantiate this singleton raises"""
-        with pytest.raises(Exception):
-            ModelLoader()
-
-    def test_with_batching(self):
-        """Make sure that loading with batching configuration correctly wraps a
-        Batcher around the model.
-        """
-        model = self.model_loader.load_model(
-            "load_with_batch",
-            Fixtures.get_good_model_path(),
-            model_type="fake_batch_block",
         ).module()
         assert isinstance(model, Batcher)
-        assert model._batch_size == get_config().runtime.batching.fake_batch_block.size
+        assert model._batch_size == cfg.runtime.batching.default.size
 
-        # Make sure another model loads without batching
-        model = self.model_loader.load_model(
-            "load_without_batch",
-            Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        ).module()
-        assert not isinstance(model, Batcher)
 
-    def test_with_batching_by_default(self):
-        """Make sure that a model type without specific batching enabled will
-        load with a batcher if default is enabled
-        """
-        with temp_config({"runtime": {"batching": {"default": {"size": 10}}}}) as cfg:
-            model = self.model_loader.load_model(
-                "load_with_batch_default",
-                Fixtures.get_good_model_path(),
-                model_type=Fixtures.get_good_model_type(),
-            ).module()
-            assert isinstance(model, Batcher)
-            assert model._batch_size == cfg.runtime.batching.default.size
-
-    def test_with_batching_collect_delay(self):
-        """Make sure that a non-zero collect_delay_s is read correctly"""
-        model_type = Fixtures.get_good_model_type()
-        with temp_config(
-            {
-                "runtime": {
-                    "batching": {
-                        model_type: {
-                            "size": 10,
-                            "collect_delay_s": 0.01,
-                        },
-                    }
+def test_with_batching_collect_delay(model_loader):
+    """Make sure that a non-zero collect_delay_s is read correctly"""
+    model_type = Fixtures.get_good_model_type()
+    with temp_config(
+        {
+            "runtime": {
+                "batching": {
+                    model_type: {
+                        "size": 10,
+                        "collect_delay_s": 0.01,
+                    },
                 }
             }
-        ) as cfg:
-            model = self.model_loader.load_model(
-                "load_with_batch_default",
-                Fixtures.get_good_model_path(),
-                model_type=model_type,
-            ).module()
-            assert isinstance(model, Batcher)
-            assert model._batch_size == getattr(cfg.runtime.batching, model_type).size
-            assert (
-                model._batch_collect_delay_s
-                == getattr(cfg.runtime.batching, model_type).collect_delay_s
-            )
+        }
+    ) as cfg:
+        model = model_loader.load_model(
+            "load_with_batch_default",
+            Fixtures.get_good_model_path(),
+            model_type=model_type,
+        ).module()
+        assert isinstance(model, Batcher)
+        assert model._batch_size == getattr(cfg.runtime.batching, model_type).size
+        assert (
+            model._batch_collect_delay_s
+            == getattr(cfg.runtime.batching, model_type).collect_delay_s
+        )
 
-    def test_load_distributed_impl(self):
-        """Make sure that when configured, an alternate distributed
-        implementation of a block can be loaded
-        """
-        with tempfile.TemporaryDirectory() as model_path:
-            # Create and save the model directly with the local impl
-            SampleBlock().save(model_path)
 
-            model_type = "gadget"
-            with reset_distributed_config():
-                with temp_config(
-                    {
-                        "module_backends": {
-                            "enabled": True,
-                            "priority": [
-                                backend_types.TEST,
-                                backend_types.LOCAL,
-                            ],
-                        },
-                    }
-                ):
-                    with temp_model_loader() as model_loader:
-                        # Load the distributed version
-                        model = model_loader.load_model(
-                            "remote_gadget",
-                            model_path,
-                            model_type=model_type,
-                        ).module()
-                        assert isinstance(model, DistributedGadget)
+def test_load_distributed_impl(reset_globals):
+    """Make sure that when configured, an alternate distributed
+    implementation of a block can be loaded
+    """
+    with tempfile.TemporaryDirectory() as model_path:
+        # Create and save the model directly with the local impl
+        SampleBlock().save(model_path)
+
+        model_type = "gadget"
+        with temp_config(
+            {
+                "module_backends": {
+                    "enabled": True,
+                    "priority": [
+                        backend_types.TEST,
+                        backend_types.LOCAL,
+                    ],
+                },
+            }
+        ):
+            with temp_model_loader() as model_loader:
+                # Load the distributed version
+                model = model_loader.load_model(
+                    "remote_gadget",
+                    model_path,
+                    model_type=model_type,
+                ).module()
+                assert isinstance(model, DistributedGadget)

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -33,8 +33,7 @@ from caikit.runtime.model_management.model_loader import ModelLoader
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.blocks.sample_task import SampleBlock
 from sample_lib.data_model import SampleInputType, SampleOutputType
-from tests.conftest import temp_config, random_test_id
-from tests.fixtures import Fixtures
+from tests.conftest import random_test_id, temp_config
 from tests.core.helpers import MockBackend
 from tests.fixtures import Fixtures
 import caikit.core.blocks

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -34,6 +34,7 @@ from sample_lib.data_model import SampleInputType, SampleOutputType
 from tests.conftest import temp_config
 from tests.core.helpers import reset_globals
 from tests.fixtures import Fixtures
+import caikit.core.blocks
 
 ## Helpers #####################################################################
 
@@ -82,7 +83,7 @@ register_backend_type(TestBackend)
     backend_type=backend_types.TEST,
     backend_config_override={"bar1": 1},
 )
-class DistributedGadget:
+class DistributedGadget(caikit.core.blocks.base.BlockBase):
     """An alternate implementation of a Gadget"""
 
     SUPPORTED_LOAD_BACKENDS = [backend_types.TEST, backend_types.LOCAL]

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -29,9 +29,8 @@ from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import get_dynamic_module
-from tests.conftest import temp_config, random_test_id
+from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
-
 
 get_dynamic_module("caikit.core")
 ANY_MODEL_TYPE = "test-any-model-type"

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -25,7 +25,6 @@ import grpc
 # Local
 from caikit import get_config
 from caikit.core.blocks.base import BlockBase
-from caikit.core.module_backend_config import _CONFIGURED_BACKENDS, configure
 from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -29,12 +29,8 @@ from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import get_dynamic_module
-from tests.conftest import temp_config
+from tests.conftest import temp_config, random_test_id
 from tests.fixtures import Fixtures
-
-
-def _random_test_id():
-    return "test-any-model-" + str(uuid.uuid4())
 
 
 get_dynamic_module("caikit.core")
@@ -120,7 +116,7 @@ class TestModelManager(unittest.TestCase):
         """Test load model's model does not exist when the loader throws"""
         with self.assertRaises(CaikitRuntimeException) as context:
             self.model_manager.load_model(
-                model_id=_random_test_id(),
+                model_id=random_test_id(),
                 local_model_path=Fixtures().get_invalid_model_archive_path(),
                 model_type="categories_esa",
             )
@@ -130,7 +126,7 @@ class TestModelManager(unittest.TestCase):
 
     def test_load_model_map_insertion(self):
         """Test if loaded model is correctly added to map storing model data"""
-        model = _random_test_id()
+        model = random_test_id()
         self.model_manager.load_model(
             model_id=model,
             local_model_path=Fixtures.get_good_model_path(),
@@ -141,12 +137,12 @@ class TestModelManager(unittest.TestCase):
     def test_load_model_count(self):
         """Test if multiple loaded models are added to map storing model data"""
         self.model_manager.load_model(
-            model_id=_random_test_id(),
+            model_id=random_test_id(),
             local_model_path=Fixtures.get_good_model_path(),
             model_type=Fixtures.get_good_model_type(),
         )
         self.model_manager.load_model(
-            model_id=_random_test_id(),
+            model_id=random_test_id(),
             local_model_path=Fixtures.get_good_model_path(),
             model_type=Fixtures.get_good_model_type(),
         )
@@ -204,14 +200,14 @@ class TestModelManager(unittest.TestCase):
     def test_unload_model_not_loaded_response(self):
         """Test unload model for model not loaded does NOT throw an error"""
         try:
-            self.model_manager.unload_model(model_id=_random_test_id())
+            self.model_manager.unload_model(model_id=random_test_id())
         except Exception:
             self.fail("Unload for a model that does not exist threw an error!")
 
     # TODO: If this is refactored to pytest, the loaded_model_id fixture can be used
     def test_retrieve_model_returns_loaded_model(self):
         """Test that a loaded model can be retrieved"""
-        model_id = _random_test_id()
+        model_id = random_test_id()
         Fixtures.load_model(
             model_id=model_id,
             local_model_path=Fixtures.get_good_model_path(),
@@ -229,7 +225,7 @@ class TestModelManager(unittest.TestCase):
 
     def test_model_size_ok_response(self):
         """Test if loaded model correctly returns model size"""
-        model = _random_test_id()
+        model = random_test_id()
         self.model_manager.load_model(
             model_id=model,
             local_model_path=Fixtures.get_good_model_path(),
@@ -252,7 +248,7 @@ class TestModelManager(unittest.TestCase):
     def test_estimate_model_size_ok_response_on_loaded_model(self):
         """Test if loaded model correctly returns model size"""
         self.model_manager.load_model(
-            model_id=_random_test_id(),
+            model_id=random_test_id(),
             local_model_path=Fixtures.get_good_model_path(),
             model_type=Fixtures.get_good_model_type(),
         )
@@ -293,7 +289,7 @@ class TestModelManager(unittest.TestCase):
         """Test if error in predict model size on unknown model path"""
         with self.assertRaises(CaikitRuntimeException) as context:
             self.model_manager.estimate_model_size(
-                model_id=_random_test_id(),
+                model_id=random_test_id(),
                 local_model_path="no_exist.zip",
                 model_type="categories_esa",
             )
@@ -308,7 +304,7 @@ class TestModelManager(unittest.TestCase):
         at a later time)."""
         mock_loader = MagicMock()
         mock_sizer = MagicMock()
-        model_id = _random_test_id()
+        model_id = random_test_id()
         expected_model_size = 1234
 
         with patch.object(self.model_manager, "model_loader", mock_loader):
@@ -337,7 +333,7 @@ class TestModelManager(unittest.TestCase):
 
             with self.assertRaises(CaikitRuntimeException) as context:
                 self.model_manager.load_model(
-                    _random_test_id(), ANY_MODEL_PATH, ANY_MODEL_TYPE
+                    random_test_id(), ANY_MODEL_PATH, ANY_MODEL_TYPE
                 )
 
             self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
@@ -345,7 +341,7 @@ class TestModelManager(unittest.TestCase):
 
     def test_retrieve_model_returns_the_block_from_the_model_loader(self):
         """Test that a loaded model can be retrieved"""
-        model_id = _random_test_id()
+        model_id = random_test_id()
         expected_block = "this is definitely a stub block"
         mock_sizer = MagicMock()
         mock_loader = MagicMock()
@@ -366,7 +362,7 @@ class TestModelManager(unittest.TestCase):
         mock_loader = MagicMock()
         mock_sizer = MagicMock()
         expected_model_size = 1234
-        model_id = _random_test_id()
+        model_id = random_test_id()
 
         with patch.object(self.model_manager, "model_loader", mock_loader):
             with patch.object(self.model_manager, "model_sizer", mock_sizer):
@@ -382,7 +378,7 @@ class TestModelManager(unittest.TestCase):
         """Test that estimating a model size uses the ModelSizer"""
         mock_sizer = MagicMock()
         expected_model_size = 5678
-        model_id = _random_test_id()
+        model_id = random_test_id()
 
         with patch.object(self.model_manager, "model_sizer", mock_sizer):
             mock_sizer.get_model_size.return_value = expected_model_size
@@ -394,7 +390,7 @@ class TestModelManager(unittest.TestCase):
     def test_estimate_model_size_throws_if_model_sizer_throws(self):
         """Test that estimating a model size uses the ModelSizer"""
         mock_sizer = MagicMock()
-        model_id = _random_test_id()
+        model_id = random_test_id()
 
         with patch.object(self.model_manager, "model_sizer", mock_sizer):
             mock_sizer.get_model_size.side_effect = CaikitRuntimeException(

--- a/tests/runtime/model_management/test_model_sizer.py
+++ b/tests/runtime/model_management/test_model_sizer.py
@@ -24,12 +24,8 @@ import grpc
 from caikit import get_config
 from caikit.runtime.model_management.model_sizer import ModelSizer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
-from tests.conftest import temp_config
+from tests.conftest import temp_config, random_test_id
 from tests.fixtures import Fixtures
-
-
-def _random_test_id() -> str:
-    return "test-any-model-" + str(uuid.uuid4())
 
 
 def _random_test_model_type() -> str:
@@ -74,7 +70,7 @@ class TestModelSizer(unittest.TestCase):
             ):
                 expected_size = total_size * mult
                 size = self.model_sizer.get_model_size(
-                    model_id=_random_test_id(),
+                    model_id=random_test_id(),
                     local_model_path=d,
                     model_type=model_type,
                 )
@@ -96,7 +92,7 @@ class TestModelSizer(unittest.TestCase):
             )
 
             size = self.model_sizer.get_model_size(
-                model_id=_random_test_id(),
+                model_id=random_test_id(),
                 local_model_path=Fixtures.get_good_model_archive_path(),
                 model_type=model_type,
             )
@@ -110,7 +106,7 @@ class TestModelSizer(unittest.TestCase):
         )
 
         size = self.model_sizer.get_model_size(
-            model_id=_random_test_id(),
+            model_id=random_test_id(),
             local_model_path=Fixtures.get_good_model_archive_path(),
             model_type=model_type,
         )
@@ -119,7 +115,7 @@ class TestModelSizer(unittest.TestCase):
     def test_it_throws_not_found_if_file_does_not_exist(self):
         with self.assertRaises(CaikitRuntimeException) as context:
             self.model_sizer.get_model_size(
-                model_id=_random_test_id(),
+                model_id=random_test_id(),
                 local_model_path="not/a/path/to/anything",
                 model_type=_random_test_model_type(),
             )
@@ -131,7 +127,7 @@ class TestModelSizer(unittest.TestCase):
             TestModelSizer._add_file(os.path.join(d, "some_file"), 256)
 
             model_type = _random_test_model_type()
-            model_id = _random_test_id()
+            model_id = random_test_id()
             original_size = self.model_sizer.get_model_size(
                 model_id=model_id,
                 local_model_path=d,

--- a/tests/runtime/model_management/test_model_sizer.py
+++ b/tests/runtime/model_management/test_model_sizer.py
@@ -24,7 +24,7 @@ import grpc
 from caikit import get_config
 from caikit.runtime.model_management.model_sizer import ModelSizer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
-from tests.conftest import temp_config, random_test_id
+from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
 
 

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -33,10 +33,6 @@ from tests.fixtures import Fixtures
 import sample_lib
 
 
-def _random_test_id():
-    return "test-any-model-" + str(uuid.uuid4())
-
-
 HAPPY_PATH_INPUT = SampleInputType(name="Gabe").to_proto()
 HAPPY_PATH_RESPONSE = SampleOutputType(greeting="Hello Gabe").to_proto()
 

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -32,7 +32,6 @@ from sample_lib.data_model import SampleInputType, SampleOutputType
 from tests.fixtures import Fixtures
 import sample_lib
 
-
 HAPPY_PATH_INPUT = SampleInputType(name="Gabe").to_proto()
 HAPPY_PATH_RESPONSE = SampleOutputType(greeting="Hello Gabe").to_proto()
 

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -36,10 +36,6 @@ import caikit.core
 ## Helpers #####################################################################
 
 
-def _random_training_id():
-    return "training-" + str(uuid.uuid4())
-
-
 def _primitives_function(
     self,
     double_field,

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -29,15 +29,11 @@ from sample_lib.data_model.sample import (
     SampleOutputType,
     SampleTrainingType,
 )
-from tests.conftest import temp_config
+from tests.conftest import temp_config, random_test_id
 from tests.fixtures import Fixtures
 import caikit.core
 
 ## Helpers #####################################################################
-
-
-def _random_test_id():
-    return "test-any-model-" + str(uuid.uuid4())
 
 
 def _random_training_id():
@@ -94,7 +90,7 @@ def test_global_train_sample_task(
     training_data = stream_type(
         jsondata=stream_type.JsonData(data=[SampleTrainingType(1)])
     ).to_proto()
-    model_name = _random_test_id()
+    model_name = random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name,
@@ -250,7 +246,7 @@ def test_run_train_job_works_with_wait(
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name=_random_test_id(),
+            model_name=random_test_id(),
             batch_size=42,
             training_data=training_data,
         )
@@ -348,7 +344,7 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_but_not_loaded_s
     sample_train_service, sample_train_servicer
 ):
     """Global train of TrainRequest raises when calling a train function that requires another loaded model, but model is not loaded"""
-    model_id = _random_test_id()
+    model_id = random_test_id()
 
     sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
         model_id=model_id
@@ -376,7 +372,7 @@ def test_global_train_Edge_Case_Widget_should_raise_when_error_surfaces_from_blo
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name=_random_test_id(),
+            model_name=random_test_id(),
             batch_size=999,
             training_data=training_data,
         )
@@ -401,7 +397,7 @@ def test_global_train_returns_exit_code_with_oom(
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name=_random_test_id(),
+            model_name=random_test_id(),
             batch_size=42,
             training_data=training_data,
             oom_exit=True,

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -65,12 +65,6 @@ def _primitives_function(
     pass
 
 
-HAPPY_PATH_RESPONSE = caikit.interfaces.runtime.data_model.TrainingJob(
-    model_name="Foo Bar Training",
-    training_id=_random_training_id(),
-)
-
-
 @pytest.fixture(autouse=True, params=[True, False])
 def set_train_location(request):
     """This fixture ensures that all tests in this file will be run with both

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -94,16 +94,17 @@ def test_global_train_sample_task(
     training_data = stream_type(
         jsondata=stream_type.JsonData(data=[SampleTrainingType(1)])
     ).to_proto()
+    model_name = _random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training",
+            model_name=model_name,
             batch_size=42,
             training_data=training_data,
         )
     )
 
     training_response = sample_train_servicer.Train(train_request)
-    assert training_response.model_name == "Foo Bar Training"
+    assert training_response.model_name == model_name
     assert training_response.training_id is not None
     assert isinstance(training_response.training_id, str)
 
@@ -249,7 +250,7 @@ def test_run_train_job_works_with_wait(
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training",
+            model_name=_random_test_id(),
             batch_size=42,
             training_data=training_data,
         )
@@ -375,7 +376,7 @@ def test_global_train_Edge_Case_Widget_should_raise_when_error_surfaces_from_blo
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training",
+            model_name=_random_test_id(),
             batch_size=999,
             training_data=training_data,
         )
@@ -400,7 +401,7 @@ def test_global_train_returns_exit_code_with_oom(
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training",
+            model_name=_random_test_id(),
             batch_size=42,
             training_data=training_data,
             oom_exit=True,

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -29,7 +29,7 @@ from sample_lib.data_model.sample import (
     SampleOutputType,
     SampleTrainingType,
 )
-from tests.conftest import temp_config, random_test_id
+from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
 import caikit.core
 

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -69,6 +69,10 @@ HAPPY_PATH_TRAIN_RESPONSE = TrainingJob(
 ).to_proto()
 
 
+def _random_test_id():
+    return "test-any-model-" + str(uuid.uuid4())
+
+
 def is_good_train_response(actual_response, expected, model_name):
     assert dir(actual_response) == dir(expected)
     assert actual_response.training_id is not None
@@ -191,7 +195,7 @@ def test_train_fake_block_ok_response_and_can_predict_with_trained_model(
             data=[SampleTrainingType(1), SampleTrainingType(2)]
         )
     ).to_proto()
-    model_name = "Foo Bar Training"
+    model_name = _random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name, training_data=training_data
@@ -225,7 +229,7 @@ def test_train_fake_block_ok_response_with_loaded_model_can_predict_with_trained
     sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
         model_id=loaded_model_id
     ).to_proto()
-    model_name = "Foo Bar Training"
+    model_name = _random_test_id()
     train_request = (
         sample_train_service.messages.WorkflowsSampleTaskSampleWorkflowTrainRequest(
             model_name=model_name, sample_block=sample_model
@@ -309,7 +313,7 @@ def test_train_fake_block_ok_response_with_datastream_jsondata(
             data=[SampleTrainingType(1), SampleTrainingType(2)]
         )
     ).to_proto()
-    model_name = "Foo Bar Training with json data"
+    model_name = _random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name,
@@ -347,7 +351,7 @@ def test_train_fake_block_ok_response_with_datastream_csv_file(
     training_data = stream_type(
         file=stream_type.File(filename=sample_csv_file)
     ).to_proto()
-    model_name = "Foo Bar Training with file data"
+    model_name = _random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name,
@@ -379,12 +383,12 @@ def test_train_fake_block_error_response_with_unloaded_model(
     """Test RPC CaikitRuntime.WorkflowsSampleTaskSampleWorkflowTrain error response because sample model is not loaded"""
     with pytest.raises(grpc.RpcError) as context:
         sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
-            model_id="some_id"
+            model_id=_random_test_id()
         ).to_proto()
 
         train_request = (
             sample_train_service.messages.WorkflowsSampleTaskSampleWorkflowTrainRequest(
-                model_name="Foo Bar Training", sample_block=sample_model
+                model_name=_random_test_id(), sample_block=sample_model
             )
         )
         train_stub.WorkflowsSampleTaskSampleWorkflowTrain(train_request)

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -55,7 +55,7 @@ from sample_lib.data_model import (
     SampleOutputType,
     SampleTrainingType,
 )
-from tests.conftest import temp_config
+from tests.conftest import temp_config, random_test_id
 from tests.fixtures import Fixtures
 import caikit
 import sample_lib
@@ -67,10 +67,6 @@ HAPPY_PATH_RESPONSE = SampleOutputType(greeting="Hello Gabe").to_proto()
 HAPPY_PATH_TRAIN_RESPONSE = TrainingJob(
     model_name="dummy name", training_id="dummy id"
 ).to_proto()
-
-
-def _random_test_id():
-    return "test-any-model-" + str(uuid.uuid4())
 
 
 def is_good_train_response(actual_response, expected, model_name):
@@ -195,7 +191,7 @@ def test_train_fake_block_ok_response_and_can_predict_with_trained_model(
             data=[SampleTrainingType(1), SampleTrainingType(2)]
         )
     ).to_proto()
-    model_name = _random_test_id()
+    model_name = random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name, training_data=training_data
@@ -229,7 +225,7 @@ def test_train_fake_block_ok_response_with_loaded_model_can_predict_with_trained
     sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
         model_id=loaded_model_id
     ).to_proto()
-    model_name = _random_test_id()
+    model_name = random_test_id()
     train_request = (
         sample_train_service.messages.WorkflowsSampleTaskSampleWorkflowTrainRequest(
             model_name=model_name, sample_block=sample_model
@@ -313,7 +309,7 @@ def test_train_fake_block_ok_response_with_datastream_jsondata(
             data=[SampleTrainingType(1), SampleTrainingType(2)]
         )
     ).to_proto()
-    model_name = _random_test_id()
+    model_name = random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name,
@@ -351,7 +347,7 @@ def test_train_fake_block_ok_response_with_datastream_csv_file(
     training_data = stream_type(
         file=stream_type.File(filename=sample_csv_file)
     ).to_proto()
-    model_name = _random_test_id()
+    model_name = random_test_id()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
             model_name=model_name,
@@ -383,12 +379,12 @@ def test_train_fake_block_error_response_with_unloaded_model(
     """Test RPC CaikitRuntime.WorkflowsSampleTaskSampleWorkflowTrain error response because sample model is not loaded"""
     with pytest.raises(grpc.RpcError) as context:
         sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
-            model_id=_random_test_id()
+            model_id=random_test_id()
         ).to_proto()
 
         train_request = (
             sample_train_service.messages.WorkflowsSampleTaskSampleWorkflowTrainRequest(
-                model_name=_random_test_id(), sample_block=sample_model
+                model_name=random_test_id(), sample_block=sample_model
             )
         )
         train_stub.WorkflowsSampleTaskSampleWorkflowTrain(train_request)

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -55,7 +55,7 @@ from sample_lib.data_model import (
     SampleOutputType,
     SampleTrainingType,
 )
-from tests.conftest import temp_config, random_test_id
+from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
 import caikit
 import sample_lib

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -15,6 +15,7 @@
 # Standard
 import os
 import tempfile
+import uuid
 
 # Third Party
 import pytest
@@ -33,6 +34,7 @@ from caikit.runtime.utils.servicer_util import (
     validate_data_model,
 )
 from sample_lib.data_model import SampleInputType
+from tests.conftest import random_test_id
 from tests.fixtures import Fixtures
 from tests.fixtures.protobufs import primitive_party_pb2
 import caikit.core
@@ -342,7 +344,7 @@ def test_global_train_build_caikit_library_request_dict_creates_caikit_core_run_
     and if not passed in request, it creates the fields with default values"""
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training"  # not having batch_size, and training_data
+            model_name=random_test_id()  # not having batch_size, and training_data
         )
     )
 
@@ -372,7 +374,7 @@ def test_global_train_build_caikit_library_request_dict_strips_empty_list_from_r
     training_data = stream_type(jsondata=stream_type.JsonData(data=[])).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training", training_data=training_data
+            model_name=random_test_id(), training_data=training_data
         )
     )
 
@@ -395,7 +397,7 @@ def test_global_train_build_caikit_library_request_dict_works_for_repeated_field
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(jsondata=stream_type.JsonData(data=[])).to_proto()
     train_request = sample_train_service.messages.BlocksSampleTaskListBlockTrainRequest(
-        model_name="Foo Bar Training",
+        model_name=random_test_id(),
         training_data=training_data,
         poison_pills=["Bob Marley", "Bunny Livingston"],
     )
@@ -449,7 +451,7 @@ def test_global_train_build_caikit_library_request_dict_ok_with_data_stream_file
     ).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training",
+            model_name=random_test_id(),
             training_data=training_data,
         )
     )
@@ -474,7 +476,7 @@ def test_global_train_build_caikit_library_request_dict_ok_with_training_data_as
         listoffiles=stream_type.ListOfFiles(files=[sample_csv_file, sample_json_file])
     ).to_proto()
     train_request = sample_train_service.messages.BlocksSampleTaskListBlockTrainRequest(
-        model_name="Foo Bar Training",
+        model_name=random_test_id(),
         training_data=training_data,
         poison_pills=["Bob Marley", "Bunny Livingston"],
     )
@@ -513,7 +515,7 @@ def test_build_caikit_library_request_dict_works_when_data_stream_directory_incl
         ).to_proto()
         train_request = (
             sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-                model_name="Foo Bar Training",
+                model_name=random_test_id(),
                 training_data=training_data,
             )
         )
@@ -537,7 +539,7 @@ def test_build_caikit_library_request_dict_raises_invalid_data_stream_source_fil
     training_data = stream_type(file=stream_type.File(filename="abc.blah")).to_proto()
     train_request = (
         sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-            model_name="Foo Bar Training",
+            model_name=random_test_id(),
             training_data=training_data,
         )
     )
@@ -622,7 +624,7 @@ def test_build_caikit_library_request_dict_raises_when_data_stream_directory_pas
         ).to_proto()
         train_request = (
             sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-                model_name="Foo Bar Training",
+                model_name=random_test_id(),
                 training_data=training_data,
             )
         )
@@ -655,7 +657,7 @@ def test_build_caikit_library_request_dict_raises_when_data_stream_directory_pas
         ).to_proto()
         train_request = (
             sample_train_service.messages.BlocksSampleTaskSampleBlockTrainRequest(
-                model_name="Foo Bar Training",
+                model_name=random_test_id(),
                 training_data=training_data,
             )
         )

--- a/tests/runtime/work_management/test_abortable_action.py
+++ b/tests/runtime/work_management/test_abortable_action.py
@@ -60,7 +60,6 @@ class TestAbortableAction(unittest.TestCase):
         infinite_function_has_started = threading.Event()
 
         def infinite_function():
-            print(infinite_function_has_started)
             infinite_function_has_started.set()
             while True:
                 time.sleep(0.1)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = pytest --cov=caikit --cov-report=term --cov-report=html {posargs:tests}
+commands = pytest --cov=caikit --cov-report=html {posargs:tests}
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
This PR is the beginning of @gabe-l-hart and @tjohnson31415 's vision of the future of backends

This is a **breaking configuration change**

This:
- Adds `SharedLoadBackend` and `SharedTrainBackend` base classes and the `local` implementations of them
- Consolidates the `module_backends.priority` and `module_backends.config` configurations as a list of objects that include the backend type and its config
- Splits the backend priorities between training and loading, `module_backends.load_priority` and `module_backends.train_priority`
- Allows multiple backends of the same type to be registered under a different name and with different configurations
- Deletes the `module_backends.enabled` flag that was only used by the runtime. (It was buggy anyway, since the core loader would run backend configuration even if `module_backends.enabled` was False)

This does not yet implement a `caikit.train` method that can use an appropriate shared train backend similar to how `caikit.load` does.

As a followup design issue, the split between "shared" and the original "not shared" backends is pretty awkward. We'd like to explore if the original backends are really required or if they can be posed as shared backends as well. This would probably mean walking back the original "distributed module" pattern where multiple backend implementations are registered against the same guid as a base module