### PR TITLE
:sparkles: add potential data stream fix

### DIFF
--- a/caikit/core/data_model/streams/data_stream.py
+++ b/caikit/core/data_model/streams/data_stream.py
@@ -168,28 +168,28 @@ class DataStream(Generic[T]):
         """
         error.file_check("<COR32600575E>", filename)
 
-        def generator_func():
-            # open the file (closure around `filename`)
-            with open(filename, mode="rb") as json_fh:
-                log.debug2("Loading JSON array file: {}".format(filename))
-                lines = json_fh.readlines()
+        return cls(cls._from_jsonl_generator, filename)
 
-                try:
-                    for line in lines:
-                        if line.strip():  # ignore empty lines
-                            yield json.loads(line)
-                except json.JSONDecodeError as e:
-                    error(
-                        "<COR55596551E>",
-                        ValueError(f"Invalid JSON object in `{line}`, error: {e.msg}"),
-                    )
-                except TypeError:
-                    error(
-                        "<COR35596551E>",
-                        ValueError("Invalid JSON object in `{}`".format(line)),
-                    )
+    @classmethod
+    def _from_jsonl_generator(cls, filename):
+        with open(filename, mode="rb") as json_fh:
+            log.debug2("Loading JSON array file: {}".format(filename))
+            lines = json_fh.readlines()
 
-        return cls(generator_func)
+            try:
+                for line in lines:
+                    if line.strip():  # ignore empty lines
+                        yield json.loads(line)
+            except json.JSONDecodeError as e:
+                error(
+                    "<COR55596551E>",
+                    ValueError(f"Invalid JSON object in `{line}`, error: {e.msg}"),
+                )
+            except TypeError:
+                error(
+                    "<COR35596551E>",
+                    ValueError("Invalid JSON object in `{}`".format(line)),
+                )
 
     @classmethod
     def from_json_array(cls, filename: str) -> "DataStream[Dict]":

--- a/tests/core/data_model/streams/test_data_stream.py
+++ b/tests/core/data_model/streams/test_data_stream.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 # Standard
 import os
+import pickle
 
 # Local
 from caikit.core import data_model as core_dm
@@ -51,6 +52,23 @@ def build_test_augmentor(produces_none):
             return obj + 5
 
     return TestStreamAugmentor()
+
+
+def test_data_stream_from_jsonl_is_pickleable(tmp_path):
+    tmpdir = str(tmp_path)
+
+    data = [1,2,3,4,5,6]
+    filepath = os.path.join(tmpdir, "foo.jsonl")
+    with open(filepath, "w") as f:
+        json.dump(data, f)
+
+    stream = core_dm.DataStream.from_jsonl(filepath)
+
+    pre_pickle_vals = list(stream)
+    pickled_stream = pickle.loads(pickle.dumps(stream))
+    post_pickle_vals = list(pickled_stream)
+
+    assert pre_pickle_vals == post_pickle_vals
 
 
 class TestDataStream(TestCaseBase):


### PR DESCRIPTION
This is an example of how we could change datastreams to be pickle-able.
The reason they are not is purely due to the way the current classmethod initializers create local closures + functions around the arguments passed in. These local closures + functions are not pickleable, pickle needs good concrete function pointers to be able to import again.

Instead, we can use DataStream's already existing functionality to store `*args` and `**kwargs` to pass to an arbitrary genrator-provider-function to reference a well-known generator producing function without requiring a closure to capture the args the user provided.

See the provided example for `.from_jsonl()`, we'll need to do something like this for all of the `.from_*` functions.