### PR TITLE
🐛  Fix name in shared backends

### DIFF
--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -188,16 +188,17 @@ class ModelManager:
             # a version of the module available for the given backend
             loaded_model = None
             log.debug("Available load backends: %s", configured_load_backends)
-            for load_backend in configured_load_backends:
+            for i, load_backend in enumerate(configured_load_backends):
                 # If this is a shared loader, try loading the model directly
                 if isinstance(load_backend, SharedLoadBackendBase):
                     log.debug("Trying shared backend loader")
                     model = load_backend.load(module_path, *args, **kwargs)
                     if model is not None:
                         log.debug2(
-                            "Successfully loaded %s with loader %s",
+                            "Successfully loaded %s with loader (%d)%s",
                             module_path,
-                            load_backend.name,
+                            i,
+                            load_backend.backend_type,
                         )
                         error.type_check(
                             "<COR76726077E>",
@@ -209,9 +210,10 @@ class ModelManager:
                         model.set_load_backend(load_backend)
                         break
                     log.debug3(
-                        "Could not load %s with loader %s",
+                        "Could not load %s with loader (%d)%s",
                         module_path,
-                        load_backend.name,
+                        i,
+                        load_backend.backend_type,
                     )
 
                 # If this is not a shared loader, look for an implementation of the

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -19,6 +19,9 @@
 from typing import Optional, Type
 import abc
 
+# First Party
+import aconfig
+
 # Local
 from ..module import ModuleBase
 
@@ -26,8 +29,7 @@ from ..module import ModuleBase
 class BackendBase(abc.ABC):
     """Interface for creating configuration setup for backends"""
 
-    def __init__(self, name: str, config=None) -> None:
-        self.name = name
+    def __init__(self, config: Optional[aconfig.Config] = None) -> None:
         self.config = config or {}
         self._started = False
 

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -16,6 +16,8 @@
 """
 
 # Standard
+from contextlib import contextmanager
+from threading import Lock
 from typing import Optional, Type
 import abc
 
@@ -32,6 +34,7 @@ class BackendBase(abc.ABC):
     def __init__(self, config: Optional[aconfig.Config] = None) -> None:
         self.config = config or {}
         self._started = False
+        self._start_lock = Lock()
 
     @property
     @classmethod
@@ -61,6 +64,11 @@ class BackendBase(abc.ABC):
     def stop(self):
         """Function to stop a distributed backend. This function
         should set self._started variable to False"""
+
+    @contextmanager
+    def start_lock(self):
+        with self._start_lock:
+            yield
 
 
 class SharedTrainBackendBase(BackendBase, abc.ABC):

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -36,8 +36,8 @@ from caikit.core.module_backends.base import SharedLoadBackendBase
 class MockBackend(BackendBase):
     backend_type = "MOCK"
 
-    def __init__(self, name, config=...) -> None:
-        super().__init__(name, config)
+    def __init__(self, config=...) -> None:
+        super().__init__(config)
         self._started = False
 
     def start(self):
@@ -64,7 +64,7 @@ class TestLoader(SharedLoadBackendBase):
                 # Don't load in this loader
                 return None
         # use the "Local" loader to actually load the model
-        model = LocalBackend(name="test").load(model_path)
+        model = LocalBackend().load(model_path)
         return model
 
     def register_config(self, config):


### PR DESCRIPTION
## Description

This PR walks back an accidental API breaking change in `0.4.0` where we added `name` as a required initializer arg to `BackendBase`. We had decided to remove this since it's not actually necessary and it adds additional awkwardness, but forgot to make the change before merging and cutting `0.4.0`.