### PR TITLE
WhichOneof from Backend

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -37,6 +37,7 @@ import alog
 # Local
 from ..toolkit.errors import error_handler
 from . import enums, json_dict
+from .data_backends.base import OneofFieldVal
 
 log = alog.use_channel("DATAM")
 error = error_handler.get(log)
@@ -309,6 +310,11 @@ class _DataBaseMetaClass(type):
                     ),
                 )
             attr_val = backend.get_attribute(self.__class__, field)
+            if isinstance(attr_val, OneofFieldVal):
+                log.debug2("Got a OneofFieldVal from the backend")
+                assert field in self.__class__._fields_oneofs_map
+                self._get_which_oneof_dict()[field] = attr_val.which_oneof
+                attr_val = attr_val.val
 
             # If the backend says that this attribute should be cached, set it
             # as an attribute on the class
@@ -483,6 +489,13 @@ class DataBase(metaclass=_DataBaseMetaClass):
         # Get the current value for the oneof and introspect which field its
         # type matches
         oneof_val = getattr(self, oneof_name)
+
+        # Re-check in case the getattr pulled a OneofFieldVal that populated the
+        # which_oneof dict with knowledge from the backend
+        if current_val := which_oneof.get(oneof_name):
+            return current_val
+
+        # Try to figure out the field based on the type
         which_field = self._infer_which_oneof(oneof_name, oneof_val)
         if which_field is not None:
             which_oneof[oneof_name] = which_field

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -20,6 +20,7 @@
 # pylint: disable=no-member
 
 # Standard
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Type, Union
 import base64
@@ -37,7 +38,6 @@ import alog
 # Local
 from ..toolkit.errors import error_handler
 from . import enums, json_dict
-from .data_backends.base import OneofFieldVal
 
 log = alog.use_channel("DATAM")
 error = error_handler.get(log)
@@ -310,7 +310,7 @@ class _DataBaseMetaClass(type):
                     ),
                 )
             attr_val = backend.get_attribute(self.__class__, field)
-            if isinstance(attr_val, OneofFieldVal):
+            if isinstance(attr_val, self.__class__.OneofFieldVal):
                 log.debug2("Got a OneofFieldVal from the backend")
                 assert field in self.__class__._fields_oneofs_map
                 self._get_which_oneof_dict()[field] = attr_val.which_oneof
@@ -417,6 +417,15 @@ class DataBase(metaclass=_DataBaseMetaClass):
         All leaves in the hierarchy of derived classes should have a corresponding protobufs class
         defined in the interface definitions.  If not, an exception will be thrown at runtime.
     """
+
+    @dataclass
+    class OneofFieldVal:
+        """Helper struct that backends can use to return information about
+        values in oneofs along with which of the oneofs is currently valid
+        """
+
+        val: Any
+        which_oneof: str
 
     def __setattr__(self, name, val):
         """Handle attribute setting for oneofs and named fields with delegation

--- a/caikit/core/data_model/data_backends/base.py
+++ b/caikit/core/data_model/data_backends/base.py
@@ -20,17 +20,10 @@ from dataclasses import dataclass
 from typing import Any, Type, Union
 import abc
 
+# Local
+from ..base import DataBase
+
 # DataModelBackendBase #########################################################
-
-
-@dataclass
-class OneofFieldVal:
-    """Helper struct that backends can use to return information about values in
-    oneofs along with which of the oneofs is currently valid
-    """
-
-    val: Any
-    which_oneof: str
 
 
 class DataModelBackendBase(abc.ABC):
@@ -41,9 +34,9 @@ class DataModelBackendBase(abc.ABC):
     @abc.abstractmethod
     def get_attribute(
         self,
-        data_model_class: Type["DataBase"],
+        data_model_class: Type[DataBase],
         name: str,
-    ) -> Union[Any, OneofFieldVal]:
+    ) -> Union[Any, DataBase.OneofFieldVal]:
         """A data model backend must implement this in order to provide the
         frontend view the functionality needed to lazily extract data.
 

--- a/caikit/core/data_model/data_backends/base.py
+++ b/caikit/core/data_model/data_backends/base.py
@@ -16,10 +16,21 @@
 """The base class for data model object backends"""
 
 # Standard
-from typing import Any, Type
+from dataclasses import dataclass
+from typing import Any, Type, Union
 import abc
 
 # DataModelBackendBase #########################################################
+
+
+@dataclass
+class OneofFieldVal:
+    """Helper struct that backends can use to return information about values in
+    oneofs along with which of the oneofs is currently valid
+    """
+
+    val: Any
+    which_oneof: str
 
 
 class DataModelBackendBase(abc.ABC):
@@ -28,7 +39,11 @@ class DataModelBackendBase(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_attribute(self, data_model_class: Type["DataBase"], name: str) -> Any:
+    def get_attribute(
+        self,
+        data_model_class: Type["DataBase"],
+        name: str,
+    ) -> Union[Any, OneofFieldVal]:
         """A data model backend must implement this in order to provide the
         frontend view the functionality needed to lazily extract data.
 
@@ -39,8 +54,9 @@ class DataModelBackendBase(abc.ABC):
                 The name of the attribute to access
 
         Returns:
-            value:  Any
-                The extracted attribute value
+            value:  Union[Any, OneofFieldVal]
+                The extracted attribute value or a OneofFieldVal that wraps the
+                field val with an indicator about the oneof field that is set.
         """
 
     # pylint: disable=unused-argument

--- a/caikit/core/data_model/data_backends/base.py
+++ b/caikit/core/data_model/data_backends/base.py
@@ -16,7 +16,6 @@
 """The base class for data model object backends"""
 
 # Standard
-from dataclasses import dataclass
 from typing import Any, Type, Union
 import abc
 

--- a/caikit/core/data_model/data_backends/dict_backend.py
+++ b/caikit/core/data_model/data_backends/dict_backend.py
@@ -109,15 +109,15 @@ class DictBackend(DataModelBackendBase):
         # instead and return the right value
         if name in data_model_class._fields_oneofs_map:
             if name in self._data_dict:
-                val = self._data_dict.get(name)
+                val = self._data_dict[name]
                 which_oneof = data_model_class._infer_which_oneof(name, val)
                 return data_model_class.OneofFieldVal(val=val, which_oneof=which_oneof)
 
-            oneof_fields = data_model_class._fields_oneofs_map.get(name)
+            oneof_fields = data_model_class._fields_oneofs_map[name]
             for field in oneof_fields:
                 if field in self._data_dict:
                     return data_model_class.OneofFieldVal(
-                        val=self._data_dict.get(field), which_oneof=field
+                        val=self._data_dict[field], which_oneof=field
                     )
 
         return raw_value

--- a/caikit/core/data_model/data_backends/dict_backend.py
+++ b/caikit/core/data_model/data_backends/dict_backend.py
@@ -103,4 +103,21 @@ class DictBackend(DataModelBackendBase):
                 for entry in raw_value
             ]
 
+        # If the target attribure is a oneof name, look for the oneof name in the data dict first.
+        # If it exists, infer the right field name based on the type of the value and return the
+        # field name and the value. If oneof name isn't in the data dict, check for field name
+        # instead and return the right value
+        if name in data_model_class._fields_oneofs_map:
+            if name in self._data_dict:
+                val = self._data_dict.get(name)
+                which_oneof = data_model_class._infer_which_oneof(name, val)
+                return data_model_class.OneofFieldVal(val=val, which_oneof=which_oneof)
+
+            oneof_fields = data_model_class._fields_oneofs_map.get(name)
+            for field in oneof_fields:
+                if field in self._data_dict:
+                    return data_model_class.OneofFieldVal(
+                        val=self._data_dict.get(field), which_oneof=field
+                    )
+
         return raw_value

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -40,6 +40,7 @@ from caikit.core import (  # NOTE: Imported from the top to validate
 )
 from caikit.core.data_model import enums
 from caikit.core.data_model.base import DataBase, _DataBaseMetaClass
+from caikit.core.data_model.data_backends.dict_backend import DictBackend
 from caikit.core.data_model.dataobject import (
     _AUTO_GEN_PROTO_CLASSES,
     render_dataobject_protos,
@@ -505,6 +506,28 @@ def test_dataobject_primitive_oneof_round_trips():
         "foo_int": 2,
     }
     assert Foo.from_json(json_repr_foo) == foo1
+
+
+def test_dataobject_oneof_from_backend():
+    """Make sure that a oneof can be correctly accessed from a backend"""
+
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: Union[int, str]
+
+    data_dict1 = {"fooint": 1234}
+    backend1 = DictBackend(data_dict1)
+    msg1 = Foo.from_backend(backend1)
+    assert msg1.foo == 1234
+    assert msg1.fooint == 1234
+    assert msg1.which_oneof("foo") == "fooint"
+
+    data_dict2 = {"foo": 1234}
+    backend2 = DictBackend(data_dict2)
+    msg2 = Foo.from_backend(backend2)
+    assert msg2.foo == 1234
+    assert msg2.fooint == 1234
+    assert msg2.which_oneof("foo") == "fooint"
 
 
 def test_dataobject_round_trip_json():


### PR DESCRIPTION
## Description

This PR adds a new return type option for data backends' `get_attribute` that will allow for the backend to return the `oneof` value along with information on which of the `oneof` fields is currently set.

## Changes

* Add a new helper struct `OneofFieldVal` in `DataBase` that holds the `oneof` value and the corresponding `which_oneof` 
* If `OneofFieldVal` is returned from a backend, use the information from the struct to set the appropriate `which_oneof` value
* Make required changes in `DictBackend` to test this functionality