### PR TITLE
Add E2E coverage to example scenarios

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -49,4 +49,4 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r setup_requirements.txt
       - name: Build and test with tox
-        run: tox -e ${{ matrix.python-version.tox }}
+        run: tox -e ${{ matrix.python-version.tox }} -- tests

--- a/examples/text-sentiment/client.py
+++ b/examples/text-sentiment/client.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Standard
+import os
+
 # Third Party
 import grpc
 
@@ -24,12 +27,12 @@ inference_service = ServicePackageFactory().get_service_package(
 )
 
 port = 8085
-channel = grpc.insecure_channel(f"localhost:{port}")
 
+# Setup the client
+channel = grpc.insecure_channel(f"localhost:{port}")
 client_stub = inference_service.stub_class(channel)
 
-# print(dir(client_stub))
-
+# Run inference for two sample prompts
 for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
     input_text_proto = TextInput(text=text).to_proto()
     request = inference_service.messages.HuggingFaceSentimentTaskRequest(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,8 @@ dependencies = [
 
 [project.urls]
 Source = "https://github.com/caikit/caikit"
+
+[tool.pytest.ini_options]
+markers = [
+    "examples: marks tests as e2e examples (deselect with '-m \"not examples\"')",
+]

--- a/tests/examples/shared.py
+++ b/tests/examples/shared.py
@@ -1,0 +1,75 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Standard
+
+# Standard
+from contextlib import contextmanager
+from os import path
+from typing import Tuple
+import asyncio
+import subprocess
+import tempfile
+import time
+import venv
+
+# Third Party
+import pytest
+
+caikit_dir = path.abspath(path.join(path.dirname(__file__), "..", ".."))
+
+
+async def waitForPort(port, timeout: int) -> bool:
+    tmax = time.time() + timeout
+    while time.time() < tmax:
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection("127.0.0.1", port), timeout=5
+            )
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except:
+            await asyncio.sleep(1)
+    return False
+
+
+@contextmanager
+def requirements(example: str) -> Tuple[str, str]:
+    """Installs caikit and requirements.txt from relative path, returns python from venv
+    and absolute path to the example.
+    Raises subprocess.CalledProcessError if installation fails
+    """
+    with tempfile.TemporaryDirectory() as venv_dir:
+        python = path.abspath(path.join(venv_dir, "bin", "python3"))
+        pip = path.abspath(path.join(venv_dir, "bin", "pip3"))
+        example_dir = path.abspath(path.join(caikit_dir, "examples", example))
+
+        # Create a venv, install local version of caikit and local version of requirements
+        venv.create(env_dir=venv_dir, system_site_packages=False, with_pip=True)
+        try:
+            subprocess.run([pip, "install", "-e", caikit_dir], check=True)
+            subprocess.run(
+                [
+                    pip,
+                    "install",
+                    "-r",
+                    path.join(example_dir, "requirements.txt"),
+                ],
+                check=True,
+            )
+            yield python, example_dir
+        except subprocess.CalledProcessError as cpe:
+            pytest.fail(
+                "Could not install requirements for {}: {}".format(example, cpe)
+            )

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,0 +1,68 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+from os import getenv, path
+import asyncio
+import subprocess
+
+# Third Party
+import pytest
+
+# Local
+from tests.examples.shared import requirements, waitForPort
+
+
+@pytest.mark.examples
+def test_example_text_sentiment():
+    # Example specific grpc port
+    grpc_port = 8085
+
+    with requirements("text-sentiment") as (python_venv, example_dir):
+        # Start the server
+        with subprocess.Popen(
+            [python_venv, "start_runtime.py"],
+            cwd=example_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as server:
+            # Check if the gRPC port is open
+            # The gRPC server start-up time has some inherent variability
+            # 60s timeout should cover most situations, while keeping the
+            # test execution time reasonable
+            if not asyncio.run(waitForPort(grpc_port, 60)):
+                server.terminate()
+                pytest.fail(
+                    "Failed to connect to the gRPC server on port {} in 30s.".format(
+                        grpc_port
+                    )
+                )
+
+            # Server is running, start the client
+            # Use a timeout of 10s for inference. Capture outputs to report
+            # them in case of failure.
+            try:
+                subprocess.run(
+                    [python_venv, path.join(example_dir, "client.py")],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=30,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                server.terminate()
+                pytest.fail("Client failed with output: {}".format(e))
+
+            # Client worked well, let's stop the server
+            server.terminate()

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml {posargs:tests}
+commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml {posargs:tests -m "not examples"}
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
Add e2e test for examples

Add an e2e test for the text sentiment example.
The test is written as a standard python test so it can be
discovered by pytest and all the nice python tooling for
tests works as usual.

The test creates a new virtual environment and installs
caikit from the local disk, to ensure it tests the version of
caikit from the pull request (or local code changes).

The test then follows the same process described in the README:
- installs requirements.txt
- runs the start_runtime.py script
- runs the client.py

This test ensures that the example stays in a working state.
The example is likely to be one of the first points of contact
of people looking at caikit and it should always be working.

This test also helps in detecting unintended API changes.
Eventually we should have a API driven test suite that covers
the whole API.

The new test is not executed by default via tox, to keep
tests execution on laptops as quick as possible. The new
test is enabled in the GitHub action workflow.

Fixes: #151

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>