### PR TITLE
Fix most unittest warnings

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,7 @@
 # Standard
 from typing import Any
 import os
+import threading
 import unittest
 
 # Local
@@ -85,3 +86,65 @@ def skip_in_wheel_test(cls):
     if os.getenv("NO_SOURCE") is not None and int(os.getenv("NO_SOURCE")) == 1:
         return None
     return cls
+
+
+class catch_threading_exception:
+    """
+    catch_threading_exception is only available in Python 3.10+
+    Maintaining this copy to run tests with Python 3.8 and 3.9
+
+    From https://github.com/python/cpython/blob/fbc9d0dbb22549bac2706f61f3ab631239d357b4/Lib/test/support/threading_helper.py#LL154C1-L208C24
+
+    Context manager catching threading.Thread exception using
+    threading.excepthook.
+
+    Attributes set when an exception is caught:
+
+    * exc_type
+    * exc_value
+    * exc_traceback
+    * thread
+
+    See threading.excepthook() documentation for these attributes.
+
+    These attributes are deleted at the context manager exit.
+
+    Usage:
+
+        with threading_helper.catch_threading_exception() as cm:
+            # code spawning a thread which raises an exception
+            ...
+
+            # check the thread exception, use cm attributes:
+            # exc_type, exc_value, exc_traceback, thread
+            ...
+
+        # exc_type, exc_value, exc_traceback, thread attributes of cm no longer
+        # exists at this point
+        # (to avoid reference cycles)
+    """
+
+    def __init__(self):
+        self.exc_type = None
+        self.exc_value = None
+        self.exc_traceback = None
+        self.thread = None
+        self._old_hook = None
+
+    def _hook(self, args):
+        self.exc_type = args.exc_type
+        self.exc_value = args.exc_value
+        self.exc_traceback = args.exc_traceback
+        self.thread = args.thread
+
+    def __enter__(self):
+        self._old_hook = threading.excepthook
+        threading.excepthook = self._hook
+        return self
+
+    def __exit__(self, *exc_info):
+        threading.excepthook = self._old_hook
+        del self.exc_type
+        del self.exc_value
+        del self.exc_traceback
+        del self.thread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ def runtime_grpc_server(
     grpc_thread = threading.Thread(
         target=server.start,
     )
-    grpc_thread.setDaemon(False)
+    grpc_thread.daemon = False
     grpc_thread.start()
     _check_server_readiness(server)
     yield server

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -26,7 +26,7 @@ import tempfile
 # Third Party
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2, descriptor_pool, message, struct_pb2
-from google.protobuf.message_factory import MessageFactory
+from google.protobuf.message_factory import GetMessageClassesForFiles
 import numpy as np
 import pytest
 
@@ -62,8 +62,7 @@ def temp_dpool():
     # HACK! Doing this _appears_ to solve the mysterious segfault cause by using
     #   Struct inside a temporary descriptor pool. The inspiration for this was
     #   https://github.com/protocolbuffers/protobuf/issues/12047
-    mf = MessageFactory(dpool)
-    msgs = mf.GetMessages([fd.name])
+    msgs = GetMessageClassesForFiles([fd.name], dpool)
     _ = msgs["google.protobuf.Struct"]
     _ = msgs["google.protobuf.Value"]
     _ = msgs["google.protobuf.ListValue"]

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -62,6 +62,7 @@ backend_types.register_backend_type(MockBackend)
 # Add a new shared load backend that tests can use
 class TestLoader(SharedLoadBackendBase):
     backend_type = "TESTLOADER"
+    __test__ = False
 
     def load(self, model_path: str, *args, **kwargs) -> Optional[ModuleBase]:
         # allow config.model_type to control whether this loader barfs


### PR DESCRIPTION
Fix unit test warnings related to:
- deprecations
- unhandled thread exceptions

The only warnings left are related to a caikit deprecation: caikit/core/modules/config.py:66: DeprecationWarning: No module_id found in config.

This cleans-up the log output and makes it easier to detect new warnings.