### PR TITLE
✨ Enable service reflection

### DIFF
--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -36,7 +36,11 @@ from caikit import get_config
 from caikit.runtime.interceptors.caikit_runtime_server_wrapper import (
     CaikitRuntimeServerWrapper,
 )
-from caikit.runtime.protobufs import model_runtime_pb2_grpc, process_pb2_grpc
+from caikit.runtime.protobufs import (
+    model_runtime_pb2,
+    model_runtime_pb2_grpc,
+    process_pb2_grpc,
+)
 from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
 from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
@@ -98,7 +102,6 @@ class RuntimeGRPCServer:
             server=self.server,
             global_predict=self._global_predict_servicer.Predict,
             intercepted_svc_descriptor=self.inference_service.descriptor,
-            excluded_methods=["/natural_language_understanding.CaikitRuntime/Echo"],
         )
         service_names.append(self.inference_service.descriptor.full_name)
 
@@ -114,7 +117,6 @@ class RuntimeGRPCServer:
                 server=self.server,
                 global_predict=global_train_servicer.Train,
                 intercepted_svc_descriptor=self.training_service.descriptor,
-                excluded_methods=None,
             )
             service_names.append(self.training_service.descriptor.full_name)
 
@@ -145,7 +147,9 @@ class RuntimeGRPCServer:
         model_runtime_pb2_grpc.add_ModelRuntimeServicer_to_server(
             ModelRuntimeServicerImpl(), self.server
         )
-        service_names.append("mmesh.ModelRuntime")
+        service_names.append(
+            model_runtime_pb2.DESCRIPTOR.services_by_name["ModelRuntime"].full_name
+        )
 
         # Add gRPC default health servicer.
         # We use the non-blocking implementation to avoid thread starvation.

--- a/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
+++ b/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
@@ -16,6 +16,7 @@
 import traceback
 
 # Third Party
+from grpc._utilities import RpcMethodHandler
 from prometheus_client import Gauge
 import grpc
 
@@ -279,7 +280,11 @@ class CaikitRuntimeServerWrapper(grpc.Server):
 
                 self._server.add_generic_rpc_handlers(generic_rpc_handlers)
 
-    def _make_new_handler(self, original_rpc_handler, replace_with_global_predict=True):
+    def _make_new_handler(
+        self,
+        original_rpc_handler: RpcMethodHandler,
+        replace_with_global_predict: bool = True,
+    ):
         if original_rpc_handler.unary_unary:
             return grpc.unary_unary_rpc_method_handler(
                 self.safe_rpc_wrapper(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "anytree>=2.7.0,<3.0",
     "docstring-parser>=0.14.1,<0.16.0",
     "grpcio-health-checking>=1.35.0,<2.0",
+    "grpcio-reflection>=1.35.0,<2.0",
     "grpcio>=1.35.0,<2.0,!=1.55.0",
     "ijson>=3.1.4,<3.3.0",
     "import-tracker>=3.1.5,<4",

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -772,9 +772,7 @@ def test_reflection_enabled(runtime_grpc_server):
     service_desc = desc_pool.FindServiceByName(
         "caikit.runtime.SampleLib.SampleLibService"
     )
-    method_desc = service_desc.FindMethodByName(
-        "caikit.runtime.SampleLib.SampleLibService/SampleTaskPredict"
-    )
+    method_desc = service_desc.FindMethodByName("SampleTaskPredict")
     assert method_desc is not None
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py, lint, fmt
 [testenv]
 description = run tests with pytest with coverage
 deps =
-    grpcio-reflection~=1.54
     pytest>=6.2.5,<7.0
     pytest-cov>=2.10.1,<3.0
     pytest-html>=3.1.1,<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py, lint, fmt
 [testenv]
 description = run tests with pytest with coverage
 deps =
+    grpcio-reflection~=1.54
     pytest>=6.2.5,<7.0
     pytest-cov>=2.10.1,<3.0
     pytest-html>=3.1.1,<4.0


### PR DESCRIPTION
Closes #156 

This PR enables service reflection, finally!

As a side-effect, this also fixes a bug where all streaming RPCs were dropped from the server. This meant that at least the grpcio-healthchecking's `Watch` rpc did not work, it would error with a `None is not callable` message. We never knew that this was a problem before, but having `None` handlers registered with the server will blow up when you try to build a descriptor pool using the reflection api.

This _also_ removes the `excluded_methods` kwarg for the server wrapper initializer, it was an unused feature that would skip setting the `global_predict` handler on a given set of rpc names in a service. It wasn't tested and I don't think we'll need it so.... might as well bump the coverage because YAGNI


With this change, here is an example grpcui page:

![image](https://github.com/caikit/caikit/assets/1646872/c0f97012-6d90-48e6-b961-73b50942599f)


