### PR TITLE
🐛 handle ctrl chars in datastream

### DIFF
--- a/caikit/core/data_model/streams/data_stream.py
+++ b/caikit/core/data_model/streams/data_stream.py
@@ -176,7 +176,7 @@ class DataStream(Generic[T]):
 
                 try:
                     for line in lines:
-                        if line != b"\n":  # ignore new line characters
+                        if line.strip():  # ignore empty lines
                             yield json.loads(line)
                 except json.JSONDecodeError as e:
                     error(

--- a/caikit/core/data_model/streams/data_stream.py
+++ b/caikit/core/data_model/streams/data_stream.py
@@ -347,6 +347,7 @@ class DataStream(Generic[T]):
         def generator_func(*csv_args, **csv_kwargs):
             # open the csv file (closure around `filename`)
             with open(filename, mode="r", encoding="utf8") as fh:
+
                 # for each line of the csv file, yield a dict
                 for line in csv.DictReader(fh, *csv_args, **csv_kwargs):
                     yield line

--- a/caikit/core/data_model/streams/data_stream.py
+++ b/caikit/core/data_model/streams/data_stream.py
@@ -176,7 +176,8 @@ class DataStream(Generic[T]):
 
                 try:
                     for line in lines:
-                        yield json.loads(line)
+                        if line != b"\n":
+                            yield json.loads(line)
                 except json.JSONDecodeError as e:
                     error(
                         "<COR55596551E>",

--- a/caikit/core/data_model/streams/data_stream.py
+++ b/caikit/core/data_model/streams/data_stream.py
@@ -176,7 +176,7 @@ class DataStream(Generic[T]):
 
                 try:
                     for line in lines:
-                        if line != b"\n":
+                        if line != b"\n":  # ignore new line characters
                             yield json.loads(line)
                 except json.JSONDecodeError as e:
                     error(
@@ -347,7 +347,6 @@ class DataStream(Generic[T]):
         def generator_func(*csv_args, **csv_kwargs):
             # open the csv file (closure around `filename`)
             with open(filename, mode="r", encoding="utf8") as fh:
-
                 # for each line of the csv file, yield a dict
                 for line in csv.DictReader(fh, *csv_args, **csv_kwargs):
                     yield line

--- a/tests/core/data_model/streams/test_data_stream.py
+++ b/tests/core/data_model/streams/test_data_stream.py
@@ -88,7 +88,7 @@ class TestDataStream(TestCaseBase):
             os.path.join(self.samples_path, "sample.jsonl")
         )
         self.jsonl_w_control_chars_data_stream = core_dm.DataStream.from_jsonl(
-            os.path.join(self.samples_path, "control_chars_jsonl.jsonl")
+            os.path.join(self.samples_path, "control_chars.jsonl")
         )
         self.sample_type_data_stream = self.txt_data_stream.map(
             lambda text: SampleInputType(name=text)

--- a/tests/core/data_model/streams/test_data_stream.py
+++ b/tests/core/data_model/streams/test_data_stream.py
@@ -87,6 +87,9 @@ class TestDataStream(TestCaseBase):
         self.jsonl_data_stream = core_dm.DataStream.from_jsonl(
             os.path.join(self.samples_path, "sample.jsonl")
         )
+        self.jsonl_w_control_chars_data_stream = core_dm.DataStream.from_jsonl(
+            os.path.join(self.samples_path, "control_chars_jsonl.jsonl")
+        )
         self.sample_type_data_stream = self.txt_data_stream.map(
             lambda text: SampleInputType(name=text)
         )
@@ -151,6 +154,12 @@ class TestDataStream(TestCaseBase):
 
     def test_jsonl_array_data_stream(self):
         self.validate_data_stream(self.jsonl_data_stream, 4, dict, 2)
+        for data_item in self.jsonl_data_stream:
+            for element in data_item:
+                self.assertIsInstance(element, str)
+
+    def test_jsonl_control_chars_array_data_stream(self):
+        self.validate_data_stream(self.jsonl_w_control_chars_data_stream, 2, dict, 2)
         for data_item in self.jsonl_data_stream:
             for element in data_item:
                 self.assertIsInstance(element, str)

--- a/tests/fixtures/data_stream_inputs/control_chars.jsonl
+++ b/tests/fixtures/data_stream_inputs/control_chars.jsonl
@@ -1,0 +1,3 @@
+{"name \t": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
+
+{"name \n": "John", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}

--- a/tests/fixtures/data_stream_inputs/control_chars_jsonl.jsonl
+++ b/tests/fixtures/data_stream_inputs/control_chars_jsonl.jsonl
@@ -1,4 +1,0 @@
-{"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
-{"name": "John", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
-
-

--- a/tests/fixtures/data_stream_inputs/control_chars_jsonl.jsonl
+++ b/tests/fixtures/data_stream_inputs/control_chars_jsonl.jsonl
@@ -1,0 +1,4 @@
+{"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
+{"name": "John", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
+
+


### PR DESCRIPTION
Handle escaped control characters in the server while loading training data.

The current code handles control characters as part of the string, for example `"name \t ": "John"` works well. But introducing new line characters as part of a `jsonl` file is what's causing problems at the moment.