### PR TITLE
Format and lint examples

### DIFF
--- a/examples/text-sentiment/client.py
+++ b/examples/text-sentiment/client.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Standard
-import os
-
 # Third Party
 import grpc
 

--- a/examples/text-sentiment/start_runtime.py
+++ b/examples/text-sentiment/start_runtime.py
@@ -20,7 +20,9 @@ import sys
 import alog
 
 # Local
+from caikit.runtime import grpc_server
 import caikit
+import text_sentiment  # pylint: disable=unused-import
 
 models_directory = path.abspath(path.join(path.dirname(__file__), "models"))
 caikit.config.configure(
@@ -34,12 +36,6 @@ sys.path.append(
     path.abspath(path.join(path.dirname(__file__), "../"))
 )  # Here we assume that `start_runtime` file is at the same level of the `text_sentiment` package
 
-# Local
-import text_sentiment
-
 alog.configure(default_level="debug")
-
-# Local
-from caikit.runtime import grpc_server
 
 grpc_server.main()

--- a/examples/text-sentiment/text_sentiment/runtime_model/hf_module.py
+++ b/examples/text-sentiment/text_sentiment/runtime_model/hf_module.py
@@ -16,7 +16,7 @@
 import os
 
 # Third Party
-from transformers import pipeline
+from transformers import pipeline  # pylint: disable=import-error
 
 # Local
 from caikit.core import ModuleBase, ModuleLoader, ModuleSaver, TaskBase, module, task
@@ -51,7 +51,9 @@ class HuggingFaceSentimentModule(ModuleBase):
         model = pipeline(model=config.hf_artifact_path, task="sentiment-analysis")
         self.sentiment_pipeline = model
 
-    def run(self, text_input: TextInput) -> ClassificationPrediction:
+    def run(  # pylint: disable=arguments-differ
+        self, text_input: TextInput
+    ) -> ClassificationPrediction:
         """Run HF sentiment analysis
         Args:
             text_input: TextInput
@@ -68,7 +70,9 @@ class HuggingFaceSentimentModule(ModuleBase):
         return ClassificationPrediction(class_info)
 
     @classmethod
-    def bootstrap(cls, model_path="distilbert-base-uncased-finetuned-sst-2-english"):
+    def bootstrap(
+        cls, model_path="distilbert-base-uncased-finetuned-sst-2-english"
+    ):  # pylint: disable=arguments-differ
         """Load a HuggingFace based caikit model
         Args:
             model_path: str
@@ -78,7 +82,7 @@ class HuggingFaceSentimentModule(ModuleBase):
         """
         return cls(model_path)
 
-    def save(self, model_path, **kwargs):
+    def save(self, model_path, **kwargs):  # pylint: disable=arguments-differ
         module_saver = ModuleSaver(
             self,
             model_path=model_path,
@@ -94,7 +98,7 @@ class HuggingFaceSentimentModule(ModuleBase):
 
     # this is how you load the model, if you have a caikit model
     @classmethod
-    def load(cls, model_path):
+    def load(cls, model_path):  # pylint: disable=arguments-differ
         """Load a HuggingFace based caikit model
         Args:
             model_path: str

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ description = lint with pylint
 extras =
     all
     dev-fmt
-commands = pylint caikit
+commands = pylint caikit examples/text-sentiment/text_sentiment examples/text-sentiment/*.py examples/*.py
 
 [testenv:imports]
 description = enforce internal import rules


### PR DESCRIPTION
This fixes the errors that will show up with tox after #196 is merged

The arguments differ problem is due to the way ModuleBase is defined.  I think disabling on each line is best fix so we still have that check elsewhere.  Is there a better fix?

Also I'm disabling the import error on transformers because I haven't found a convenient way to ensure we have the example requirements (and don't want to install transformers for now).