### PR TITLE
Fix text sentiment example after api change v0.5.0

### DIFF
--- a/examples/text-sentiment/client.py
+++ b/examples/text-sentiment/client.py
@@ -33,8 +33,8 @@ client_stub = inference_service.stub_class(channel)
 
 for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
     input_text_proto = TextInput(text=text).to_proto()
-    request = inference_service.messages.HfBlockRequest(text_input=input_text_proto)
-    response = client_stub.HfBlockPredict(
+    request = inference_service.messages.HfModuleRequest(text_input=input_text_proto)
+    response = client_stub.HfModulePredict(
         request, metadata=[("mm-model-id", "text_sentiment")]
     )
     print("Text:", text)


### PR DESCRIPTION
Fix to client code as client stubs changed following the module flattening in release [v0.5.0](https://github.com/caikit/caikit/releases/tag/v0.5.0)

Thanks @afrittoli for finding this bug.


**Notes for Reviewers:**

- Going to push a test PR for the example following this fix. Think it is best to get this fixed first asap.