### PR TITLE
Display OpenSSF Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7443/badge)](https://bestpractices.coreinfrastructure.org/projects/7443)
+
 # Caikit
 
 Caikit is an AI toolkit that enables users to manage models through a set of developer friendly APIs. It provides a consistent format for creating and using AI models against a wide variety of data domains and tasks.


### PR DESCRIPTION
caikit has passed the OpenSSF basic level as `passing`. We want to display the badge in the README as standard practice.
Result from this [issue](https://github.com/caikit/caikit/issues/152)