### PR TITLE
Add missing maintainers to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-*  @gabe-l-hart @joerunde @prashantgupta24 @gkumbhat @hickeyma @evaline-ju
+*  @gabe-l-hart @joerunde @prashantgupta24 @gkumbhat @hickeyma @evaline-ju @alex-jw-brooks @tharapalanivel


### PR DESCRIPTION
Quick PR to add @tharapalanivel & and I to the codeowners. 😄 