### PR TITLE
Add lint for code under examples

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ skip_install = True # Skip package install since fmt doesn't need to execute cod
 [testenv:lint]
 description = lint with pylint
 deps = pylint>=2.16.2,<3.0
-commands = pylint caikit
+commands = pylint caikit examples/text-sentiment/text_sentiment examples/text-sentiment/*.py examples/*.py
 
 [testenv:imports]
 description = enforce internal import rules


### PR DESCRIPTION
The existing tox lint was only processing the caikit module.

This adds:
* examples/*.py: example files outside of text-sentiment
* examples/text-sentiment/text_sentiment: the text_sentiment module
* examples/text-sentiment/*.py: text_sentiment files outside of the module

Note: Without the *.py use outside of modules you can get into recursion errors processing an arbitrarily named "venv" dir.

Part of: #186