### PR TITLE
Drop the coverage action

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -50,14 +50,3 @@ jobs:
           python -m pip install -r setup_requirements.txt
       - name: Build and test with tox
         run: tox -e ${{ matrix.python-version.tox }}
-      - name: Publish coverage
-        if: ${{ github.event_name == 'pull_request' && matrix.python-version.setup == '3.11' }}
-        uses: orgoro/coverage@v3.1
-        with:
-            coverageFile: coverage-py311.xml
-            token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.0
-            thresholdNew: 0.8
-            thresholdModified: 0.0
-
-


### PR DESCRIPTION
The coverage action does not get the correct permissions in the GITHUB_TOKEN on PRs from non-maintainers, so dropping it for now.