### PR TITLE
💥 Remove primitive configs

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -98,7 +98,6 @@ runtime:
         module_guids:
             included: []
             excluded: []
-        primitive_data_model_types: []
         task_types:
             included: []
             excluded: []

--- a/caikit/core/task.py
+++ b/caikit/core/task.py
@@ -82,6 +82,18 @@ class TaskBase:
                 f"Wrong types provided for parameters to {signature.module}: {type_mismatch_errors}"
             )
 
+        if signature.return_type != cls.get_output_type():
+            # Wrong return type: Just check to make sure it's not
+            # `Union[expected_type, other_types]`
+            if typing.get_origin(signature.return_type) != Union or (
+                typing.get_origin(signature.return_type) == Union
+                and cls.get_output_type() not in typing.get_args(signature.return_type)
+            ):
+                raise TypeError(
+                    f"Wrong output type for module {signature.module}: "
+                    f"Found {signature.return_type} but expected {cls.get_output_type()}"
+                )
+
     @classmethod
     def get_required_parameters(cls) -> Dict[str, ValidInputTypes]:
         """Get the set of input types required by this task

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -51,12 +51,9 @@ def create_inference_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase
         get_config().runtime.service_generation.primitive_data_model_types
     )
 
-    rpcs = []
-
-
     # Create the RPCs for each module
     return _create_rpcs_for_modules(
-        modules, primitive_data_model_types, INFERENCE_FUNCTION_NAME
+        modules, primitive_data_model_types
     )
 
 
@@ -114,11 +111,10 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
 def _create_rpcs_for_modules(
     modules: List[Type[ModuleBase]],
     primitive_data_model_types: List[str],
-    fname: str = INFERENCE_FUNCTION_NAME,
 ) -> List[CaikitRPCBase]:
     """Create the RPCs for each module"""
     rpcs = []
-    task_groups = _group_modules_by_task(modules, fname)
+    task_groups = _group_modules_by_task(modules)
 
     # Create the RPC for each task
     for task, task_methods in task_groups.items():
@@ -140,15 +136,12 @@ def _create_rpcs_for_modules(
 
 
 def _group_modules_by_task(
-    modules: List[Type[ModuleBase]], fname: str
+    modules: List[Type[ModuleBase]]
 ) -> Dict[Type[TaskBase], List[Type[ModuleBase]]]:
     task_groups = {}
     for ck_module in modules:
         if ck_module.TASK_CLASS:
             ck_module_task_name = ck_module.TASK_CLASS.__name__
-
-            signature = CaikitMethodSignature(ck_module, fname)
-
             if ck_module_task_name is not None:
-                task_groups.setdefault(ck_module.TASK_CLASS, []).append(signature)
+                task_groups.setdefault(ck_module.TASK_CLASS, []).append(ck_module.RUN_SIGNATURE)
     return task_groups

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -82,8 +82,7 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
             )
             continue
 
-        # 🌶️🌶️🌶️ For some reason, using ck_module.TRAIN_SIGNATURE causes a test failure
-        signature = CaikitMethodSignature(ck_module, TRAIN_FUNCTION_NAME)
+        signature = ck_module.TRAIN_SIGNATURE
         log.debug(
             "Function signature for %s::%s [%s -> %s]",
             ck_module,

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -24,7 +24,6 @@ from typing import Dict, List, Type
 import alog
 
 # Local
-from ... import get_config
 from .rpcs import CaikitRPCBase, ModuleClassTrainRPC, TaskPredictRPC
 from caikit.core import ModuleBase, TaskBase
 from caikit.core.signature_parsing.module_signature import CaikitMethodSignature

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -46,14 +46,9 @@ class ServiceType(Enum):
 
 def create_inference_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]:
     """Handles the logic to create all the RPCs for inference"""
-
-    primitive_data_model_types = (
-        get_config().runtime.service_generation.primitive_data_model_types
-    )
-
     # Create the RPCs for each module
     return _create_rpcs_for_modules(
-        modules, primitive_data_model_types
+        modules
     )
 
 
@@ -110,7 +105,6 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
 
 def _create_rpcs_for_modules(
     modules: List[Type[ModuleBase]],
-    primitive_data_model_types: List[str],
 ) -> List[CaikitRPCBase]:
     """Create the RPCs for each module"""
     rpcs = []
@@ -121,7 +115,7 @@ def _create_rpcs_for_modules(
         with alog.ContextLog(log.debug, "Generating task RPC for %s", task):
             try:
                 rpcs.append(
-                    TaskPredictRPC(task, task_methods, primitive_data_model_types)
+                    TaskPredictRPC(task, task_methods)
                 )
                 log.debug("Successfully generated task RPC for %s", task)
             except Exception as err:  # pylint: disable=broad-exception-caught
@@ -137,7 +131,7 @@ def _create_rpcs_for_modules(
 
 def _group_modules_by_task(
     modules: List[Type[ModuleBase]]
-) -> Dict[Type[TaskBase], List[Type[ModuleBase]]]:
+) -> Dict[Type[TaskBase], List[CaikitMethodSignature]]:
     task_groups = {}
     for ck_module in modules:
         if ck_module.TASK_CLASS:

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -47,9 +47,7 @@ class ServiceType(Enum):
 def create_inference_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]:
     """Handles the logic to create all the RPCs for inference"""
     # Create the RPCs for each module
-    return _create_rpcs_for_modules(
-        modules
-    )
+    return _create_rpcs_for_modules(modules)
 
 
 def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]:
@@ -110,9 +108,7 @@ def _create_rpcs_for_modules(
     for task, task_methods in task_groups.items():
         with alog.ContextLog(log.debug, "Generating task RPC for %s", task):
             try:
-                rpcs.append(
-                    TaskPredictRPC(task, task_methods)
-                )
+                rpcs.append(TaskPredictRPC(task, task_methods))
                 log.debug("Successfully generated task RPC for %s", task)
             except Exception as err:  # pylint: disable=broad-exception-caught
                 log.warning(
@@ -126,12 +122,14 @@ def _create_rpcs_for_modules(
 
 
 def _group_modules_by_task(
-    modules: List[Type[ModuleBase]]
+    modules: List[Type[ModuleBase]],
 ) -> Dict[Type[TaskBase], List[CaikitMethodSignature]]:
     task_groups = {}
     for ck_module in modules:
         if ck_module.TASK_CLASS:
             ck_module_task_name = ck_module.TASK_CLASS.__name__
             if ck_module_task_name is not None:
-                task_groups.setdefault(ck_module.TASK_CLASS, []).append(ck_module.RUN_SIGNATURE)
+                task_groups.setdefault(ck_module.TASK_CLASS, []).append(
+                    ck_module.RUN_SIGNATURE
+                )
     return task_groups

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -57,10 +57,6 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
 
     rpcs = []
 
-    primitive_data_model_types = (
-        get_config().runtime.service_generation.primitive_data_model_types
-    )
-
     for ck_module in modules:
         if not ck_module.TASK_CLASS:
             log.debug("Skipping module %s with no task", ck_module)
@@ -91,7 +87,7 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
         )
         with alog.ContextLog(log.debug, "Generating train RPC for %s", ck_module):
             try:
-                rpcs.append(ModuleClassTrainRPC(signature, primitive_data_model_types))
+                rpcs.append(ModuleClassTrainRPC(signature))
                 log.debug("Successfully generated train RPC for %s", ck_module)
             except Exception as err:  # pylint: disable=broad-exception-caught
                 log.warning(

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -25,7 +25,6 @@ import alog
 
 # Local
 from ... import get_config
-from .primitives import is_primitive_method
 from .rpcs import CaikitRPCBase, ModuleClassTrainRPC, TaskPredictRPC
 from caikit.core import ModuleBase, TaskBase
 from caikit.core.signature_parsing.module_signature import CaikitMethodSignature
@@ -53,20 +52,12 @@ def create_inference_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase
     )
 
     rpcs = []
-    # Inference specific logic:
-    # Remove non-primitive modules (including modules that return None type)
-    primitive_modules = _remove_non_primitive_modules(
-        modules, primitive_data_model_types
-    )
+
 
     # Create the RPCs for each module
-    rpcs.extend(
-        _create_rpcs_for_modules(
-            primitive_modules, primitive_data_model_types, INFERENCE_FUNCTION_NAME
-        )
+    return _create_rpcs_for_modules(
+        modules, primitive_data_model_types, INFERENCE_FUNCTION_NAME
     )
-
-    return rpcs
 
 
 def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]:
@@ -118,23 +109,6 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
                     exc_info=True,
                 )
     return rpcs
-
-
-def _remove_non_primitive_modules(
-    modules: List[Type[ModuleBase]],
-    primitive_data_model_types: List[str],
-) -> List[Type[ModuleBase]]:
-    primitive_modules = []
-    # If the module is not "primitive" we won't include it
-    for ck_module in modules:
-        signature = CaikitMethodSignature(ck_module, "run")
-        if signature.parameters and signature.return_type:
-            if not is_primitive_method(signature, primitive_data_model_types):
-                log.debug("Skipping non-primitive module %s", ck_module)
-                continue
-
-            primitive_modules.append(ck_module)
-    return primitive_modules
 
 
 def _create_rpcs_for_modules(

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -16,9 +16,8 @@ This file contains our logic about what constitutes a "primitive" for RPC genera
 """
 
 # Standard
-from typing import Dict, List, Type, Union, get_args, get_origin
+from typing import Dict, Type, Union, get_args, get_origin
 import inspect
-import sys
 import typing
 
 # First Party
@@ -151,21 +150,6 @@ def _is_primitive_type(arg_type: Type) -> bool:
 
     log.debug2("Arg is not primitive, arg_type: %s", arg_type)
     return False
-
-
-def _get_library_dm_primitives(primitive_data_model_types) -> List[Type[DataBase]]:
-    """For a given caikit.* library name, determine the set of data model "primitives"."""
-
-    lib_dm_primitives = []
-    for primitive_name in primitive_data_model_types:
-        parts = primitive_name.split(".")
-        current = sys.modules.get(parts[0])
-        for part in parts[1:]:
-            current = getattr(current, part, None)
-        if current is not None:
-            lib_dm_primitives.append(current)
-    log.debug3("DM Primitives: %s", lib_dm_primitives)
-    return lib_dm_primitives
 
 
 def _is_optional_type(arg_type: Type):

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -31,9 +31,7 @@ from caikit.core.data_model.base import DataBase
 log = alog.use_channel("MODULE_PRIMS")
 
 
-def to_primitive_signature(
-    signature: Dict[str, Type]
-) -> Dict[str, Type]:
+def to_primitive_signature(signature: Dict[str, Type]) -> Dict[str, Type]:
     """Returns dictionary of primitive types only
     If there is a Union, pick the primitive type
 
@@ -44,9 +42,7 @@ def to_primitive_signature(
     primitives = {}
     log.debug("Building primitive signature for %s", signature)
     for arg, arg_type in signature.items():
-        primitive_arg_type = handle_primitives_in_union(
-            arg_type
-        )
+        primitive_arg_type = handle_primitives_in_union(arg_type)
         if primitive_arg_type:
             primitives[arg] = primitive_arg_type
 
@@ -151,12 +147,7 @@ def _is_primitive_type(arg_type: Type) -> bool:
     if typing.get_origin(arg_type) == Union:
         log.debug2("Arg is Union")
         # pylint: disable=use-a-generator
-        return any(
-            [
-                _is_primitive_type(arg)
-                for arg in typing.get_args(arg_type)
-            ]
-        )
+        return any([_is_primitive_type(arg) for arg in typing.get_args(arg_type)])
 
     log.debug2("Arg is not primitive, arg_type: %s", arg_type)
     return False

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -150,9 +150,3 @@ def _is_primitive_type(arg_type: Type) -> bool:
 
     log.debug2("Arg is not primitive, arg_type: %s", arg_type)
     return False
-
-
-def _is_optional_type(arg_type: Type):
-    if typing.get_origin(arg_type) == Union and type(None) in typing.get_args(arg_type):
-        return True
-    return False

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -129,31 +129,6 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
     return arg_type
 
 
-def is_primitive_method(
-    method: CaikitMethodSignature, primitive_data_model_types: List[str]
-) -> bool:
-    """Determine if the arguments to the module's run function meet the criteria
-    for being a "primitive" interface this means that all **non-optional** arguments
-    types must be either (a) a primitive data model type for the given library or
-    (b) a language-primitive type.
-
-    Args:
-        method (CaikitMethodSignature): The method signature of the "primitive"
-            data model types for each library
-    """
-
-    # pylint: disable=use-a-generator
-    return all(
-        [
-            (
-                _is_primitive_type(arg_type, primitive_data_model_types)
-                or _is_optional_type(arg_type)
-            )
-            for arg_type in method.parameters.values()
-        ]
-    )
-
-
 def _is_primitive_type(arg_type: Type, primitive_data_model_types: List[str]) -> bool:
     """
     Returns True is arg_type is in PROTO_TYPE_MAP(float, int, bool, str, bytes)

--- a/caikit/runtime/service_generation/primitives.py
+++ b/caikit/runtime/service_generation/primitives.py
@@ -32,7 +32,7 @@ log = alog.use_channel("MODULE_PRIMS")
 
 
 def to_primitive_signature(
-    signature: Dict[str, Type], primitive_data_model_types: List[str]
+    signature: Dict[str, Type]
 ) -> Dict[str, Type]:
     """Returns dictionary of primitive types only
     If there is a Union, pick the primitive type

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -129,7 +129,7 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
 
 def is_protoable_type(arg_type: Type) -> bool:
     """
-    Returns True is arg_type is in PROTO_TYPE_MAP(float, int, bool, str, bytes)
+    Returns True if arg_type is in PROTO_TYPE_MAP(float, int, bool, str, bytes)
     Or if it's an imported Caikit data model class.
     Or if it's a Union of at least one of those.
     Or if it's a List of one of those.

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -134,6 +134,9 @@ def is_protoable_type(arg_type: Type) -> bool:
 
     if typing.get_origin(arg_type) == list:
         log.debug2("Arg is List")
+        if len(typing.get_args(arg_type)) == 0:
+            log.debug2("List annotation has no type")
+            return False
         return typing.get_args(arg_type)[0] in proto_primitive_set
 
     if typing.get_origin(arg_type) == Union:

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -21,10 +21,10 @@ import inspect
 import typing
 
 # First Party
+from py_to_proto.dataclass_to_proto import PY_TO_PROTO_TYPES
 import alog
 
 # Local
-from .type_helpers import PROTO_TYPE_MAP
 from caikit.core.data_model.base import DataBase
 
 log = alog.use_channel("PROTOABLES")
@@ -134,7 +134,7 @@ def is_protoable_type(arg_type: Type) -> bool:
     Or if it's a Union of at least one of those.
     Or if it's a List of one of those.
     False otherwise"""
-    proto_primitive_set = list(PROTO_TYPE_MAP.keys())
+    proto_primitive_set = list(PY_TO_PROTO_TYPES.keys())
 
     if arg_type in proto_primitive_set:
         return True

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -21,11 +21,11 @@ import inspect
 import typing
 
 # First Party
-from py_to_proto.dataclass_to_proto import PY_TO_PROTO_TYPES
 import alog
 
 # Local
 from caikit.core.data_model.base import DataBase
+from caikit.core.data_model.dataobject import DATAOBJECT_PY_TO_PROTO_TYPES
 
 log = alog.use_channel("PROTOABLES")
 
@@ -134,7 +134,7 @@ def is_protoable_type(arg_type: Type) -> bool:
     Or if it's a Union of at least one of those.
     Or if it's a List of one of those.
     False otherwise"""
-    proto_primitive_set = list(PY_TO_PROTO_TYPES.keys())
+    proto_primitive_set = list(DATAOBJECT_PY_TO_PROTO_TYPES.keys())
 
     if arg_type in proto_primitive_set:
         return True

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This file contains our logic about what constitutes a "primitive" for RPC generation purposes
+This file contains our logic about what constitutes a proto-able for RPC generation purposes
 """
 
 # Standard
@@ -27,68 +27,74 @@ import alog
 from .type_helpers import PROTO_TYPE_MAP
 from caikit.core.data_model.base import DataBase
 
-log = alog.use_channel("MODULE_PRIMS")
+log = alog.use_channel("PROTOABLES")
 
 
-def to_primitive_signature(signature: Dict[str, Type]) -> Dict[str, Type]:
-    """Returns dictionary of primitive types only
-    If there is a Union, pick the primitive type
+def to_protoable_signature(signature: Dict[str, Type]) -> Dict[str, Type]:
+    """Returns dictionary of protoable types only
+    If there is a Union, pick the protoable type
 
     Args:
         signature: Dict[str, Type]
             module signature of parameters and types
     """
-    primitives = {}
-    log.debug("Building primitive signature for %s", signature)
+    protoables = {}
+    log.debug("Building protoable signature for %s", signature)
     for arg, arg_type in signature.items():
-        primitive_arg_type = handle_primitives_in_union(arg_type)
-        if primitive_arg_type:
-            primitives[arg] = primitive_arg_type
+        protoable_type = handle_protoables_in_union(arg_type)
+        if protoable_type:
+            protoables[arg] = protoable_type
 
-    return primitives
+    return protoables
 
 
-def handle_primitives_in_union(arg_type: Type) -> Type:
-    """Handles various primitive arg types from a Union:
-    Union[supported_type, unsupported_type] -> returns only the supported_type
-    Union[supported_type1, supported_type2] -> returns the union which creates the oneof
-    Union[supported_type1, supported_type2, unsupported_type] ->
-        returns the first primitive object in the Union
+def handle_protoables_in_union(arg_type: Type) -> Type:
+    """Handles various protoable arg types from a Union.
+
+    If arg_type is a union, then this will return the union back if all types in it are proto-able,
+    or the first proto-able arg type if the union has non-protoable arg types.
+
+    If arg_type is not a union nor protoable at all, this returns None.
+
+    Examples:
+    Union[protoable_type, non_protoable_type] -> protoable_type
+    Union[protoable_type_1, protoable_type_2] -> Union[protoable_type_1, protoable_type_2]
+    Union[protoable_type_1, protoable_type_2, non_protoable_type] -> protoable_type_1
     """
-    if _is_primitive_type(arg_type):
+    if is_protoable_type(arg_type):
         if typing.get_origin(arg_type) == Union:
-            union_primitives = [
+            union_protoables = [
                 union_val
                 for union_val in typing.get_args(arg_type)
-                if _is_primitive_type(union_val)
+                if is_protoable_type(union_val)
             ]
-            # if all are primitives, return the union (which will create a oneof)
-            if len(union_primitives) == len(typing.get_args(arg_type)):
+            # if all are protoable, return the union (which will create a oneof)
+            if len(union_protoables) == len(typing.get_args(arg_type)):
                 return arg_type
-            # if there's only 1 primitive found, return that
-            if len(union_primitives) == 1:
-                return union_primitives[0]
-            # otherwise, try to get the primitive dm objects in the Union
+            # if there's only 1 protoable found, return that
+            if len(union_protoables) == 1:
+                return union_protoables[0]
+            # otherwise, try to get the data model objects in the Union
             dm_types = [
                 arg
-                for arg in union_primitives
+                for arg in union_protoables
                 if inspect.isclass(arg) and issubclass(arg, DataBase)
             ]
             # if there are multiple, pick the first one
             if len(dm_types) > 0:
                 log.debug2(
-                    "Picking first data model type %s in union primitives %s",
+                    "Picking first data model type %s in union protoables %s",
                     dm_types,
-                    union_primitives,
+                    union_protoables,
                 )
                 return dm_types[0]
             log.debug(
-                "Just picking first primitive type %s in union",
-                union_primitives[0],
+                "Just picking first protoable type %s in union",
+                union_protoables[0],
             )
-            return union_primitives[0]
+            return union_protoables[0]
         return arg_type
-    log.debug("Skipping non-primitive argument type [%s]", arg_type)
+    log.debug("Skipping non-protoable argument type [%s]", arg_type)
 
 
 def extract_data_model_type_from_union(arg_type: Type) -> Type:
@@ -121,16 +127,16 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
     return arg_type
 
 
-def _is_primitive_type(arg_type: Type) -> bool:
+def is_protoable_type(arg_type: Type) -> bool:
     """
     Returns True is arg_type is in PROTO_TYPE_MAP(float, int, bool, str, bytes)
     Or if it's an imported Caikit data model class.
     Or if it's a Union of at least one of those.
     Or if it's a List of one of those.
     False otherwise"""
-    primitive_set = list(PROTO_TYPE_MAP.keys())
+    proto_primitive_set = list(PROTO_TYPE_MAP.keys())
 
-    if arg_type in primitive_set:
+    if arg_type in proto_primitive_set:
         return True
     if isinstance(arg_type, type) and issubclass(arg_type, DataBase):
         return True
@@ -139,14 +145,14 @@ def _is_primitive_type(arg_type: Type) -> bool:
         log.debug2("Arg is List")
         # check that list is not nested
         if len(typing.get_args(arg_type)) == 1:
-            return typing.get_args(arg_type)[0] in primitive_set
+            return typing.get_args(arg_type)[0] in proto_primitive_set
         # TODO: that check is always true
         log.debug2("Arg is a list more than one type")
 
     if typing.get_origin(arg_type) == Union:
         log.debug2("Arg is Union")
         # pylint: disable=use-a-generator
-        return any([_is_primitive_type(arg) for arg in typing.get_args(arg_type)])
+        return any([is_protoable_type(arg) for arg in typing.get_args(arg_type)])
 
-    log.debug2("Arg is not primitive, arg_type: %s", arg_type)
+    log.debug2("Arg is not protoable, arg_type: %s", arg_type)
     return False

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -143,11 +143,7 @@ def is_protoable_type(arg_type: Type) -> bool:
 
     if typing.get_origin(arg_type) == list:
         log.debug2("Arg is List")
-        # check that list is not nested
-        if len(typing.get_args(arg_type)) == 1:
-            return typing.get_args(arg_type)[0] in proto_primitive_set
-        # TODO: that check is always true
-        log.debug2("Arg is a list more than one type")
+        return typing.get_args(arg_type)[0] in proto_primitive_set
 
     if typing.get_origin(arg_type) == Union:
         log.debug2("Arg is Union")

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -29,7 +29,7 @@ from py_to_proto.dataclass_to_proto import (  # NOTE: Imported from here for com
 import alog
 
 # Local
-from . import primitives, type_helpers
+from . import protoable, type_helpers
 from .compatibility_checker import ApiFieldNames
 from .data_stream_source import make_data_stream_source
 from caikit.core import ModuleBase, TaskBase
@@ -193,7 +193,7 @@ class ModuleClassTrainRPC(CaikitRPCBase):
                 # Found a model pointer
                 new_params[name] = ModelPointer
             else:
-                new_params[name] = primitives.handle_primitives_in_union(
+                new_params[name] = protoable.handle_protoables_in_union(
                     arg_type=typ,
                 )
 
@@ -229,7 +229,7 @@ class TaskPredictRPC(CaikitRPCBase):
         default_parameters = {}
         for method in method_signatures:
             default_parameters.update(method.default_parameters)
-            primitive_arg_dict = primitives.to_primitive_signature(method.parameters)
+            primitive_arg_dict = protoable.to_protoable_signature(method.parameters)
             for arg_name, arg_type in primitive_arg_dict.items():
                 current_val = parameters_dict.get(arg_name, arg_type)
                 # TODO: raise runtime error here instead of assert!
@@ -248,7 +248,7 @@ class TaskPredictRPC(CaikitRPCBase):
         return_types = {method.return_type for method in method_signatures}
         assert len(return_types) == 1, f"Found multiple return types for task [{task}]"
         return_type = list(return_types)[0]
-        self.return_type = primitives.extract_data_model_type_from_union(return_type)
+        self.return_type = protoable.extract_data_model_type_from_union(return_type)
 
         # Create the rpc name based on the module type
         self.name = self._task_to_rpc_name()

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -171,7 +171,9 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         )
 
     @staticmethod
-    def _mutate_method_signature_for_training(signature: CaikitMethodSignature) -> Optional[CaikitMethodSignature]:
+    def _mutate_method_signature_for_training(
+        signature: CaikitMethodSignature,
+    ) -> Optional[CaikitMethodSignature]:
         # Change return type for async training interface
         return_type = TrainingJob
 
@@ -227,9 +229,7 @@ class TaskPredictRPC(CaikitRPCBase):
         default_parameters = {}
         for method in method_signatures:
             default_parameters.update(method.default_parameters)
-            primitive_arg_dict = primitives.to_primitive_signature(
-                method.parameters
-            )
+            primitive_arg_dict = primitives.to_primitive_signature(method.parameters)
             for arg_name, arg_type in primitive_arg_dict.items():
                 current_val = parameters_dict.get(arg_name, arg_type)
                 # TODO: raise runtime error here instead of assert!

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -200,7 +200,6 @@ class ModuleClassTrainRPC(CaikitRPCBase):
             else:
                 new_params[name] = primitives.handle_primitives_in_union(
                     arg_type=typ,
-                    primitive_data_model_types=primitive_data_model_types,
                 )
 
         return CustomSignature(

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -216,7 +216,6 @@ class TaskPredictRPC(CaikitRPCBase):
         self,
         task: Type[TaskBase],
         method_signatures: List[CaikitMethodSignature],
-        primitive_data_model_types: List[str],
     ):
         """Initialize a .proto generator with all modules of a given task to convert
 
@@ -240,7 +239,7 @@ class TaskPredictRPC(CaikitRPCBase):
         for method in method_signatures:
             default_parameters.update(method.default_parameters)
             primitive_arg_dict = primitives.to_primitive_signature(
-                method.parameters, primitive_data_model_types
+                method.parameters
             )
             for arg_name, arg_type in primitive_arg_dict.items():
                 current_val = parameters_dict.get(arg_name, arg_type)

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -113,21 +113,16 @@ class ModuleClassTrainRPC(CaikitRPCBase):
     def __init__(
         self,
         method_signature: CaikitMethodSignature,
-        primitive_data_model_types: List[str],
     ):
         """Initialize a .proto generator with a single module to convert
 
         Args:
             method_signature (CaikitMethodSignature): The module method signature to
             generate an RPC for
-
-            primitive_data_model_types: List[str]
-                List of primitive data model types for a caikit_* library, such as
-                caikit.interfaces.nlp.data_model.RawDocument for nlp domains
         """
         self.clz: Type[ModuleBase] = method_signature.module
         self._method = ModuleClassTrainRPC._mutate_method_signature_for_training(
-            method_signature, primitive_data_model_types
+            method_signature
         )
         self.name = self._module_class_to_rpc_name()
 
@@ -176,9 +171,7 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         )
 
     @staticmethod
-    def _mutate_method_signature_for_training(
-        signature, primitive_data_model_types: List[str]
-    ) -> Optional[CaikitMethodSignature]:
+    def _mutate_method_signature_for_training(signature: CaikitMethodSignature) -> Optional[CaikitMethodSignature]:
         # Change return type for async training interface
         return_type = TrainingJob
 
@@ -224,10 +217,6 @@ class TaskPredictRPC(CaikitRPCBase):
 
             method_signatures (List[CaikitMethodSignature]): The list of method
                 signatures from concrete modules implementing this task
-
-            primitive_data_model_types: List[str]
-                List of primitive data model types for a caikit_* library, such as
-                caikit.interfaces.nlp.data_model.RawDocument for nlp domains
         """
         self.task = task
         self._module_list = [method.module for method in method_signatures]

--- a/caikit/runtime/service_generation/type_helpers.py
+++ b/caikit/runtime/service_generation/type_helpers.py
@@ -14,14 +14,14 @@
 """
 Some type conversion helpers for going between python and protocol buffer interfaces
 """
-
 # Standard
 from inspect import isclass
 from typing import Optional, Type, Union, get_args, get_origin
+import inspect
 
 # Local
 from caikit.core import ModuleBase
-from caikit.core.data_model import DataStream
+from caikit.core.data_model import DataBase, DataStream
 
 
 def has_data_stream(arg_type: Type) -> bool:
@@ -61,6 +61,10 @@ def is_model_type(arg_type: Type) -> bool:
             if isclass(typ) and issubclass(typ, ModuleBase):
                 return True
     return False
+
+
+def is_data_model_type(arg_type: Type) -> bool:
+    return inspect.isclass(arg_type) and issubclass(arg_type, DataBase)
 
 
 def _is_data_stream(arg_type: Type) -> bool:

--- a/caikit/runtime/service_generation/type_helpers.py
+++ b/caikit/runtime/service_generation/type_helpers.py
@@ -19,15 +19,10 @@ Some type conversion helpers for going between python and protocol buffer interf
 from inspect import isclass
 from typing import Optional, Type, Union, get_args, get_origin
 
-# First Party
-import alog
-
 # Local
 from caikit.core import ModuleBase
 from caikit.core.data_model import DataStream
 import caikit.core
-
-log = alog.use_channel("PGEN-TYPEHLP")
 
 # Constants #########################################
 # The common prefix for all data model package names

--- a/caikit/runtime/service_generation/type_helpers.py
+++ b/caikit/runtime/service_generation/type_helpers.py
@@ -17,7 +17,6 @@ Some type conversion helpers for going between python and protocol buffer interf
 # Standard
 from inspect import isclass
 from typing import Optional, Type, Union, get_args, get_origin
-import inspect
 
 # Local
 from caikit.core import ModuleBase
@@ -64,7 +63,7 @@ def is_model_type(arg_type: Type) -> bool:
 
 
 def is_data_model_type(arg_type: Type) -> bool:
-    return inspect.isclass(arg_type) and issubclass(arg_type, DataBase)
+    return isclass(arg_type) and issubclass(arg_type, DataBase)
 
 
 def _is_data_stream(arg_type: Type) -> bool:

--- a/caikit/runtime/service_generation/type_helpers.py
+++ b/caikit/runtime/service_generation/type_helpers.py
@@ -22,11 +22,6 @@ from typing import Optional, Type, Union, get_args, get_origin
 # Local
 from caikit.core import ModuleBase
 from caikit.core.data_model import DataStream
-import caikit.core
-
-# Constants #########################################
-# The common prefix for all data model package names
-caikit.core_DATA_MODEL_PREFIX = "caikit.core_data_model"
 
 
 def has_data_stream(arg_type: Type) -> bool:

--- a/caikit/runtime/service_generation/type_helpers.py
+++ b/caikit/runtime/service_generation/type_helpers.py
@@ -17,10 +17,9 @@ Some type conversion helpers for going between python and protocol buffer interf
 
 # Standard
 from inspect import isclass
-from typing import Dict, Optional, Type, Union, get_args, get_origin
+from typing import Optional, Type, Union, get_args, get_origin
 
 # First Party
-# First party
 import alog
 
 # Local
@@ -33,15 +32,6 @@ log = alog.use_channel("PGEN-TYPEHLP")
 # Constants #########################################
 # The common prefix for all data model package names
 caikit.core_DATA_MODEL_PREFIX = "caikit.core_data_model"
-
-# Mapping from native python types to the corresponding protobufs types
-PROTO_TYPE_MAP: Dict[Type, str] = {
-    float: "double",
-    int: "int32",
-    bool: "bool",
-    str: "string",
-    bytes: "bytes",
-}
 
 
 def has_data_stream(arg_type: Type) -> bool:

--- a/examples/text-sentiment/text_sentiment/config.yml
+++ b/examples/text-sentiment/text_sentiment/config.yml
@@ -14,6 +14,3 @@
 
 runtime:
     library: text_sentiment
-    service_generation:
-        primitive_data_model_types:
-            - "text_sentiment.data_model.classification.TextInput"

--- a/tests/fixtures/sample_lib/config.yml
+++ b/tests/fixtures/sample_lib/config.yml
@@ -1,8 +1,5 @@
 runtime:
     library: sample_lib # TODO: replace with libraries below when runtime can support multiple libraries
-    service_generation:
-        primitive_data_model_types:
-            - "sample_lib.data_model.SampleInputType"
 
 libraries:
     sample_lib:

--- a/tests/runtime/service_generation/test_primitives.py
+++ b/tests/runtime/service_generation/test_primitives.py
@@ -12,71 +12,70 @@ from caikit.runtime.service_generation.primitives import (
 from sample_lib.data_model import SampleInputType, SampleOutputType
 
 
+# Class that does not have to/from_proto
+class NonProtoable:
+    pass
+
+
 def test_to_primitive_signature_raw():
     assert to_primitive_signature(
         signature={"name": str},
-        primitive_data_model_types=[],
     ) == {"name": str}
 
 
 def test_to_primitive_signature_union_raw():
     assert to_primitive_signature(
         signature={"name": Union[str, int]},
-        primitive_data_model_types=[],
     ) == {"name": Union[str, int]}
 
 
 def test_to_primitive_signature_dm():
     assert to_primitive_signature(
         signature={"name": SampleInputType},
-        primitive_data_model_types=["sample_lib.data_model.SampleInputType"],
     ) == {"name": SampleInputType}
 
 
 def test_to_primitive_signature_union_dm():
     assert to_primitive_signature(
         signature={"name": Union[SampleInputType, str]},
-        primitive_data_model_types=["sample_lib.data_model.SampleInputType"],
     ) == {"name": Union[SampleInputType, str]}
 
 
 def test_to_primitive_signature_unsupported_type_in_union():
     assert to_primitive_signature(
-        signature={"name": Union[SampleInputType, str]},
-        primitive_data_model_types=[],
+        signature={"name": Union[NonProtoable, str]},
     ) == {"name": str}
 
 
-def test_to_primitive_signature_no_dm_primitives_in_union():
+def test_to_primitive_signature_no_dm_types_in_union():
+    class AnotherNonProtoable:
+        pass
+
     assert to_primitive_signature(
-        signature={"name": Union[SampleInputType, SampleOutputType, str]},
-        primitive_data_model_types=[],
+        signature={"name": Union[NonProtoable, AnotherNonProtoable, str]},
     ) == {"name": str}
 
 
-def test_to_primitive_signature_multiple_primitives_in_union():
+def test_to_primitive_signature_multiple_types_in_union():
     """We have the first arg as a supported DM arg, and the last as
     a supported primitive arg. We return the first supported DM arg"""
     assert to_primitive_signature(
-        signature={"name": Union[SampleInputType, SampleOutputType, str]},
-        primitive_data_model_types=["sample_lib.data_model.SampleInputType"],
+        signature={"name": Union[SampleInputType, NonProtoable, str]},
     ) == {"name": SampleInputType}
 
 
-def test_to_primitive_signature_multiple_no_dm_primitives_in_union():
-    """We have 1 dm arg that's not supported, and 2 primitive args. We
+def test_to_primitive_signature_multiple_no_dm_types_in_union():
+    """We have the first arg that's not supported, and 2 primitive args. We
     return the first primitive arg"""
     assert to_primitive_signature(
-        signature={"name": Union[SampleInputType, str, int]},
-        primitive_data_model_types=[],
+        signature={"name": Union[NonProtoable, str, int]},
     ) == {"name": str}
 
 
-def test_to_primitive_signature_no_primitive():
+def test_to_primitive_signature_no_protoable_types():
     assert (
         to_primitive_signature(
-            signature={"name": SampleInputType},
-            primitive_data_model_types=[],
+            signature={"name": NonProtoable},
         )
         == {}
     )

--- a/tests/runtime/service_generation/test_protoable.py
+++ b/tests/runtime/service_generation/test_protoable.py
@@ -5,9 +5,9 @@ from typing import Optional, Union
 import pytest
 
 # Local
-from caikit.runtime.service_generation.primitives import (
+from caikit.runtime.service_generation.protoable import (
     extract_data_model_type_from_union,
-    to_primitive_signature,
+    to_protoable_signature,
 )
 from sample_lib.data_model import SampleInputType, SampleOutputType
 
@@ -18,31 +18,31 @@ class NonProtoable:
 
 
 def test_to_primitive_signature_raw():
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": str},
     ) == {"name": str}
 
 
 def test_to_primitive_signature_union_raw():
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": Union[str, int]},
     ) == {"name": Union[str, int]}
 
 
 def test_to_primitive_signature_dm():
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": SampleInputType},
     ) == {"name": SampleInputType}
 
 
 def test_to_primitive_signature_union_dm():
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": Union[SampleInputType, str]},
     ) == {"name": Union[SampleInputType, str]}
 
 
 def test_to_primitive_signature_unsupported_type_in_union():
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": Union[NonProtoable, str]},
     ) == {"name": str}
 
@@ -51,7 +51,7 @@ def test_to_primitive_signature_no_dm_types_in_union():
     class AnotherNonProtoable:
         pass
 
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": Union[NonProtoable, AnotherNonProtoable, str]},
     ) == {"name": str}
 
@@ -59,7 +59,7 @@ def test_to_primitive_signature_no_dm_types_in_union():
 def test_to_primitive_signature_multiple_types_in_union():
     """We have the first arg as a supported DM arg, and the last as
     a supported primitive arg. We return the first supported DM arg"""
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": Union[SampleInputType, NonProtoable, str]},
     ) == {"name": SampleInputType}
 
@@ -67,14 +67,14 @@ def test_to_primitive_signature_multiple_types_in_union():
 def test_to_primitive_signature_multiple_no_dm_types_in_union():
     """We have the first arg that's not supported, and 2 primitive args. We
     return the first primitive arg"""
-    assert to_primitive_signature(
+    assert to_protoable_signature(
         signature={"name": Union[NonProtoable, str, int]},
     ) == {"name": str}
 
 
 def test_to_primitive_signature_no_protoable_types():
     assert (
-        to_primitive_signature(
+        to_protoable_signature(
             signature={"name": NonProtoable},
         )
         == {}

--- a/tests/runtime/service_generation/test_protoable.py
+++ b/tests/runtime/service_generation/test_protoable.py
@@ -1,5 +1,5 @@
 # Standard
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 # Third Party
 import pytest
@@ -23,31 +23,37 @@ def test_to_primitive_signature_raw():
     ) == {"name": str}
 
 
-def test_to_primitive_signature_union_raw():
+def test_to_protoable_signature_union_raw():
     assert to_protoable_signature(
         signature={"name": Union[str, int]},
     ) == {"name": Union[str, int]}
 
 
-def test_to_primitive_signature_dm():
+def test_to_protoable_signature_lists():
+    assert to_protoable_signature(
+        signature={"good_list": List[str], "bad_list": List, "lowercase_l_list": list},
+    ) == {"good_list": List[str]}
+
+
+def test_to_protoable_signature_dm():
     assert to_protoable_signature(
         signature={"name": SampleInputType},
     ) == {"name": SampleInputType}
 
 
-def test_to_primitive_signature_union_dm():
+def test_to_protoable_signature_union_dm():
     assert to_protoable_signature(
         signature={"name": Union[SampleInputType, str]},
     ) == {"name": Union[SampleInputType, str]}
 
 
-def test_to_primitive_signature_unsupported_type_in_union():
+def test_to_protoable_signature_unsupported_type_in_union():
     assert to_protoable_signature(
         signature={"name": Union[NonProtoable, str]},
     ) == {"name": str}
 
 
-def test_to_primitive_signature_no_dm_types_in_union():
+def test_to_protoable_signature_no_dm_types_in_union():
     class AnotherNonProtoable:
         pass
 
@@ -56,7 +62,7 @@ def test_to_primitive_signature_no_dm_types_in_union():
     ) == {"name": str}
 
 
-def test_to_primitive_signature_multiple_types_in_union():
+def test_to_protoable_signature_multiple_types_in_union():
     """We have the first arg as a supported DM arg, and the last as
     a supported primitive arg. We return the first supported DM arg"""
     assert to_protoable_signature(
@@ -64,7 +70,7 @@ def test_to_primitive_signature_multiple_types_in_union():
     ) == {"name": SampleInputType}
 
 
-def test_to_primitive_signature_multiple_no_dm_types_in_union():
+def test_to_protoable_signature_multiple_no_dm_types_in_union():
     """We have the first arg that's not supported, and 2 primitive args. We
     return the first primitive arg"""
     assert to_protoable_signature(
@@ -72,7 +78,7 @@ def test_to_primitive_signature_multiple_no_dm_types_in_union():
     ) == {"name": str}
 
 
-def test_to_primitive_signature_no_protoable_types():
+def test_to_protoable_signature_no_protoable_types():
     assert (
         to_protoable_signature(
             signature={"name": NonProtoable},

--- a/tests/runtime/service_generation/test_rpcs.py
+++ b/tests/runtime/service_generation/test_rpcs.py
@@ -19,9 +19,8 @@ import uuid
 
 # Local
 from caikit.core import ModuleBase, TaskBase
-from caikit.core.signature_parsing import CaikitMethodSignature
 from caikit.runtime.service_generation.rpcs import TaskPredictRPC
-from sample_lib.data_model import SampleOutputType, SampleTask
+from sample_lib.data_model import SampleOutputType
 import caikit.core
 
 
@@ -41,7 +40,7 @@ def test_task_inference_rpc_with_all_optional_params():
 
     rpc = TaskPredictRPC(
         task=TestTask,
-        method_signatures=[CaikitMethodSignature(TestModule, "run")],
+        method_signatures=[TestModule.RUN_SIGNATURE],
     )
 
     data_model = rpc.create_request_data_model(package_name="blah")

--- a/tests/runtime/service_generation/test_rpcs.py
+++ b/tests/runtime/service_generation/test_rpcs.py
@@ -42,7 +42,6 @@ def test_task_inference_rpc_with_all_optional_params():
     rpc = TaskPredictRPC(
         task=TestTask,
         method_signatures=[CaikitMethodSignature(TestModule, "run")],
-        primitive_data_model_types=[],
     )
 
     data_model = rpc.create_request_data_model(package_name="blah")


### PR DESCRIPTION
This PR deletes all the gorpy `is_primitive` logic and the ever confusing `runtime.service_generation.primitive_data_model_types` configurations.

As a follow-on to #167, this should actually finish up #90 and help with #30

This is all made possible by the explicit `tasks`, which now validate up-front that a module has the required input parameters and output type. The remainder of the work at service-generation time is to strip any non-protobufable args out of the request messages, which has much simpler implementation logic than what we were previously doing