### PR TITLE
Add coverage report and threshold

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -23,6 +23,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     strategy:
       matrix:
         python-version:
@@ -50,4 +54,14 @@ jobs:
           python -m pip install -r setup_requirements.txt
       - name: Build and test with tox
         run: tox -e ${{ matrix.python-version.tox }}
+      - name: Publish coverage 
+        if: ${{ matrix.python-version.setup == '3.11' }}
+        uses: orgoro/coverage@v3.1
+        with:
+            coverageFile: coverage-py311.xml
+            token: ${{ secrets.GITHUB_TOKEN }}
+            thresholdAll: 0.0
+            thresholdNew: 0.8
+            thresholdModified: 0.0
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 .coverage
 .coverage.*
+coverage*.xml
 dist
 htmlcov
 build

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = pytest --cov=caikit --cov-report=html {posargs:tests}
+commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml {posargs:tests}
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
Add coverage report thanks to the python-coverage GitHub action https://github.com/marketplace/actions/python-coverage

The action reports the coverage as a GitHub comment. It also allows defining thresholds for the level of coverage. For now, setting an 80% thresholds for new files and zero for existing content. Once the report is published to PRs we can start working on bringing the coverage up to the desired level and enable the threshold for existing code.

We run unit tests for four different versions of python, but I don't think we need coverage for each.
Nonetheless, I changed the tox.ini to make sure that the coverage reports from the four runs do not override each other, and produce both html and xml reports.
Html is convenient when running locally, xml is needed by the action.

The action uses the coverage report for python 3.11

Fixes: #146