### PR TITLE
:sparkles: Add config merge strategy

### DIFF
--- a/caikit/config/config.py
+++ b/caikit/config/config.py
@@ -163,10 +163,7 @@ def merge_configs(
         ):
             base[key] = value
         elif isinstance(value, list):
-            if key not in base or not isinstance(base[key], list):
-                base[key] = value
-            else:
-                base[key] = merge_list(base[key], value)
+            base[key] = merge_list(base[key], value)
         else:
             base[key] = merge_configs(base[key], value, merge_strategy)
 

--- a/caikit/config/config.py
+++ b/caikit/config/config.py
@@ -19,7 +19,6 @@
 # Standard
 from typing import Any, Dict, Optional, Union
 import os
-import threading
 
 # First Party
 import aconfig

--- a/caikit/config/config.py
+++ b/caikit/config/config.py
@@ -160,16 +160,12 @@ def merge_configs(
         ):
             base[key] = value
         elif isinstance(value, list):
-            base[key] = merge_list(base[key], value)
+            # merge lists by prepending new one
+            base[key] = value + base[key]
         else:
             base[key] = merge_configs(base[key], value, merge_strategy)
 
     return base
-
-
-def merge_list(base_list: list, new_list: list) -> list:
-    """Returns new list + base list with duplicates removed"""
-    return new_list + [v for v in base_list if v not in new_list]
 
 
 def _get_merge_strategy(cfg: _CONFIG_TYPE) -> str:

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -26,8 +26,6 @@ load_path: null
 
 # Configuration for training/loading via module backends
 module_backends:
-    # Local is always enabled unless explicitly disabled
-    disable_local: false
     # Configuration for distributed loading and training. Each has an ordered
     # list of backends in priority order. Each entry is a mapping with a "type"
     # field and optionally a "config" field that maps to a blob of config for

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -14,6 +14,9 @@
 
 # User can set comma-separated string of config file locations to read
 config_files: ""
+# merge_strategy can be either `merge` which will merge lists and dicts,
+# or `override` which will set the values directly
+merge_strategy: "merge"
 
 # Global config switch for runtime check functions (type_check, value_check, file_check...)
 enable_error_checks: true

--- a/caikit/core/module_backend_config.py
+++ b/caikit/core/module_backend_config.py
@@ -17,7 +17,6 @@ from typing import List
 import copy
 
 # First Party
-import aconfig
 import alog
 
 # Local
@@ -74,31 +73,6 @@ def configure():
     ]:
         backend_priority = backend_priority or []
         error.type_check("<COR46006487E>", list, backend_priority=backend_priority)
-
-        # Check if disable_local is set
-        disable_local_backend = config_object.disable_local or False
-
-        # Add local at the end of priority by default
-        backend_priority_types = [cfg.get("type") for cfg in backend_priority]
-        error.value_check(
-            "<COR92038969E>",
-            not (
-                disable_local_backend
-                and MODULE_BACKEND_TYPES.LOCAL in backend_priority_types
-            ),
-            "Invalid configuration with {} in the priority list and disable_local set",
-            MODULE_BACKEND_TYPES.LOCAL,
-        )
-        if not disable_local_backend and (
-            MODULE_BACKEND_TYPES.LOCAL not in backend_priority_types
-        ):
-            log.debug3("Adding fallback priority to [%s]", MODULE_BACKEND_TYPES.LOCAL)
-            backend_priority.append(
-                aconfig.Config(
-                    {"type": MODULE_BACKEND_TYPES.LOCAL},
-                    override_env_vars=False,
-                )
-            )
 
         # Configure each backend instance
         for i, backend_config in enumerate(backend_priority):

--- a/tests/config/test_configs.py
+++ b/tests/config/test_configs.py
@@ -124,7 +124,7 @@ def test_configure_merges_lists():
     # If values already existed in the list, they are popped then prepended
     cfg3 = {"foo_list": [1, 2]}
     caikit.configure(config_dict=cfg3)
-    assert caikit.get_config().foo_list == [1, 2, 4, 5, 6, 3]
+    assert caikit.get_config().foo_list == [1, 2, 4, 5, 6, 1, 2, 3]
 
 
 def test_merge_strategy():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,7 @@ def other_loaded_model_id(other_good_model_path) -> str:
 
 
 @contextmanager
-def temp_config(config_overrides: dict):
+def temp_config(config_overrides: dict, merge_strategy="override"):
     """Temporarily edit the caikit config in a mock context"""
     existing_config = copy.deepcopy(getattr(caikit.config.config, "_CONFIG"))
     # Patch out the internal config, starting with a fresh copy of the current config
@@ -196,6 +196,7 @@ def temp_config(config_overrides: dict):
         with patch.object(caikit.config.config, "_IMMUTABLE_CONFIG", None):
             # Run our config overrides inside the patch
             if config_overrides:
+                config_overrides["merge_strategy"] = merge_strategy
                 caikit.configure(config_dict=config_overrides)
             else:
                 # or just slap some random uuids in there. Barf, but we need to call `.configure()`

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -17,7 +17,7 @@
 # Standard
 from dataclasses import dataclass, field, is_dataclass
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional
 import copy
 import json
 import os

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -322,8 +322,7 @@ def test_backend_model_loaded_as_singleton(reset_globals):
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK],
-                "configs": {"mock": {}},
+                "load_priority": [{"type": backend_types.MOCK}],
             }
         }
     ):
@@ -359,8 +358,7 @@ def test_singleton_cache_with_different_backend(reset_globals):
     with temp_config(
         {
             "module_backends": {
-                "priority": [backend_types.MOCK],
-                "configs": {"mock": {}},
+                "load_priority": [{"type": backend_types.MOCK}],
             }
         }
     ):

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -403,20 +403,18 @@ def test_fall_back_to_local(reset_globals):
     assert isinstance(model, NonDistributedBlock)
 
 
-def test_no_local_if_disabled(reset_globals):
-    """Make sure that if LOCAL is disabled and a given module doesn't have any
-    registered backends, loading fails.
+def test_load_fails_on_no_supported_backend(reset_globals):
+    """Make sure if a given module doesn't have any registered backends,
+    loading fails.
     """
     _ = setup_saved_model(MockBackend)
-    # 🌶️ TODO: remove the `disable_local` flag
-    # ...if LOCAL can always be supplied in the caikit base config
     with temp_config(
         {
+            "merge_strategy": "override",
             "module_backends": {
                 "load_priority": [{"type": backend_types.MOCK}],
                 "train_priority": [],
-                "disable_local": True,
-            }
+            },
         }
     ):
         configure()

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -67,12 +67,14 @@ def test_configure_with_module(reset_globals):
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
+                        "name": "moo",
                     }
                 ],
                 "train_priority": [
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
+                        "name": "moo",
                     }
                 ],
             }
@@ -81,12 +83,12 @@ def test_configure_with_module(reset_globals):
         configure()
 
         # Test load backend config
-        mock_load_backend = get_load_backend(backend_types.MOCK)
+        mock_load_backend = get_load_backend("moo")
         assert mock_load_backend.backend_type == backend_types.MOCK
         assert foo_cfg == mock_load_backend.config
 
         # Test train backend config
-        mock_train_backend = get_train_backend(backend_types.MOCK)
+        mock_train_backend = get_train_backend("moo")
         assert mock_train_backend.backend_type == backend_types.MOCK
         assert foo_cfg == mock_train_backend.config
 
@@ -100,6 +102,7 @@ def test_configure_load_only(reset_globals):
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
+                        "name": "moose",
                     }
                 ],
                 "train_priority": [],
@@ -109,7 +112,7 @@ def test_configure_load_only(reset_globals):
         configure()
 
         # Test load backend config
-        mock_load_backend = get_load_backend(backend_types.MOCK)
+        mock_load_backend = get_load_backend("moose")
         assert mock_load_backend.backend_type == backend_types.MOCK
         assert foo_cfg == mock_load_backend.config
 
@@ -174,6 +177,7 @@ def test_one_configured_backend_can_start(reset_globals):
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
+                        "name": "moo",
                     }
                 ],
             }
@@ -183,7 +187,7 @@ def test_one_configured_backend_can_start(reset_globals):
         start_backends()
 
         # This is configured to be True in helpers
-        mock_load_backend = get_load_backend(backend_types.MOCK)
+        mock_load_backend = get_load_backend("moo")
         assert mock_load_backend.backend_type == backend_types.MOCK
         assert mock_load_backend.is_started
 

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -67,14 +67,12 @@ def test_configure_with_module(reset_globals):
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
-                        "name": "moo",
                     }
                 ],
                 "train_priority": [
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
-                        "name": "moo",
                     }
                 ],
             }
@@ -83,12 +81,12 @@ def test_configure_with_module(reset_globals):
         configure()
 
         # Test load backend config
-        mock_load_backend = get_load_backend("moo")
+        mock_load_backend = get_load_backend(backend_types.MOCK)
         assert mock_load_backend.backend_type == backend_types.MOCK
         assert foo_cfg == mock_load_backend.config
 
         # Test train backend config
-        mock_train_backend = get_train_backend("moo")
+        mock_train_backend = get_train_backend(backend_types.MOCK)
         assert mock_train_backend.backend_type == backend_types.MOCK
         assert foo_cfg == mock_train_backend.config
 
@@ -102,7 +100,6 @@ def test_configure_load_only(reset_globals):
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
-                        "name": "moose",
                     }
                 ],
                 "train_priority": [],
@@ -112,7 +109,7 @@ def test_configure_load_only(reset_globals):
         configure()
 
         # Test load backend config
-        mock_load_backend = get_load_backend("moose")
+        mock_load_backend = get_load_backend(backend_types.MOCK)
         assert mock_load_backend.backend_type == backend_types.MOCK
         assert foo_cfg == mock_load_backend.config
 
@@ -177,7 +174,6 @@ def test_one_configured_backend_can_start(reset_globals):
                     {
                         "type": backend_types.MOCK,
                         "config": foo_cfg,
-                        "name": "moo",
                     }
                 ],
             }
@@ -187,7 +183,7 @@ def test_one_configured_backend_can_start(reset_globals):
         start_backends()
 
         # This is configured to be True in helpers
-        mock_load_backend = get_load_backend("moo")
+        mock_load_backend = get_load_backend(backend_types.MOCK)
         assert mock_load_backend.backend_type == backend_types.MOCK
         assert mock_load_backend.is_started
 

--- a/tests/core/test_module_backend_config.py
+++ b/tests/core/test_module_backend_config.py
@@ -132,26 +132,6 @@ def test_non_supported_backend_raises():
             configure()
 
 
-def test_disabling_local_backend(reset_globals):
-    """Test that disabling local backend does not add it to priority automatically"""
-    with temp_config(
-        {
-            "module_backends": {
-                "disable_local": True,
-                "load_priority": [{"type": backend_types.MOCK}],
-                "train_priority": [{"type": backend_types.MOCK}],
-            }
-        }
-    ):
-        configure()
-        assert get_load_backend(backend_types.MOCK)
-        assert get_train_backend(backend_types.MOCK)
-        with pytest.raises(AssertionError):
-            get_load_backend(backend_types.LOCAL)
-        with pytest.raises(AssertionError):
-            get_train_backend(backend_types.LOCAL)
-
-
 def test_duplicate_config_raises(reset_globals):
     """Test that duplicate configuration of a backend raises"""
     with temp_config(

--- a/tests/core/workflows/test_base.py
+++ b/tests/core/workflows/test_base.py
@@ -17,7 +17,6 @@ import os
 import tempfile
 
 # Local
-from caikit.config import get_config
 from caikit.core.workflows import workflow
 from caikit.core.workflows.base import WorkflowLoader, WorkflowSaver
 

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -88,7 +88,9 @@ class TestModelManager(unittest.TestCase):
                 os.path.join(tempdir, "model2.zip"),
             )
             ModelManager._ModelManager__instance = None
-            with temp_config({"runtime": {"local_models_dir": tempdir}}):
+            with temp_config(
+                {"runtime": {"local_models_dir": tempdir}}, merge_strategy="merge"
+            ):
                 self.model_manager = ModelManager()
 
                 self.assertEqual(len(self.model_manager.loaded_models), 2)

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -743,7 +743,8 @@ def test_out_of_range_port(sample_inference_service):
                 "port": free_high_port,
                 "find_available_port": False,
             }
-        }
+        },
+        merge_strategy="merge",
     ):
         with RuntimeGRPCServer(
             inference_service=sample_inference_service,


### PR DESCRIPTION
- Allow for "merge" (prepend for lists, deep merge for dicts) or "override" merge strategies via a new configuration key
- Remove `disable_local` since we don't want anymore special handling for the local module backends. The default values will include `LOCAL`
- ~~Supply backend name to tests so that multiple Mock backend types will not conflict - we will plan to remove name-based lookup semantics in the near future as backends are not accessed by name except in tests~~

Addresses part of #102