### PR TITLE
Add mechanism to generate API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ tests/protos/*
 
 # Tox envs
 .tox
+
+# Sphinx generated files
+docs/api/
+docs/_build/

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,3 @@
+# For API doc generation
+sphinx>=4.0.2,<7.0
+sphinx-rtd-theme~=1.2.0

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,78 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Caikit'
+copyright = '2023, The Caikit Authors'
+author = 'The Caikit Authors'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+]   
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'caikit/config']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+ # a list of builtin themes.
+ #
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = []
+
+# Support external links to specific versions of the files in the Github repo
+branch = os.environ.get("READTHEDOCS_VERSION")
+if branch is None or branch == "latest":
+    branch = "main"
+
+REPO = "caikit/caikit"
+scm_raw_web = "https://raw.githubusercontent.com/" + REPO + branch
+scm_web = "https://github.com/" + REPO + "blob/" + branch
+
+# Store variables in the epilogue so they are globally available.
+rst_epilog = """
+.. |SCM_WEB| replace:: {s}
+.. |SCM_RAW_WEB| replace:: {sr}
+.. |SCM_BRANCH| replace:: {b}
+""".format(
+    s=scm_web, sr=scm_raw_web, b=branch
+)
+
+# used to have links to repo files
+extlinks = {
+    "scm_raw_web": (scm_raw_web + "/%s", "scm_raw_web"),
+    "scm_web": (scm_web + "/%s", "scm_web"),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+Welcome to Caikit's API documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,37 @@ commands = pytest --cov=caikit --cov-report=html {posargs:tests}
 ; Without this, sdist packaging is tested so that's a start.
 package=wheel
 
+[testenv:docs]
+recreate = True
+deps = 
+    -r {toxinidir}/docs-requirements.txt
+    alchemy-config>=1.1.1,<2.0.0
+    alchemy-logging>=1.0.4,<2.0.0
+    anytree>=2.7.0,<3.0
+    docstring-parser>=0.14.1,<0.16.0
+    grpcio-health-checking>=1.35.0,<2.0
+    grpcio>=1.35.0,<2.0
+    ijson>=3.1.4,<3.3.0
+    munch>=2.5.0,<4.0
+    protobuf>=3.19.0,<5
+    prometheus_client>=0.12.0,<1.0
+    py-grpc-prometheus>=0.7.0,<0.8
+    PyYAML>=6.0,<7.0
+    requests>=2.26.0,<3.0
+    semver>=2.13.0,<4.0
+    six>=1.16.0,<2.0.0
+    tqdm>=4.59.0,<5.0.0
+    py-to-proto>=0.2.0,<0.3.0
+    import-tracker>=3.1.5,<4
+changedir = docs
+
+; Disabled '-W' flag as warnings in the files
+; TOTO: Add back in once build warnings fixed
+commands =
+  sphinx-apidoc -f -o api/ ../caikit
+  sphinx-build -E -a -b html -T . _build/html
+skip_install = True
+
 [testenv:fmt]
 description = format with pre-commit
 deps = pre-commit>=3.0.4,<4.0


### PR DESCRIPTION
This is first part of hosting caikit API docs on readthedocs.org.

In this PR the mechanism is added to enable the API docs to be generated using [sphinx](https://www.sphinx-doc.org/en/master/). Docse can be generated using the following command: `tox -e docs` and output is in `docs/_build/html`

Partial-Fix: #69 

**Notes for your reviewer**:

- Warnings when `sphinx` builds docstrings. Disabled not to fail on the warnings for now. Lets fix as we go along.
- `sphinx-apidoc` generates the `sphinx` resources on the fly. See can see going forward if we want the resources stored in the repo statically.
- Generating all docs for now. We can review as we go along and exclude if need be.