### PR TITLE
:bug: put default load impl back

### DIFF
--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -36,6 +36,7 @@ import types
 import alog
 
 # Local
+from .loader import ModuleLoader
 from ..data_model import DataBase, DataStream
 from ..toolkit import fileio
 from ..toolkit.errors import DataValidationError, error_handler
@@ -106,12 +107,17 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
     @classmethod
     @alog.logged_function(log.debug)
-    def load(cls, *args, **kwargs):
-        """Load a model."""
-        error(
-            "<COR92634437E>",
-            NotImplementedError("This is not available in this module."),
-        )
+    def load(cls, model_path, *args, **kwargs):
+        """Load a new instance of workflow from a given model_path
+
+        Args:
+            model_path: str
+                Path to workflow
+        Returns:
+            caikit.core.workflows.base.WorkflowBase
+                A new instance of any given implementation of WorkflowBase
+        """
+        return cls._load(ModuleLoader(model_path), *args, **kwargs)
 
     @classmethod
     def _load(cls, module_loader, *args, **kwargs):

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -36,10 +36,10 @@ import types
 import alog
 
 # Local
-from .loader import ModuleLoader
 from ..data_model import DataBase, DataStream
 from ..toolkit import fileio
 from ..toolkit.errors import DataValidationError, error_handler
+from .loader import ModuleLoader
 from .meta import _ModuleBaseMeta
 from caikit import core
 

--- a/tests/core/modules/test_module.py
+++ b/tests/core/modules/test_module.py
@@ -24,7 +24,6 @@ import aconfig
 from caikit.core import ModuleConfig, ModuleLoader
 from caikit.core.module_backends.module_backend_config import configured_load_backends
 from caikit.core.modules.decorator import SUPPORTED_LOAD_BACKENDS_VAR_NAME
-from caikit.core.registries import module_backend_registry
 
 # pylint: disable=import-error
 from sample_lib.data_model.sample import SampleInputType
@@ -98,12 +97,12 @@ def test_init_available():
     assert isinstance(model, caikit.core.ModuleBase)
 
 
-def test_under_load_not_implemented():
+def test_underscore_load_not_implemented():
     with pytest.raises(NotImplementedError):
         caikit.core.ModuleBase._load(None)
 
 
-def test_load_delegates_to_under_load(good_model_path):
+def test_load_delegates_to_underscore_load(good_model_path):
     @caikit.core.modules.module(id="blah", name="dummy base", version="0.0.1")
     class DummyFoo(caikit.core.ModuleBase):
         @classmethod

--- a/tests/core/modules/test_module.py
+++ b/tests/core/modules/test_module.py
@@ -21,7 +21,7 @@ import tempfile
 import aconfig
 
 # Local
-from caikit.core import ModuleConfig
+from caikit.core import ModuleConfig, ModuleLoader
 from caikit.core.module_backends.module_backend_config import configured_load_backends
 from caikit.core.modules.decorator import SUPPORTED_LOAD_BACKENDS_VAR_NAME
 from caikit.core.registries import module_backend_registry
@@ -98,9 +98,20 @@ def test_init_available():
     assert isinstance(model, caikit.core.ModuleBase)
 
 
-def test_load_not_implemented():
+def test_under_load_not_implemented():
     with pytest.raises(NotImplementedError):
-        caikit.core.ModuleBase.load()
+        caikit.core.ModuleBase._load(None)
+
+
+def test_load_delegates_to_under_load(good_model_path):
+    @caikit.core.modules.module(id="blah", name="dummy base", version="0.0.1")
+    class DummyFoo(caikit.core.ModuleBase):
+        @classmethod
+        def _load(cls, module_loader, **kwargs):
+            assert isinstance(module_loader, ModuleLoader)
+            return "foo"
+
+    assert DummyFoo.load(good_model_path) == "foo"
 
 
 def test_run_not_implemented(base_module_instance):


### PR DESCRIPTION
For @gkumbhat

This puts back the old workflow base load as the module base load, so users that implement only `_load` aren't broken