### PR TITLE
:bug: install graphviz/dot

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -37,5 +37,7 @@ jobs:
         run: tox -e fmt
       - name: Run pylint
         run: tox -e lint
+      - name: Setup Graphviz # `graphviz/dot` is required for the import checker
+        uses: ts-graphviz/setup-graphviz@v1
       - name: Enforce import rules
         run: tox -e imports

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands = pylint caikit
 
 [testenv:imports]
 description = enforce internal import rules
-deps = pydeps
+deps = pydeps==1.12.3
 commands = ./scripts/check_deps.sh
 allowlist_externals = ./scripts/check_deps.sh
 skip_install = True


### PR DESCRIPTION
PR checks are having issues because:
- pydeps needs `dot` installed
- some weird bug with 1.12.5 crashes :(