### PR TITLE
Create docstring converter

### DIFF
--- a/caikit/config/config.py
+++ b/caikit/config/config.py
@@ -62,8 +62,8 @@ def configure(
             with overrides for your usage.
         config_dict (Optional[Dict]): Config overrides in dictionary form
 
-    Returns: None
-        This only sets the config object that is returned by `caikit.get_config()`
+    Returns: None: This only sets the config object that is returned by
+        `caikit.get_config()`
     """
     if not config_yml_path and not config_dict:
         log.error("<CFG43273054E>", "No config_file or config_dict provided")
@@ -129,12 +129,10 @@ def merge_configs(
     and the type of the key for both is a dict, recursively merge, otherwise
     set the base value to the override value.
     Args:
-        base: Optional[dict]
-            The base config that will be updated with the overrides
-        overrides: Optional[dict]
-            The override config
-        merge_strategy: str
-            The merging strategy, either `merge` or `override`
+        base (Optional[dict]): The base config that will be updated with the
+            overrides
+        overrides (Optional[dict]): The override config
+        merge_strategy (str): The merging strategy, either `merge` or `override`
             `override` will replace values in base with those from overrides
             `merge` will deep-merge dictionaries and prepend-merge lists
     Returns:

--- a/caikit/core/augmentors/base.py
+++ b/caikit/core/augmentors/base.py
@@ -53,11 +53,11 @@ class AugmentorBase:
         """Take an object in, give an object back. Calls ._augment in the subclass.
 
         Args:
-            inp_obj: str | caikit.core.data_model.DataBase
-                Object to be augmented.
+            inp_obj (str | caikit.core.data_model.DataBase): Object to be
+                augmented.
         Returns:
-            str | caikit.core.data_model.DataBase
-                Augmented object of same type as input inp_obj.
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input inp_obj.
         """
         if not isinstance(inp_obj, self.augmentor_type):
             raise TypeError(

--- a/caikit/core/augmentors/merged_augmentor.py
+++ b/caikit/core/augmentors/merged_augmentor.py
@@ -32,8 +32,8 @@ class MergedAugmentor(AugmentorBase):
         """Build an augmentor encapsulating multiple augmentors, where application order is
         governed by the provided scheme.
         Args:
-            scheme: SchemeBase
-                Scheme indicating how encapsulated augmentors should be combined.
+            scheme (SchemeBase): Scheme indicating how encapsulated augmentors
+                should be combined.
         """
         # NOTE: Random seed of merged augmentor does not currently matter since randomness is
         # already represented completely within encapsulated augmentors and scheme state
@@ -58,11 +58,10 @@ class MergedAugmentor(AugmentorBase):
         """Apply a merged augmentor whose behavior is controlled by the encapsulated scheme.
 
         Args:
-            obj: str | caikit.core.data_model.DataBase
-                Object to be augmented.
+            obj (str | caikit.core.data_model.DataBase): Object to be augmented.
         Returns:
-            str | caikit.core.data_model.DataBase
-                Augmented object of same type as input obj.
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input obj.
         """
         return self._scheme.execute(obj)
 

--- a/caikit/core/augmentors/schemes/always_selection_scheme.py
+++ b/caikit/core/augmentors/schemes/always_selection_scheme.py
@@ -24,13 +24,12 @@ class AlwaysSelectionScheme(SchemeBase):
         """Create a merging augmentor scheme which always applies every contained augmentor.
 
         Args:
-            preserve_order: bool
-                Indicates whether or not the contained augmentors should always be considered in
-                the order that they were provided when they are being applied.
-            augmentors: list(AugmentorBase) | tuple(AugmentorBase)
-                Augmentors to be applied (in same order as selection_probs).
-            random_seed: int
-                Random seed for controlling shuffling behavior.
+            preserve_order (bool): Indicates whether or not the contained
+                augmentors should always be considered in the order that they
+                were provided when they are being applied.
+            augmentors (list(AugmentorBase) | tuple(AugmentorBase)): Augmentors
+                to be applied (in same order as selection_probs).
+            random_seed (int): Random seed for controlling shuffling behavior.
         """
         super().__init__(preserve_order, augmentors, random_seed)
 
@@ -39,11 +38,10 @@ class AlwaysSelectionScheme(SchemeBase):
         shuffled ordering, based on the value of self.preserve_order).
 
         Args:
-            obj: str | caikit.core.data_model.DataBase
-                Object to be augmented.
+            obj (str | caikit.core.data_model.DataBase): Object to be augmented.
         Returns:
-            str | caikit.core.data_model.DataBase
-                Augmented object of same type as input obj.
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input obj.
         """
         output_obj = obj
         for idx in self._current_order:

--- a/caikit/core/augmentors/schemes/base.py
+++ b/caikit/core/augmentors/schemes/base.py
@@ -35,13 +35,12 @@ class SchemeBase:
         augmentors.
 
         Args:
-            preserve_order: bool
-                Indicates whether or not the contained augmentors should always be considered in
-                the order that they were provided when they are being applied.
-            augmentors: list(AugmentorBase) | tuple(AugmentorBase)
-                List or tuple of Augmentor objects to be applied.
-            random_seed: int
-                Random seed for controlling shuffling behavior.
+            preserve_order (bool): Indicates whether or not the contained
+                augmentors should always be considered in the order that they
+                were provided when they are being applied.
+            augmentors (list(AugmentorBase) | tuple(AugmentorBase)): List or
+                tuple of Augmentor objects to be applied.
+            random_seed (int): Random seed for controlling shuffling behavior.
         """
         error.type_check("<COR54555981E>", bool, preserve_order=preserve_order)
         error.type_check("<COR54155111E>", list, tuple, augmentors=augmentors)
@@ -64,11 +63,10 @@ class SchemeBase:
         augmentors.
 
         Args:
-            obj: str | caikit.core.data_model.DataBase
-                Object to be augmented.
+            obj (str | caikit.core.data_model.DataBase): Object to be augmented.
         Returns:
-            str | caikit.core.data_model.DataBase
-                Augmented object of same type as input obj.
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input obj.
         """
         if not self._preserve_order:
             random.shuffle(self._current_order)

--- a/caikit/core/augmentors/schemes/random_multi_selection_scheme.py
+++ b/caikit/core/augmentors/schemes/random_multi_selection_scheme.py
@@ -35,15 +35,14 @@ class RandomMultiSelectionScheme(SchemeBase):
         simultaneously, each of which is controlled by an independent application probability.
 
         Args:
-            preserve_order: bool
-                Indicates whether or not the contained augmentors should always be considered in
-                the order that they were provided when they are being applied.
-            selection_probs: list(int|float) | tuple(int|float)
-                Independent probability values for applying each augmentor.
-            augmentors: list(AugmentorBase) | tuple(AugmentorBase)
-                Augmentors to be applied (in same order as selection_probs).
-            random_seed: int
-                Random seed for controlling shuffling behavior.
+            preserve_order (bool): Indicates whether or not the contained
+                augmentors should always be considered in the order that they
+                were provided when they are being applied.
+            selection_probs (list(int|float) | tuple(int|float)): Independent
+                probability values for applying each augmentor.
+            augmentors (list(AugmentorBase) | tuple(AugmentorBase)): Augmentors
+                to be applied (in same order as selection_probs).
+            random_seed (int): Random seed for controlling shuffling behavior.
         """
         super().__init__(preserve_order, augmentors, random_seed)
         error.type_check("<COR99517020E>", list, tuple, selection_probs=selection_probs)
@@ -67,11 +66,10 @@ class RandomMultiSelectionScheme(SchemeBase):
         shuffled ordering, based on the value of self.preserve_order).
 
         Args:
-            obj: str | caikit.core.data_model.DataBase
-                Object to be augmented.
+            obj (str | caikit.core.data_model.DataBase): Object to be augmented.
         Returns:
-            str | caikit.core.data_model.DataBase
-                Augmented object of same type as input obj.
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input obj.
         """
         output_obj = obj
         for idx in self._current_order:

--- a/caikit/core/augmentors/schemes/random_single_selection_scheme.py
+++ b/caikit/core/augmentors/schemes/random_single_selection_scheme.py
@@ -35,12 +35,11 @@ class RandomSingleSelectionScheme(SchemeBase):
         augmentors when executed.
 
         Args:
-            selection_probs: list(int|float) | tuple(int|float)
-                Probability values for applying each augmentor (must sum to 1).
-            augmentors: list(AugmentorBase) | tuple(AugmentorBase)
-                Augmentors to be applied (in same order as selection_probs).
-            random_seed: int
-                Random seed for controlling shuffling behavior.
+            selection_probs (list(int|float) | tuple(int|float)): Probability
+                values for applying each augmentor (must sum to 1).
+            augmentors (list(AugmentorBase) | tuple(AugmentorBase)): Augmentors
+                to be applied (in same order as selection_probs).
+            random_seed (int): Random seed for controlling shuffling behavior.
         """
         super().__init__(True, augmentors, random_seed)
         error.type_check("<COR26721310E>", list, tuple, selection_probs=selection_probs)
@@ -68,11 +67,10 @@ class RandomSingleSelectionScheme(SchemeBase):
         """Execute the merged scheme by picking one random augmentor and applying it.
 
         Args:
-            obj: str | caikit.core.data_model.DataBase
-                Object to be augmented.
+            obj (str | caikit.core.data_model.DataBase): Object to be augmented.
         Returns:
-            str | caikit.core.data_model.DataBase
-                Augmented object of same type as input obj.
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input obj.
         """
         aug = random.choices(self._augmentors, weights=self._selection_probs)[0]
         return aug.augment(obj)

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -490,8 +490,8 @@ class DataBase(metaclass=_DataBaseMetaClass):
         message or a repeated message
 
         Args:
-            field_name:  str
-                Field name to check (AttributeError raised if name is invalid)
+            field_name (str): Field name to check (AttributeError raised if name
+                is invalid)
 
         Returns:
             data_model_type:  Type[DataBase]
@@ -610,7 +610,6 @@ class DataBase(metaclass=_DataBaseMetaClass):
 
         Args:
             buf: The binary buffer containing a serialized protobufs message
-
         Returns:
             A data model object instantiated from the protobufs message deserialized out of `buf`
         """
@@ -624,12 +623,9 @@ class DataBase(metaclass=_DataBaseMetaClass):
         """Build a DataBase from protobufs.
 
         Args:
-            proto:
-                A protocol buffer to serialize from.
-
+            proto: A protocol buffer to serialize from.
         Returns:
-            protobufs
-                A DataBase object.
+            protobufs: A DataBase object.
         """
         error.type_check("<COR45207671E>", ProtoMessageType, proto=proto)
         if cls._proto_class.DESCRIPTOR.name != proto.DESCRIPTOR.name:
@@ -713,12 +709,11 @@ class DataBase(metaclass=_DataBaseMetaClass):
         deserialization
 
         Args:
-            json_str: str or dict
-                A stringified JSON specification/dict of the data_model
+            json_str (str or dict): A stringified JSON specification/dict of the
+                data_model
 
         Returns:
-            caikit.core.data_model.DataBase
-                A DataBase object.
+            caikit.core.data_model.DataBase: A DataBase object.
         """
         # Get protobufs class required for parsing
         error.type_check("<COR91037250E>", str, dict, json_str=json_str)
@@ -761,12 +756,9 @@ class DataBase(metaclass=_DataBaseMetaClass):
         """Populate a protobufs with the values from this data model object.
 
         Args:
-            proto:
-                A protocol buffer to be populated.
-
+            proto: A protocol buffer to be populated.
         Returns:
-            protobufs
-                The filled protobufs.
+            protobufs: The filled protobufs.
 
         Notes:
             The protobufs is filled in place, so the argument and the return
@@ -956,8 +948,8 @@ class DataBase(metaclass=_DataBaseMetaClass):
                 The proto name or descriptor to look up against
 
         Returns:
-            dm_class (Type[DataBase])
-                The data model class corresponding to the given protobuf
+            dm_class (Type[DataBase]): The data model class corresponding to the
+                given protobuf
         """
         error.type_check(
             "<COR46446770E>",
@@ -1002,8 +994,8 @@ class DataBase(metaclass=_DataBaseMetaClass):
                 or as the unqualified class name
 
         Returns:
-            dm_class (Type[DataBase])
-                The data model class corresponding to the given protobuf
+            dm_class (Type[DataBase]): The data model class corresponding to the
+                given protobuf
         """
         dm_class = _DataBaseMetaClass.class_registry.get(class_name)
         if dm_class is not None:

--- a/caikit/core/data_model/data_backends/base.py
+++ b/caikit/core/data_model/data_backends/base.py
@@ -40,10 +40,9 @@ class DataModelBackendBase(abc.ABC):
         frontend view the functionality needed to lazily extract data.
 
         Args:
-            data_model_class:  Type[DataBase]
-                The frontend data model class that is accessing this attribute
-            name:  str
-                The name of the attribute to access
+            data_model_class (Type[DataBase]): The frontend data model class
+                that is accessing this attribute
+            name (str): The name of the attribute to access
 
         Returns:
             value:  Union[Any, OneofFieldVal]
@@ -61,10 +60,8 @@ class DataModelBackendBase(abc.ABC):
         based on the name/value of the individual field.
 
         Args:
-            name:  str
-                The name of the attribute to check
-            value:  Any
-                The extracted value
+            name (str): The name of the attribute to check
+            value (Any): The extracted value
 
         Returns:
             should_cache:  bool

--- a/caikit/core/data_model/data_backends/dict_backend.py
+++ b/caikit/core/data_model/data_backends/dict_backend.py
@@ -48,10 +48,9 @@ class DictBackend(DataModelBackendBase):
         same backend.
 
         Args:
-            data_model_class:  Type[DataBase]
-                The frontend data model class that is accessing this attribute
-            name:  str
-                The name of the attribute to access
+            data_model_class (Type[DataBase]): The frontend data model class
+                that is accessing this attribute
+            name (str): The name of the attribute to access
 
         Returns:
             value:  Any

--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -146,8 +146,7 @@ def dataobject(*args, **kwargs) -> Callable[[Type], Type[DataBase]]:
         before this decorator can auto-gen the protobufs class.
 
     Args:
-        package:  str
-            The package name to use for the generated protobufs class
+        package (str): The package name to use for the generated protobufs class
 
     Returns:
         decorator:  Callable[[Type], Type[DataBase]]
@@ -237,8 +236,7 @@ def render_dataobject_protos(interfaces_dir: str):
     to the target interfaces directory
 
     Args:
-        interfaces_dir:  str
-            The target directory (must already exist)
+        interfaces_dir (str): The target directory (must already exist)
     """
     for proto_class in _AUTO_GEN_PROTO_CLASSES:
         proto_class.write_proto_file(interfaces_dir)

--- a/caikit/core/data_model/enums.py
+++ b/caikit/core/data_model/enums.py
@@ -67,10 +67,9 @@ def import_enum(
     """Import a single enum into the global enum module by name
 
     Args:
-        proto_enum:  EnumTypeWrapper
-            The enum to import
-        enum_class:  Optional[Type[Enum]]
-            A pre-existing enum class that this proto enum binds to
+        proto_enum (EnumTypeWrapper): The enum to import
+        enum_class (Optional[Type[Enum]]): A pre-existing enum class that this
+            proto enum binds to
 
     Returns:
         name:  str
@@ -119,8 +118,8 @@ def import_enums(current_globals):
     your enums (as importable from this file) with the data model.
 
     Args:
-        current_globals: dict
-            global dictionary from your data model package __init__ file.
+        current_globals (dict): global dictionary from your data model package
+            __init__ file.
     """
     # Like the proto imports, we'd one day like to do this with introspection using something
     # like below, but can't because our wheel is compiled. If you can think of a cleaner way

--- a/caikit/core/data_model/protobufs/__init__.py
+++ b/caikit/core/data_model/protobufs/__init__.py
@@ -43,12 +43,12 @@ def import_protobufs(proto_dir, package_base_name, current_globals):
     nice with inspecting a wheel whose contents have been compiled to bytecode. :(
 
     Args:
-        proto_dir: str
-            Path to the proto directory, i.e., the directory that you __init__ protobufs file is in.
-        package_base_name: str
-            full name of your package, e.g., __name__ from the __init__ protobufs file.
-        current_globals: dict
-            global dictionary from your protobufs package __init__ file.
+        proto_dir (str): Path to the proto directory, i.e., the directory that
+            you __init__ protobufs file is in.
+        package_base_name (str): full name of your package, e.g., __name__ from
+            the __init__ protobufs file.
+        current_globals (dict): global dictionary from your protobufs package
+            __init__ file.
     """
 
     # look for *_pb2.py files in proto_dir, we will consider these to be our protobufs files

--- a/caikit/core/data_model/streams/converter.py
+++ b/caikit/core/data_model/streams/converter.py
@@ -74,10 +74,9 @@ class DataStreamConverter:
         """Initialize DataStreamConverter
 
         Args:
-            target_type: type
-                Target DataStream type, either dict or list
-            key_list: List(str)
-                List of keys that determines how data will be formatted into a DataStream
+            target_type (type): Target DataStream type, either dict or list
+            key_list (List(str)): List of keys that determines how data will be
+                formatted into a DataStream
         """
         error.type_check("<COR56775827E>", type, target_type=target_type)
         error.type_check_all("<COR16523028E>", str, key_list=key_list)
@@ -109,8 +108,7 @@ class DataStreamConverter:
         See classdoc for examples
 
         Args:
-            stream: DataStream
-                stream intended to be converted
+            stream (DataStream): stream intended to be converted
 
         Returns:
             Converted datastream based on the target type
@@ -122,8 +120,7 @@ class DataStreamConverter:
         """Attempt to convert a stream to dictionaries
 
         Args:
-            stream: DataStream
-                Stream to convert to a stream of dictionaries
+            stream (DataStream): Stream to convert to a stream of dictionaries
         Returns:
             A stream which will lazily convert data items to dictionaries
         """
@@ -143,8 +140,7 @@ class DataStreamConverter:
         """Attempt to convert a stream to lists
 
         Args:
-            stream: DataStream
-                Stream to convert to a stream of lists
+            stream (DataStream): Stream to convert to a stream of lists
         Returns:
             A stream which will lazily convert data items to lists
         """

--- a/caikit/core/data_model/streams/csv_column_formatter.py
+++ b/caikit/core/data_model/streams/csv_column_formatter.py
@@ -57,8 +57,8 @@ class CSVColumnFormatter:
         """Initialize CSVColumnConsolidator
 
         Args:
-            expected_columns: Dict(str, type)
-                (Ordered) dictionary mapping the csv column names to expected types
+            expected_columns (Dict(str, type)): (Ordered) dictionary mapping the
+                csv column names to expected types
         """
         error.type_check("<COR56775937E>", dict, expected_columns=expected_columns)
         error.value_check(
@@ -75,8 +75,7 @@ class CSVColumnFormatter:
         See classdoc for examples
 
         Args:
-            stream: DataStream
-                stream intended to be converted
+            stream (DataStream): stream intended to be converted
 
         Returns:
             DataStream:

--- a/caikit/core/data_model/streams/data_stream.py
+++ b/caikit/core/data_model/streams/data_stream.py
@@ -67,21 +67,22 @@ class DataStream(Generic[T]):
         over the desired data items.
 
         Args:
-            generator_func:  callable(*args, **kwargs)
-                A function that, when called, either (a) constructs a generator or (b) returns a
-                python iterator that yields data items, which may be any python or data model
-                object.  Each time `generator_func` is called, it must recreate the same
-                generator/iterator.  `generator_func` must also produce its elements lazily.
-                If `generator_func` returns, say a list or tuple, then all of the data will be
-                loaded into memory immediately instead of lazily.  `generator_func` is invoked every
-                time that a `DataStream` is iterated over, i.e., when `__iter__` is called.
+            generator_func (callable(*args, **kwargs)): A function that, when
+                called, either (a) constructs a generator or (b) returns a
+                python iterator that yields data items, which may be any python
+                or data model object.  Each time `generator_func` is called, it
+                must recreate the same generator/iterator.  `generator_func`
+                must also produce its elements lazily. If `generator_func`
+                returns, say a list or tuple, then all of the data will be
+                loaded into memory immediately instead of lazily.
+                `generator_func` is invoked every time that a `DataStream` is
+                iterated over, i.e., when `__iter__` is called.
 
-            args, kwargs:
-                Additional arguments passed to `generator_func`.  These are passed every time that
-                `generator_func` is called, i.e., every time we iterate over the data stream.
-                These arguments are generally useful for passing arguments to an initial data loader
-                function (see `.from_csv` for an example).  In order to retain other variables in a
-                `generator_func` consider relying on closures instead of arguments.
+            args, kwargs: Additional arguments passed to `generator_func`.  These are passed every
+                time that `generator_func` is called, i.e., every time we iterate over the data
+                stream. These arguments are generally useful for passing arguments to an initial
+                data loader function (see `.from_csv` for an example).  In order to retain other
+                variables in a `generator_func` consider relying on closures instead of arguments.
 
         Notes:
             The constructor of `DataStream` is not usually invoked directly.  The typical use case
@@ -108,13 +109,13 @@ class DataStream(Generic[T]):
         stream produces a single data item for each element of the iterable..
 
         Args:
-            data:  iterable
-                A list or tuple or other python iterable used to construct a new data stream where
-                each data item contains a single data item.
+            data (iterable): A list or tuple or other python iterable used to
+                construct a new data stream where each data item contains a
+                single data item.
 
         Returns:
-            DataStream
-                A new data stream that produces data items from the elements of `data`.
+            DataStream: A new data stream that produces data items from the
+                elements of `data`.
 
         Examples:
             >>> list_stream = DataStream.from_iterable([1, 2, 3])
@@ -137,14 +138,12 @@ class DataStream(Generic[T]):
         each line is a valid JSON (python dict)
 
         Args:
-            filename: str
-                A path to a utf8 encode text file with JSON lines array, where each line
-                is a valid JSON (python dict)
+            filename (str): A path to a utf8 encode text file with JSON lines
+                array, where each line is a valid JSON (python dict)
 
         Returns:
-            DataStream
-                A new data stream that produces python dict items each containing a
-                single JSON object corresponding to each line
+            DataStream: A new data stream that produces python dict items each
+                containing a single JSON object corresponding to each line
 
         Notes:
             This class method returns a data stream over the valid JSON objects and each
@@ -199,14 +198,12 @@ class DataStream(Generic[T]):
         valid JSON (python dict)
 
         Args:
-            filename: str
-                A path to a utf8 encode text file with JSON array, where each item is a
-                valid JSON (python dict)
+            filename (str): A path to a utf8 encode text file with JSON array,
+                where each item is a valid JSON (python dict)
 
         Returns:
-            DataStream
-                A new data stream that produces python dict items each containing a
-                single JSON object specified by 'filename'
+            DataStream: A new data stream that produces python dict items each
+                containing a single JSON object specified by 'filename'
 
         Notes:
             This class method returns a data stream over the valid JSON objects of a single
@@ -257,20 +254,17 @@ class DataStream(Generic[T]):
         values.
 
         Args:
-            filename:  str
-                A path to a csv file that has rows corresponding to data items and columns
-                corresponding to the elements of each data item.
-            skip:  int
-                Number of lines to skip at the beginning of the csv file.  This is often useful for
-                skipping a header line.
-            args, kwargs:
-                Additional arguments passed to the `csv.reader` function.  These can be used to
-                specify the delimiter or other csv settings.
+            filename (str): A path to a csv file that has rows corresponding to
+                data items and columns corresponding to the elements of each
+                data item.
+            skip (int): Number of lines to skip at the beginning of the csv
+                file.  This is often useful for skipping a header line.
+            args, kwargs: Additional arguments passed to the `csv.reader` function.
+                These can be used to specify the delimiter or other csv settings.
         Returns:
-            DataStream
-                A data stream that produces a data item for each line of the csv file and where each
-                element of the data item corresponds to a column in the csv file.
-        Examples:
+            DataStream: A data stream that produces a data item for each line of
+                the csv file and where each element of the data item corresponds
+                to a column in the csv file.Examples:
             For a sample.csv that looks like:
                 a, b, c
                 d, e, f
@@ -314,17 +308,15 @@ class DataStream(Generic[T]):
         column headers.
 
         Args:
-            filename:  str
-                A path to a csv file that has rows corresponding to data items and columns
-                corresponding to the elements of each data item.
-            args, kwargs:
-                Additional arguments passed to the `csv.reader` function.  These can be used to
-                specify the delimiter or other csv settings.
+            filename (str): A path to a csv file that has rows corresponding to
+                data items and columns corresponding to the elements of each
+                data item.
+            args, kwargs: Additional arguments passed to the `csv.reader` function.
+                These can be used to specify the delimiter or other csv settings.
         Returns:
-            DataStream
-                A data stream that produces a data item for each line of the csv file and where each
-                element of the stream is a dict representation of the fields
-        Examples:
+            DataStream: A data stream that produces a data item for each line of
+                the csv file and where each element of the stream is a dict
+                representation of the fieldsExamples:
             For a sample.csv that looks like:
                 foo, bar, baz
                 a, b, c
@@ -363,13 +355,12 @@ class DataStream(Generic[T]):
         corresponds to a single line of the file.
 
         Args:
-            filename:  str
-                A path to a utf8 encode text file with each line corresponding to a data item.
+            filename (str): A path to a utf8 encode text file with each line
+                corresponding to a data item.
 
         Returns:
-            DataStream
-                A new data stream that produces string data items each containing a single line from
-                the file specified by `filename`.
+            DataStream: A new data stream that produces string data items each
+                containing a single line from the file specified by `filename`.
 
         Notes:
             This class method returns a data stream over the lines of a single text file.  In
@@ -414,8 +405,7 @@ class DataStream(Generic[T]):
             For all other files (besides CSV for now)
                 strings (1 per line)
         Args:
-            filename: str
-                name of file
+            filename (str): name of file
 
         Returns:
             DataStream: resulting datastream from file
@@ -444,19 +434,17 @@ class DataStream(Generic[T]):
         file_handler function does the serialization of individual files
 
         Args:
-            dirname:  str
-                A directory path containing a number of utf8 encoded text files with the `.txt`
-                filename extension.
-            extension: str
-                Extension of the file. Note that all files are read in the same
-                utf8 encoding.
-            file_opener: function
-                Function to deserialize a file on disk to memory
+            dirname (str): A directory path containing a number of utf8 encoded
+                text files with the `.txt` filename extension.
+            extension (str): Extension of the file. Note that all files are read
+                in the same utf8 encoding.
+            file_opener (function): Function to deserialize a file on disk to
+                memory
 
         Returns:
-            DataStream
-                A new data stream that produces string data items each containing the text contained
-                in a single file found in `dirname`.
+            DataStream: A new data stream that produces string data items each
+                containing the text contained in a single file found in
+                `dirname`.
 
         Notes:
             Each data item in this data stream represents the *entire* text contained in a single
@@ -479,17 +467,16 @@ class DataStream(Generic[T]):
         each data item corresponds to the entire text contained in a single file.
 
         Args:
-            dirname:  str
-                A directory path containing a number of utf8 encoded text files with the `.txt`
-                filename extension.
+            dirname (str): A directory path containing a number of utf8 encoded
+                text files with the `.txt` filename extension.
             extension: str (Optional)
                 Optional extension of the text file. Note that all files are read in the same
                 utf8 encoding. Defaults to 'txt'
 
         Returns:
-            DataStream
-                A new data stream that produces string data items each containing the text contained
-                in a single `.txt` (or specified extension) file found in `dirname`.
+            DataStream: A new data stream that produces string data items each
+                containing the text contained in a single `.txt` (or specified
+                extension) file found in `dirname`.
 
         Notes:
             Each data item in this data stream represents the *entire* text contained in a single
@@ -505,17 +492,16 @@ class DataStream(Generic[T]):
         each data item corresponds to the entire serialized JSON contained in a single file.
 
         Args:
-            dirname:  str
-                A directory path containing a number of utf8 encoded text files with the `.txt`
-                filename extension.
+            dirname (str): A directory path containing a number of utf8 encoded
+                text files with the `.txt` filename extension.
             extension: str (Optional)
                 Optional extension of the JSON file. Note that all files are read in the same
                 utf8 encoding. Defaults to 'json'
 
         Returns:
-            DataStream
-                A new data stream that produces string data items each containing the text contained
-                in a single `.json` (or specified extension) file found in `dirname`.
+            DataStream: A new data stream that produces string data items each
+                containing the text contained in a single `.json` (or specified
+                extension) file found in `dirname`.
 
         Notes:
             Each data item in this data stream represents the *entire* text contained in a single
@@ -529,14 +515,12 @@ class DataStream(Generic[T]):
         containing multiple csv files where each file can have 1 or more data item.
 
         Args:
-            dirname:  str
-                A directory path containing a number of csv files
+            dirname (str): A directory path containing a number of csv files
 
         Returns:
-            DataStream
-                A new data stream that is chained from all data streams by reading
-                (from_header_csv) all files in all `.csv` files found in `dirname`.
-                All data items are dicts.
+            DataStream: A new data stream that is chained from all data streams
+                by reading (from_header_csv) all files in all `.csv` files found
+                in `dirname`. All data items are dicts.
         """
         # verify that `dirname` exists
         cls._verify_dir(dirname)
@@ -560,13 +544,12 @@ class DataStream(Generic[T]):
         containing multiple jsonl files where each file can have 1 or more data item.
 
         Args:
-            dirname:  str
-                A directory path containing a number of jsonl files
+            dirname (str): A directory path containing a number of jsonl files
 
         Returns:
-            DataStream
-                A new data stream that is chained from all data streams by reading
-                (from_jsonl) all files in all `.jsonl` files found in `dirname`.
+            DataStream: A new data stream that is chained from all data streams
+                by reading (from_jsonl) all files in all `.jsonl` files found in
+                `dirname`.
         """
         # verify that `dirname` exists
         cls._verify_dir(dirname)
@@ -590,15 +573,14 @@ class DataStream(Generic[T]):
         """Split the current datastream into train/test substreams.
 
         Args:
-            test_split:  float
-                The fraction of examples to assign to the test substream, in [0, 1]
-            seed: int | None
-                The seed for initializing the random assignment.  If not provided, a randomly
-                chosen seed will be used.
+            test_split (float): The fraction of examples to assign to the test
+                substream, in [0, 1]
+            seed (int | None): The seed for initializing the random assignment.
+                If not provided, a randomly chosen seed will be used.
 
         Returns:
-            tuple(DataStream, DataStream)
-                Two substreams: a train set substream, and a test set substream
+            tuple(DataStream, DataStream): Two substreams: a train set
+                substream, and a test set substream
         """
         assert 0.0 <= test_split <= 1.0
 
@@ -625,13 +607,12 @@ class DataStream(Generic[T]):
         the data items from each passed data stream in turn.
 
         Args:
-            args:  tuple(DataStream)
-                A tuple containing the data streams to chain, passed as variadic arguments.
+            args (tuple(DataStream)): A tuple containing the data streams to
+                chain, passed as variadic arguments.
 
         Returns:
-            DataStream
-                A new data stream that produces the data items from the provided data streams
-                sequentially.
+            DataStream: A new data stream that produces the data items from the
+                provided data streams sequentially.
         """
         return DataStream(lambda: itertools.chain(*args))
 
@@ -642,15 +623,15 @@ class DataStream(Generic[T]):
         """Skip elements in the data stream as identified by a passed function.
 
         Args:
-            func:  callable(data_item)
-                The function used to identify data items that will be filtered.  The function takes
-                a single data item as an argument and returns `True` in order to keep the element
-                and `False` in order to skip it.  The default filter function removes falsey values.
+            func (callable(data_item)): The function used to identify data items
+                that will be filtered.  The function takes a single data item as
+                an argument and returns `True` in order to keep the element and
+                `False` in order to skip it.  The default filter function
+                removes falsey values.
 
         Returns:
-            DataStream
-                A new data stream that produces the data items from the current data stream only
-                when `func` evaluates to true.
+            DataStream: A new data stream that produces the data items from the
+                current data stream only when `func` evaluates to true.
         """
         error.value_check(
             "<COR59884427E>", callable(func), "filter function is not callable"
@@ -672,15 +653,13 @@ class DataStream(Generic[T]):
         buffer.
 
         Args:
-            buffer_size: int
-                the size of the buffer space, should be greater than 0
-            seed: int | None
-                The seed for initializing the random assignment.  If not provided, a randomly
-                chosen seed will be used.
+            buffer_size (int): the size of the buffer space, should be greater
+                than 0
+            seed (int | None): The seed for initializing the random assignment.
+                If not provided, a randomly chosen seed will be used.
 
         Returns:
-            DataStream
-                A new data stream after shuffled.
+            DataStream: A new data stream after shuffled.
         """
         # make sure buffer space is valid
         error.type_check("<COR06395206E>", int, buffer_size=buffer_size)
@@ -721,9 +700,8 @@ class DataStream(Generic[T]):
         stream each time it is iterated over.
 
         Returns:
-            DataStream
-                A new data stream that iterates over the evaluated, in-memory data items in this
-                stream.
+            DataStream: A new data stream that iterates over the evaluated, in-
+                memory data items in this stream.
         """
         return DataStream.from_iterable(list(self))
 
@@ -731,14 +709,13 @@ class DataStream(Generic[T]):
         """Apply a function to each element in the data stream.
 
         Args:
-            func:  callable(*args, **kwargs)
-                A function this is lazily applied to each element in the data stream.
+            func (callable(*args, **kwargs)): A function this is lazily applied
+                to each element in the data stream.
             *args, **kwargs
                 Additional arguments to pass `func`.
 
         Returns:
-            DataStream
-                A new data stream with `func` applied to each element.
+            DataStream: A new data stream with `func` applied to each element.
         """
         return DataStream(
             lambda: (func(data_item, *args, **kwargs) for data_item in self)
@@ -748,8 +725,7 @@ class DataStream(Generic[T]):
         """Convert a 2-level nested stream into a flattened stream
 
         Returns:
-            DataStream
-                A new data stream with inner stream items 'flattened'
+            DataStream: A new data stream with inner stream items 'flattened'
         """
 
         def generator_func():
@@ -764,12 +740,11 @@ class DataStream(Generic[T]):
         """Combine the data items of multiple data streams together in tuples.
 
         Args:
-            args:  tuple(DataStream)
-                A tuple containing the data streams to be zip, passed as variadic arguments.
+            args (tuple(DataStream)): A tuple containing the data streams to be
+                zip, passed as variadic arguments.
 
         Returns:
-            DataStream
-                A data stream that produces the zipped data items.
+            DataStream: A data stream that produces the zipped data items.
 
         Notes:
             A `ValueError` is raised when the stream is iterated over if any of the zipped data
@@ -911,12 +886,12 @@ class DataStream(Generic[T]):
         elements of a stream that produces tuples, lists, arrays, et cetra.
 
         Args:
-            idx:  int or slice
-                The index or slice to be applied to each data item.
+            idx (int or slice): The index or slice to be applied to each data
+                item.
 
         Returns:
-            DataStream
-                A new data stream with `data_item[idx]` applied to each data item.
+            DataStream: A new data stream with `data_item[idx]` applied to each
+                data item.
 
         Notes:
             This operation may be somewhat counter intuitive since `data_stream[0]` does not return

--- a/caikit/core/data_model/streams/resolver.py
+++ b/caikit/core/data_model/streams/resolver.py
@@ -39,12 +39,10 @@ class DataStreamResolver:
         """Initialize DataStreamResolver
 
         Args:
-            target_stream_type: type
-                The target type for the data items in the resolved stream.
-                dict and list are supported.
-            expected_keys: dict(str, type)
-                Dictionary of keys -> types that determines how data will be formatted in the data
-                stream.
+            target_stream_type (type): The target type for the data items in the
+                resolved stream. dict and list are supported.
+            expected_keys (dict(str, type)): Dictionary of keys -> types that
+                determines how data will be formatted in the data stream.
 
                 If you want a stream of dictionaries, we'll try to put these as keys in each one.
                 If you want a stream of lists, we'll try to locate these values and place them in
@@ -68,8 +66,8 @@ class DataStreamResolver:
         ...Or leaves the error for you to find later when reading the stream.
 
         Args:
-            file_or_data_stream: str or DataStream
-                Either a string path to a file, or a DataStream
+            file_or_data_stream (str or DataStream): Either a string path to a
+                file, or a DataStream
         Returns:
             DataStream: The data as a converted and properly formatted data stream
         """

--- a/caikit/core/data_model/streams/validator.py
+++ b/caikit/core/data_model/streams/validator.py
@@ -39,9 +39,8 @@ class DataStreamValidator:
         """Initialize DataStreamValidator
 
         Args:
-            expected_keys: Dict(str)
-                (Ordered) dictionary of key names -> types that determines
-                how data will be validated
+            expected_keys (Dict(str)): (Ordered) dictionary of key names ->
+                types that determines how data will be validated
         """
         self._expected_keys: Dict[str, type] = expected_keys
         error.value_check(
@@ -60,8 +59,7 @@ class DataStreamValidator:
             items and the type of the nth item matches the nth type in `self._expected_keys`
 
         Args:
-            stream: DataStream
-                stream intended to be converted
+            stream (DataStream): stream intended to be converted
 
         Returns:
             The same data stream, which will now throw DataValidationErrors when accessed if the
@@ -83,7 +81,7 @@ class DataStreamValidator:
 
         Args:
             data_item: A data object yielded by the stream
-            data_item_number: The index of the object in the stream
+            Nonedata_item_number: The index of the object in the stream
         """
         if isinstance(data_item, dict):
             # From dictionary: error if key doesn't exist

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -73,24 +73,24 @@ class ModelManager:
         """Load a model and return an instantiated object on which we can run inference.
 
         Args:
-            module_path: str | BytesIO | bytes
-                A module path to one of the following.
-                    1. A module path to a directory containing a yaml config file in the top level.
-                    2. A module path to a zip archive containing either a yaml config file in the
-                       top level when extracted, or a directory containing a yaml config file in
-                       the top level.
-                    3. A BytesIO object corresponding to a zip archive containing either a yaml
-                       config file in the top level when extracted, or a directory containing a
-                       yaml config file in the top level.
-                    4. A bytes object corresponding to a zip archive containing either a yaml
-                       config file in the top level when extracted, or a directory containing a
-                       yaml config file in the top level.
+            module_path (str | BytesIO | bytes): A module path to one of the
+                following. 1. A module path to a directory containing a yaml
+                config file in the top level. 2. A module path to a zip archive
+                containing either a yaml config file in the top level when
+                extracted, or a directory containing a yaml config file in the
+                top level. 3. A BytesIO object corresponding to a zip archive
+                containing either a yaml config file in the top level when
+                extracted, or a directory containing a yaml config file in the
+                top level. 4. A bytes object corresponding to a zip archive
+                containing either a yaml config file in the top level when
+                extracted, or a directory containing a yaml config file in the
+                top level.
             load_singleton: bool (Defaults to False)
                 Indicates whether this model should be loaded as a singleton.
 
         Returns:
-            subclass of caikit.core.modules.ModuleBase
-                Model object that is loaded, configured, and ready for prediction.
+            subclass of caikit.core.modules.ModuleBase: Model object that is
+                loaded, configured, and ready for prediction.
         """
         error.type_check("<COR98255724E>", bool, load_singleton=load_singleton)
 
@@ -127,15 +127,14 @@ class ModelManager:
         """Load a model from a directory.
 
         Args:
-            module_path:  str
-                Path to directory. At the top level of directory is `config.yml` which holds info
-                about the model.
-            load_singleton: bool
-                Indicates whether this model should be loaded as a singleton.
+            module_path (str): Path to directory. At the top level of directory
+                is `config.yml` which holds info about the model.
+            load_singleton (bool): Indicates whether this model should be loaded
+                as a singleton.
 
         Returns:
-            subclass of caikit.core.modules.ModuleBase
-                Model object that is loaded, configured, and ready for prediction.
+            subclass of caikit.core.modules.ModuleBase: Model object that is
+                loaded, configured, and ready for prediction.
         """
         # Short-circuit the loading process if the path does not exist
         if not os.path.exists(module_path):
@@ -294,15 +293,14 @@ class ModelManager:
         """Load a model from a zip archive.
 
         Args:
-            module_path:  str
-                Path to directory. At the top level of directory is `config.yml` which holds info
-                about the model.
-            load_singleton: bool
-                Indicates whether this model should be loaded as a singleton.
+            module_path (str): Path to directory. At the top level of directory
+                is `config.yml` which holds info about the model.
+            load_singleton (bool): Indicates whether this model should be loaded
+                as a singleton.
 
         Returns:
-            subclass of caikit.core.modules.ModuleBase
-                Model object that is loaded, configured, and ready for prediction.
+            subclass of caikit.core.modules.ModuleBase: Model object that is
+                loaded, configured, and ready for prediction.
         """
         with tempfile.TemporaryDirectory() as extract_path:
             with zipfile.ZipFile(module_path, "r") as zip_f:
@@ -359,15 +357,13 @@ class ModelManager:
         """Method to extract a downloaded archive to a specified directory.
 
         Args:
-            zip_path: str
-                Location of .zip file to extract.
-            model_path: str
-                Model directory where the archive should be unzipped unzipped.
+            zip_path (str): Location of .zip file to extract.
+            model_path (str): Model directory where the archive should be
+                unzipped unzipped.
             force_overwrite: bool (Defaults to false)
                 Force an overwrite to model_path, even if the folder exists
         Returns:
-            str
-                Output path where the model archive is unzipped.
+            str: Output path where the model archive is unzipped.
         """
         model_path = os.path.abspath(model_path)
 
@@ -399,12 +395,11 @@ class ModelManager:
                 - Name of a model that the catalog knows about
                 - Loaded module
             **kwargs: Any keyword arguments to pass along to ModelManager.load()
-                      or ModelManager.download()
+                        or ModelManager.download()
                 e.g. parent_dir
 
         Returns:
             A loaded module
-
         Examples:
             >>> stock_syntax_model = manager.resolve_and_load('syntax_izumo_en_stock')
             >>> local_categories_model = manager.resolve_and_load('path/to/categories/model')
@@ -444,8 +439,7 @@ class ModelManager:
         """Returns information about the singleton cache in {hash: module type} format
 
         Returns:
-            Dict[str, type]
-                A dictionary of model hashes to model types
+            Dict[str, type]: A dictionary of model hashes to model types
         """
         return {k: type(v) for k, v in self.singleton_module_cache.items()}
 
@@ -475,11 +469,11 @@ class ModelManager:
         that the module supports
 
         Args:
-            backend_impl: caikit.core.ModuleBase
-                Module implementing the backend
+            backend_impl (caikit.core.ModuleBase): Module implementing the
+                backend
         Returns:
-            list(backend_types)
-                list of backends that are supported for model load
+            list(backend_types): list of backends that are supported for model
+                load
         """
 
         # Get list of backends that are supported for load

--- a/caikit/core/module_backends/backend_types.py
+++ b/caikit/core/module_backends/backend_types.py
@@ -43,8 +43,7 @@ def register_backend_type(config_class: Optional[Type[BackendBase]] = None):
     a property of the config_class
 
     Args:
-        config_class: BackendBase
-            Module to configure particular backend
+        config_class (BackendBase): Module to configure particular backend
     """
     # Type validation
     error.type_check(

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -92,7 +92,6 @@ class SharedTrainBackendBase(BackendBase, abc.ABC):
         Args:
             module_class (Type[ModuleBase]): The module class to train
             *args, **kwargs: The args to pass through to training
-
         Returns:
             model (ModuleBase): The in-memory instance of the trained
                 module

--- a/caikit/core/module_backends/module_backend_config.py
+++ b/caikit/core/module_backends/module_backend_config.py
@@ -144,12 +144,10 @@ def _configure_backend_overrides(backend: str, backend_instance: object):
     for a particular backend and configure their backend overrides
 
     Args:
-        backend: str
-            Name of the backend to select from registry
-        backend_instance: object
-            Initialized backend instance. This object should
-            implement the `register_config` function which will be
-            used to merge / iteratively configure the backend
+        backend (str): Name of the backend to select from registry
+        backend_instance (object): Initialized backend instance. This object
+            should implement the `register_config` function which will be used
+            to merge / iteratively configure the backend
     """
     # Go through all the modules registered with particular backend
     for module_id, module_type_mapping in module_backend_registry().items():

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -111,11 +111,10 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Load a new instance of workflow from a given model_path
 
         Args:
-            model_path: str
-                Path to workflow
+            model_path (str): Path to workflow
         Returns:
-            caikit.core.workflows.base.WorkflowBase
-                A new instance of any given implementation of WorkflowBase
+            caikit.core.workflows.base.WorkflowBase: A new instance of any given
+                implementation of WorkflowBase
         """
         return cls._load(ModuleLoader(model_path), *args, **kwargs)
 
@@ -132,16 +131,14 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Time a model `load` call.
 
         Args:
-            *args: list
-                Will be passed to `self.load`.
-            **kwargs:  dict
-                Will be passed to `self.load` -- the only way to pass arbitrary arguments to
-                `self.load` from this function.
+            *args (list): Will be passed to `self.load`.
+            **kwargs (dict): Will be passed to `self.load` -- the only way to
+                pass arbitrary arguments to `self.load` from this function.
 
         Returns:
-            int, caikit.core._ModuleBase
-                The first return value is the total time spent in the `self.load` call. The second
-                return value is the loaded model.
+            int, caikit.core._ModuleBase: The first return value is the total
+                time spent in the `self.load` call. The second return value is
+                the loaded model.
 
         Notes:
             You can pass everything that should go to the run function normally using args/kwargs.
@@ -171,8 +168,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Save a model.
 
         Args:
-            model_path: str
-                Path on disk to export the model to.
+            model_path (str): Path on disk to export the model to.
         """
         error(
             "<COR58632237E>",
@@ -188,11 +184,10 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         handled automatically.
 
         Args:
-            *args, **kwargs: dict
-                Optional keyword arguments for saving.
+            *args, **kwargs (dict): Optional keyword arguments for saving.
         Returns:
-            io.BytesIO
-                File like object holding an exported model in memory as a io.BytesIO object.
+            io.BytesIO: File like object holding an exported model in memory as
+                a io.BytesIO object.
         """
         return BytesIO(self.as_bytes(*args, **kwargs))
 
@@ -205,11 +200,9 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         handled automatically.
 
         Args:
-            *args, **kwargs: dict
-                Optional keyword arguments for saving.
+            *args, **kwargs (dict): Optional keyword arguments for saving.
         Returns:
-            bytes
-                bytes object holding an exported model in memory.
+            bytes: bytes object holding an exported model in memory.
         """
         # Open a temporary directory & do all operations relative to that temporary directory.
         with tempfile.TemporaryDirectory() as ephemeral_model_path:
@@ -269,10 +262,9 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
         Args:
             *args: Variable length argument list to be passed directly to run().
-            **kwargs: Arbitrary keyword arguments to be passed directly to run().
+            None**kwargs: Arbitrary keyword arguments to be passed directly to run().
         Returns:
-            tuple
-                Iterable of prediction outputs, run as a batch.
+            tuple: Iterable of prediction outputs, run as a batch.
         """
         predictions = []
         fixed_args = {}
@@ -308,22 +300,19 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Time a number of runs over set seconds or iterations.
 
         Args:
-            *args: list
-                Will be passed to `self.run`.
-            num_seconds:  int
-                Minimum number of seconds to run timed_run over. Will most likely be more than this
-                value due to its waiting for the each call to `self.run` to finish.
-            num_iterations:  int
-                Minimum number of iterations to run timed_run over. Will run exactly this many
-                times.
-            **kwargs:  dict
-                Will be passed to `self.run`.
+            *args (list): Will be passed to `self.run`.
+            num_seconds (int): Minimum number of seconds to run timed_run over.
+                Will most likely be more than this value due to its waiting for
+                the each call to `self.run` to finish.
+            num_iterations (int): Minimum number of iterations to run timed_run
+                over. Will run exactly this many times.
+            **kwargs (dict): Will be passed to `self.run`.
 
         Returns:
-            int, int, caikit.core.data_model.DataBase
-                The first return value is the total time spent in the `self.run` loop. The second
-                return value is the total number of calls to `self.run` were made.
-                The return value is the output of the module's run method
+            int, int, caikit.core.data_model.DataBase: The first return value is
+                the total time spent in the `self.run` loop. The second return
+                value is the total number of calls to `self.run` were made. The
+                return value is the output of the module's run method
 
         Notes:
             You can pass everything that should go to the run function normally using args/kwargs.
@@ -365,13 +354,12 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         and expand along multiple data streams.
 
         Args:
-            data_stream: caikit.core.data_model.DataStream
-                Datastream to be lazily sequentially processed by the module under consideration.
+            data_stream (caikit.core.data_model.DataStream): Datastream to be
+                lazily sequentially processed by the module under consideration.
             *args: Variable length argument list to be passed directly to run().
-            **kwargs: Arbitrary keyword arguments to be passed directly to run().
+            None**kwargs: Arbitrary keyword arguments to be passed directly to run().
         Returns:
-            protobufs
-                A DataBase object.
+            protobufs: A DataBase object.
         """
         error.type_check("<COR98214589E>", DataStream, data_stream=data_stream)
         # Ensure that no args/kwargs are DataStreams, since these get passed to stream()
@@ -451,36 +439,35 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Run quality evaluation for instance of module
 
         Args:
-            dataset_path:  str
-                Path to where the input "gold set" dataset lives. Most often this is .json file.
-            preprocess_func:  method
-                Function used as proxy for any preliminary steps that need to be taken to run the
-                model on the input text. This helper function ultimately leads to the input to this
+            dataset_path (str): Path to where the input "gold set" dataset
+                lives. Most often this is .json file.
+            preprocess_func (method): Function used as proxy for any preliminary
+                steps that need to be taken to run the model on the input text.
+                This helper function ultimately leads to the input to this
                 module and may involve executing other modules.
             detailed_metrics: boolean (Optional, defaults to False)
                 Only for 'keywords'. Include partial scores and scores over every text in document.
-            labels:  list (Optional, defaults to None)
+            labels: list (Optional, defaults to None)
                 Optional list of class labels to evaluate quality on. By default evaluation is done
                 over all class labels. Using this, you can explicitly mention only a subset of
                 labels to include in the quality evaluation.
             partial_match_metrics: boolean (Optional, defaults to False)
                 Include partial match micro avg F1.
-            max_hierarchy_levels: int
-                Used in hierarchical multilabel multiclass evaluation only. The number of levels in
-                the hierarchy to run model evaluation on,
-                in addition to complete matches.
-            *args, **kwargs:
-                Optional arguments which can be used by goldset/prediction set extraction.
-                keyword arguments:
-                `block_level`: str
+            max_hierarchy_levels (int): Used in hierarchical multilabel
+                multiclass evaluation only. The number of levels in the
+                hierarchy to run model evaluation on, in addition to complete
+                matches.
+            *args, **kwargs: Optional arguments which can be used by goldset/prediction
+                set extraction.
+                Nonekeyword arguments: `block_level`: str
                     For any module that has pre processing steps in the
                     middle of raw text and actual module input, use the input from gold standard
                     labels instead of a pre-process function. Useful for measuring quality for the
                     'block' alone (instead of the module + pre_process pipeline)
         Returns:
-            dict
-                Dictionary of results provided by the `self.evaluator.run` function, depending on
-                the associated `evaluation_type`. Reports things like precision, recall, and f1.
+            dict: Dictionary of results provided by the `self.evaluator.run`
+                function, depending on the associated `evaluation_type`. Reports
+                things like precision, recall, and f1.
         """
         # 1) load dataset
         dataset = self._load_evaluation_dataset(dataset_path)
@@ -530,11 +517,10 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         contrast, if something is not expandable, it will be passed as is to each call.
 
         Args:
-            arg: any
-                Argument to run_batch being considered.
+            arg (any): Argument to run_batch being considered.
         Returns:
-            bool
-                True if the argument is a compatible iterable, False otherwise.
+            bool: True if the argument is a compatible iterable, False
+                otherwise.
         """
         # Throw if generators are passed - can't imagine any situation (for now) where this is
         # something that someone is doing on purpose, so we are a bit specific about this error.
@@ -559,10 +545,9 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
         Args:
             *args: Variable length argument list to be passed directly to run().
-            **kwargs: Arbitrary keyword arguments to be passed directly to run().
+            None**kwargs: Arbitrary keyword arguments to be passed directly to run().
         Returns:
-            int
-                Inferred batch size based on expandable iterables.
+            int: Inferred batch size based on expandable iterables.
         """
         batch_size = None
         for _, arg in enumerate(args):
@@ -578,11 +563,10 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         if it conflicts with what we know about the inferred batch size so far.
 
         args:
-            val: any
-                Argument / keyword argument value being inspected.
-            current_batch_size: None | int
-                Current inferred batch size from previous args/kwargs, or None if no inferences
-                have been made on other expandable iterables yet.
+            val (any): Argument / keyword argument value being inspected.
+            current_batch_size (None | int): Current inferred batch size from
+                previous args/kwargs, or None if no inferences have been made on
+                other expandable iterables yet.
         Returns:
             None | inferred batch size.
         """
@@ -606,15 +590,12 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         index correspondes to the current document under consideration.
 
         Args:
-            fixed_args: dict
-                Noniterable args - common across all documents.
-            expanded_args: dict
-                Iterable args - we'll need to index into this to get our doc arg.
-            idx: int
-                Index of the document being considered.
+            fixed_args (dict): Noniterable args - common across all documents.
+            expanded_args (dict): Iterable args - we'll need to index into this
+                to get our doc arg.
+            idx (int): Index of the document being considered.
         Returns:
-            list
-                Args to be run for document [idx].
+            list: Args to be run for document [idx].
         """
         constructed_args = []
         if not expanded_args and not fixed_args:
@@ -649,13 +630,12 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         kwargs instead of cycling through them, because order doesn't matter here.
 
         Args:
-            fixed_args: dict
-                Noniterable valued kwargs - common across all documents.
-            expanded_args: dict
-                Iterable valued kwargs - we'll need to index into these to get our doc kwarg.
+            fixed_args (dict): Noniterable valued kwargs - common across all
+                documents.
+            expanded_args (dict): Iterable valued kwargs - we'll need to index
+                into these to get our doc kwarg.
         Returns:
-            dict
-                Kwargs to be run for document [idx].
+            dict: Kwargs to be run for document [idx].
         """
         constructed_kwargs = fixed_kwargs.copy()
         for arg_name, iterable_arg_val in expanded_kwargs.items():
@@ -672,12 +652,12 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Method for extracting gold set from dataset. Implemented in subclass.
 
         Args:
-            dataset:  object
-                In-memory version of whatever is loaded from on-disk. May be json, txt, etc.
+            dataset (object): In-memory version of whatever is loaded from on-
+                disk. May be json, txt, etc.
 
         Returns:
-            list
-                List of labels in the format of the module_type that is being called.
+            list: List of labels in the format of the module_type that is being
+                called.
         """
         error(
             "<COR01455940E>",
@@ -688,17 +668,16 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Method for extracting pred set from dataset. Implemented in subclass.
 
         Args:
-            dataset:  object
-                In-memory version of whatever is loaded from on-disk. May be json, txt, etc.
-            preprocess_func:  method
-                Function used as proxy for any preliminary steps that need to be taken to run the
-                model on the input text. This helper function ultimately leads to the input to this
+            dataset (object): In-memory version of whatever is loaded from on-
+                disk. May be json, txt, etc.
+            preprocess_func (method): Function used as proxy for any preliminary
+                steps that need to be taken to run the model on the input text.
+                This helper function ultimately leads to the input to this
                 module and may involve executing other modules.
-            *args, **kwargs: dict
-                Optional keyword arguments for prediction set extraction.
+            *args, **kwargs (dict): Optional keyword arguments for prediction set extraction.
         Returns:
-            list
-                List of labels in the format of the module_type that is being called.
+            list: List of labels in the format of the module_type that is being
+                called.
         """
         error(
             "<COR95693719E>",
@@ -710,13 +689,13 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Helper specifically for dataset loading.
 
         Args:
-            dataset_path:  str
-                Path to where the input 'gold set' dataset lives. Most often this is .json file.
+            dataset_path (str): Path to where the input 'gold set' dataset
+                lives. Most often this is .json file.
 
         Returns:
-            object
-                list, dict, or other python object, depending on the input dataset_path extension.
-                Currently only supports `.json` and uses fileio from toolkit.
+            object: list, dict, or other python object, depending on the input
+                dataset_path extension. Currently only supports `.json` and uses
+                fileio from toolkit.
         """
         error.type_check("<COR33285197E>", str, dataset_path=dataset_path)
 
@@ -734,7 +713,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Extract the core list of annotations that is needed for quality evaluation
 
         Args:
-            gold_set: list
+            gold_set (list)
         Returns:
             gold_annotations: list
         """
@@ -745,7 +724,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         """Extract the core list of predictions that is needed for quality evaluation
 
         Args:
-            pred_set: list
+            pred_set (list)
         Returns:
             pred_annotations: list
         """
@@ -755,7 +734,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
     def _generate_report(report, gold_set):
         """Generate the quality report output
         Args:
-            report: dict
-            gold_set: list(dict)
+            report (dict)
+            gold_set (list(dict))
         """
         return report

--- a/caikit/core/modules/config.py
+++ b/caikit/core/modules/config.py
@@ -37,8 +37,8 @@ class ModuleConfig(aconfig.Config):
         """Construct a new module configuration object from a dictionary of config options.
 
         Args:
-            config_dict:  dict
-                Dictionary or containing the module's configuration.
+            config_dict (dict): Dictionary or containing the module's
+                configuration.
 
         Notes:
             The following keys are reserved and *must not* be specified at the top level of a
@@ -86,15 +86,14 @@ class ModuleConfig(aconfig.Config):
         """Load a new module configuration from a directory on disk.
 
         Args:
-            model_path: str
-                Path to model directory. At the top level of directory is `config.yml` which holds
-                info about the model. Note that the model_path here is assumed to be operating
-                system correct as a consequence of the way this method is invoked by the model
-                manager.
+            model_path (str): Path to model directory. At the top level of
+                directory is `config.yml` which holds info about the model. Note
+                that the model_path here is assumed to be operating system
+                correct as a consequence of the way this method is invoked by
+                the model manager.
 
         Returns:
-            BlockConfig
-                Instantiated BlockConfig for model given model_path.
+            BlockConfig: Instantiated BlockConfig for model given model_path.
         """
         error.type_check("<COR71170339E>", str, model_path=model_path)
 

--- a/caikit/core/modules/decorator.py
+++ b/caikit/core/modules/decorator.py
@@ -243,19 +243,16 @@ def _register_module_implementation(
     backend_type to the implementation class
 
     Args:
-        implementation_class:  type
-            The class that is used to implement this backend type for the given
-            module_id
-        backend_type:  str
-            Value from MODULE_BACKEND_TYPES that indicates the backend
-            that this class implements
-        module_id:  str
-            The module_id from the caikit.core module registry that this class
-            overloads
-        backend_config_override: Dict
-            Dictionary containing essential overrides for the backend config.
-            This will get stored with the implementation_class class name and will automatically
-            get picked up and merged with other such configs for a specific backend
+        implementation_class (type): The class that is used to implement this
+            backend type for the given module_id
+        backend_type (str): Value from MODULE_BACKEND_TYPES that indicates the
+            backend that this class implements
+        module_id (str): The module_id from the caikit.core module registry that
+            this class overloads
+        backend_config_override (Dict): Dictionary containing essential
+            overrides for the backend config. This will get stored with the
+            implementation_class class name and will automatically get picked up
+            and merged with other such configs for a specific backend
 
     """
 

--- a/caikit/core/modules/loader.py
+++ b/caikit/core/modules/loader.py
@@ -38,8 +38,8 @@ class ModuleLoader:
         """Construct a new module loader.
 
         Args:
-            model_path:  str
-                The path to the directory where the model is to be loaded from.
+            model_path (str): The path to the directory where the model is to be
+                loaded from.
         """
         self.model_path = os.path.normpath(model_path)
         error.dir_check("<COR43014802E>", model_path)
@@ -57,10 +57,10 @@ class ModuleLoader:
         """Load a CaikitCore module from a module config.module_paths specification.
 
         Args:
-            module_paths_key:  str
-                key in `config.module_paths` looked at to load a module
-            load_singleton: bool
-                singleton load flag to pass to individual module loads
+            module_paths_key (str): key in `config.module_paths` looked at to
+                load a module
+            load_singleton (bool): singleton load flag to pass to individual
+                module loads
         """
         # Load module from a given relative path
         if "module_paths" not in self.config:
@@ -87,12 +87,11 @@ class ModuleLoader:
         """Load a list of CaikitCore module from a workflow config.module_paths specification.
 
         Args:
-            module_paths_key:  str
-                key in `config.module_paths` looked at to load a list of modules
+            module_paths_key (str): key in `config.module_paths` looked at to
+                load a list of modules
 
         Returns:
-            list
-                list of loaded modules
+            list: list of loaded modules
         """
         # Load module from a given relative path
         # Can be updated to load from a module key

--- a/caikit/core/modules/saver.py
+++ b/caikit/core/modules/saver.py
@@ -55,11 +55,11 @@ class ModuleSaver:
         """Construct a new module saver.
 
         Args:
-            module:  caikit.core.module.Module
-                The instance of the module to be saved.
-            model_path:  str
-                The absolute path to the directory where the model will be saved.  If this directory
-                does not exist, it will be created.
+            module (caikit.core.module.Module): The instance of the module to be
+                saved.
+            model_path (str): The absolute path to the directory where the model
+                will be saved.  If this directory does not exist, it will be
+                created.
         """
         self.model_path = os.path.normpath(model_path)
 
@@ -118,16 +118,14 @@ class ModuleSaver:
         """Create a directory inside the `model_path` for this saver.
 
         Args:
-            relative_path:  str
-                A path relative to this saver's `model_path` denoting the directory to create.
-            base_relative_path:  str
-                A path, relative to this saver's `model_path`, in which `relative_path` will be
-                created.
+            relative_path (str): A path relative to this saver's `model_path`
+                denoting the directory to create.
+            base_relative_path (str): A path, relative to this saver's
+                `model_path`, in which `relative_path` will be created.
 
         Returns:
-            str, str
-                A tuple containing both the `relative_path` and `absolute_path` to the
-                directory created.
+            str, str: A tuple containing both the `relative_path` and
+                `absolute_path` to the directory created.
 
         Examples:
             >>> with ModelSaver('/path/to/model') as saver:
@@ -151,16 +149,15 @@ class ModuleSaver:
         """Copy an external file into a subdirectory of the `model_path` for this saver.
 
         Args:
-            file_path:  str
-                Absolute path to the external file to copy.
-            relative_path:  str
-                The relative path inside of `model_path` where the file will be copied to.
-                If set to the empty string (default) then the file will be placed directly in
-                the `model_path` directory.
+            file_path (str): Absolute path to the external file to copy.
+            relative_path (str): The relative path inside of `model_path` where
+                the file will be copied to. If set to the empty string (default)
+                then the file will be placed directly in the `model_path`
+                directory.
 
         Returns:
-            str, str
-                A tuple containing both the `relative_path` and `absolute_path` to the copied file.
+            str, str: A tuple containing both the `relative_path` and
+                `absolute_path` to the copied file.
         """
         file_path = os.path.normpath(file_path)
 
@@ -187,15 +184,12 @@ class ModuleSaver:
         """Save a Python object using the provided ObjectSerializer.
 
         Args:
-            obj:  any
-                The Python object to save
-            filename: str
-                The filename to use for the saved object
-            serializer: ObjectSerializer
-                An ObjectSerializer instance (e.g., YAMLSerializer) that should be used to serialize
-                the object
-            relative_path:  str
-                The relative path inside of `model_path` where the object will be saved
+            obj (any): The Python object to save
+            filename (str): The filename to use for the saved object
+            serializer (ObjectSerializer): An ObjectSerializer instance (e.g.,
+                YAMLSerializer) that should be used to serialize the object
+            relative_path (str): The relative path inside of `model_path` where
+                the object will be saved
         """
         if not issubclass(serializer.__class__, ObjectSerializer):
             error(
@@ -221,8 +215,8 @@ class ModuleSaver:
         """Add items to this saver's config dictionary.
 
         Args:
-            additional_config:  dict
-                A dictionary of config options to add the this saver's configuration.
+            additional_config (dict): A dictionary of config options to add the
+                this saver's configuration.
 
         Notes:
             The behavior of this method matches `dict.update` and is equivalent to calling
@@ -235,10 +229,10 @@ class ModuleSaver:
         """Save a CaikitCore module within a workflow artifact and add a reference to the config.
 
         Args:
-            module:  caikit.core.ModuleBase
-                The CaikitCore module to save as part of this workflow
-            relative_path:  str
-                The relative path inside of `model_path` where the module will be saved
+            module (caikit.core.ModuleBase): The CaikitCore module to save as
+                part of this workflow
+            relative_path (str): The relative path inside of `model_path` where
+                the module will be saved
         """
 
         if not issubclass(module.__class__, ModuleBase):
@@ -264,12 +258,11 @@ class ModuleSaver:
         config.
 
         Args:
-            modules:  dict{str -> caikit.core.ModuleBase}
-                A dict with module relative path as key and a CaikitCore module as value to save as
+            modules (dict{str -> caikit.core.ModuleBase}): A dict with module
+                relative path as key and a CaikitCore module as value to save as
                 part of this workflow
-            config_key:  str
-                The config key inside of `model_path` where the modules' relative path with be
-                referenced
+            config_key (str): The config key inside of `model_path` where the
+                modules' relative path with be referenced
 
         Returns:
             list_of_rel_path: list(str)

--- a/caikit/core/registries.py
+++ b/caikit/core/registries.py
@@ -48,8 +48,7 @@ def module_registry() -> Dict[str, "caikit.core.ModuleBase"]:
     Dict[ module_id, module_class ]
 
     Returns:
-        Dict[str, caikit.core.ModuleBase]
-            The module registry
+        Dict[str, caikit.core.ModuleBase]: The module registry
     """
     return MODULE_REGISTRY
 
@@ -66,8 +65,8 @@ def module_backend_registry() -> Dict[
     Dict[ module_id, Dict[ backend_type, Tuple[ backend_impl_class, backend_config_dict ] ] ]
 
     Returns:
-        Dict[str, Dict[str, Tuple["caikit.core.BackendBase", Dict]]]
-            The module backend registry
+        Dict[str, Dict[str, Tuple["caikit.core.BackendBase", Dict]]]: The module
+            backend registry
     """
     # TODO: put a real data structure here instead of nested dicts
     return MODULE_BACKEND_REGISTRY

--- a/caikit/core/signature_parsing/docstrings.py
+++ b/caikit/core/signature_parsing/docstrings.py
@@ -265,14 +265,13 @@ def _extract_type_from_pymodule(
     """This walks down a type hierarchy to try to find the concrete type given an input string name
 
     Args:
-        py_module: Type | Dict
-            A python module, or dictionary of modules, to start walking to find "type_name"
-        type_name: str
-            The name of the type that we're trying to find. e.g. "caikit.core.data_model.ProducerId"
+        py_module (Type | Dict): A python module, or dictionary of modules, to
+            start walking to find "type_name"
+        type_name (str): The name of the type that we're trying to find. e.g.
+            "caikit.core.data_model.ProducerId"
 
     Returns:
-        Optional[Type]
-            The type of "type_name", or None if it cannot be found
+        Optional[Type]: The type of "type_name", or None if it cannot be found
     """
     output_type = py_module
 

--- a/caikit/core/signature_parsing/parsers.py
+++ b/caikit/core/signature_parsing/parsers.py
@@ -203,9 +203,8 @@ def _get_default_type(arg: inspect.Parameter) -> Optional[Type]:
     Tries to infer a type from the default value of the argument
     Args:
         arg: (inspect.Parameter) The inspected argument
-
-    Returns: (Optional[Type]) The type of the argument,
-        or None if no default value is present
+    Returns: (Optional[Type]) The type of the argument,: or None if no default value is
+        present
     """
     if arg.default != inspect.Parameter.empty and arg.default is not None:
         log.debug3("Found default with type %s", type(arg.default))

--- a/caikit/core/task.py
+++ b/caikit/core/task.py
@@ -203,8 +203,7 @@ def task(
     Args:
         required_parameters (Dict[str, ValidInputTypes]): The required parameters that all public
             models' .run functions must contain. A dictionary of parameter name to parameter
-            type, where the types can be in the set of:
-                - Python primitives
+            type, where the types can be in the set of: - Python primitives
                 - Caikit data models
                 - Iterable containers of the above
                 - Caikit model references (maybe?)

--- a/caikit/core/toolkit/compatibility.py
+++ b/caikit/core/toolkit/compatibility.py
@@ -33,8 +33,8 @@ def unsupported_platforms(platforms):
     see: https://docs.python.org/3/library/sys.html#sys.platform
 
     Args:
-        platforms: List | Tuple | str
-            Platforms on which this capability is not implemented.
+        platforms (List | Tuple | str): Platforms on which this capability is
+            not implemented.
     """
     error.type_check("<COR48137162E>", list, tuple, str, platforms=platforms)
     if not isinstance(platforms, str):
@@ -74,16 +74,14 @@ def is_importable_on_platform(module, package, exc_type, platforms, platform_hin
     raise on other platforms.
 
     Args:
-        module: str
-            Module that we want to import.
-        package: str
-            Package from which we want to import the module.
-        exc_type: Exception
-            Exception that we want to warn a hint for if we hit it on import for a given platform.
-        platforms: str
-            Platform on which we expect potential bad import from for this module.
-        platform_hint: str
-            Hint to warn if we hit the exception type on the provided platform.
+        module (str): Module that we want to import.
+        package (str): Package from which we want to import the module.
+        exc_type (Exception): Exception that we want to warn a hint for if we
+            hit it on import for a given platform.
+        platforms (str): Platform on which we expect potential bad import from
+            for this module.
+        platform_hint (str): Hint to warn if we hit the exception type on the
+            provided platform.
     """
     error.type_check(
         "<COR48442162E>",

--- a/caikit/core/toolkit/errors/error_handler.py
+++ b/caikit/core/toolkit/errors/error_handler.py
@@ -35,14 +35,14 @@ def get(log_chan):
     be returned if this function is called repeatedly with the same log channel.
 
     Args:
-        name:  alog channel
+        name: alog channel
             An alog log channel.
 
     Returns:
-        ErrorHandler
-            An instance of `ErrorHandler` associated with `log_chan` that can be used to perform
-            various error checks and to raise exceptions while also automatically logging
-            appropriate message on `log_chan`.
+        ErrorHandler: An instance of `ErrorHandler` associated with `log_chan`
+            that can be used to perform various error checks and to raise
+            exceptions while also automatically logging appropriate message on
+            `log_chan`.
     """
     return _error_handlers.setdefault(log_chan.name, ErrorHandler(log_chan))
 
@@ -57,7 +57,7 @@ class ErrorHandler:
         """Create a new error handler that provides reusable error checking and automatic logging.
 
         Args:
-            log_chan:  alog channel
+            log_chan: alog channel
                 The logging channel that this error handle will use for logging.
         """
         self.log_chan = log_chan
@@ -100,14 +100,14 @@ class ErrorHandler:
         debugging in environments where stack traces are not available.
 
         Args:
-            log_code:  str
-                A log code with format `<COR12345678E>` where `COR` is a short code for the library
-                (for `caikit_core` in this example) and where `12345678` is a unique eight-digit
-                identifier (example generation in `scripts/cor_log_code`) and where `E` is an error
-                level short-code, one of `{'fatal': 'F', 'error': 'E', 'warning': 'W', 'info': 'I',
-                'trace': 'T', 'debug': 'D'}`.
-            exception:  Exception
-                A python exception object or an instance of any subclass of `Exception`.
+            log_code (str): A log code with format `<COR12345678E>` where `COR`
+                is a short code for the library (for `caikit_core` in this
+                example) and where `12345678` is a unique eight-digit identifier
+                (example generation in `scripts/cor_log_code`) and where `E` is
+                an error level short-code, one of `{'fatal': 'F', 'error': 'E',
+                'warning': 'W', 'info': 'I', 'trace': 'T', 'debug': 'D'}`.
+            exception (Exception): A python exception object or an instance of
+                any subclass of `Exception`.
             root_exception: Exception (Optional)
                 A python exception object or an instance of any subclass of `Exception` which is
                 considered a 'root' exception, wrapped by the preceding exception. Done in cases
@@ -140,26 +140,27 @@ class ErrorHandler:
         a function that expects a string is actually an instance of a string.
 
         Args:
-            log_code:  str
-                A log code with format `<COR90063501E>` where `COR` is a short code for the library
-                (for `caikit_core` in this example) and where `90063501` is a unique eight-digit
-                identifier (example generation in `scripts/cor_log_code`) and where `E` is an error
-                level short-code, one of `{'fatal': 'F', 'error': 'E', 'warning': 'W', 'info': 'I',
-                'trace': 'T', 'debug': 'D'}`.
-            *types:  type or None
-                Variadic arguments containing all acceptable types for `variables`.  If any values
-                of `variable` are not any of `*types` then a log message will be emitted and a
-                `TypeError` will be raised.  Multiple types may be specified as separate arguments.
-                If no types are specified, then a `RuntimeError` will be raised.
-            allow_none:  bool
-                If `True` then the values of `variables` are allowed to take on the value of `None`
-                without causing the type check to fail.  If `False` (default) then `None` values
-                will cause the type check to fail.
-            **variables:  object
-                Variadic keyword arguments to be examined for acceptable type.  The name of the
-                variable is used in log and error messages while its value is actually check against
-                `types`.  Multiple keyword variables may be specified.  If no variables are
-                specified, then a `RuntimeError` will be raised.
+            log_code (str): A log code with format `<COR90063501E>` where `COR`
+                is a short code for the library (for `caikit_core` in this
+                example) and where `90063501` is a unique eight-digit identifier
+                (example generation in `scripts/cor_log_code`) and where `E` is
+                an error level short-code, one of `{'fatal': 'F', 'error': 'E',
+                'warning': 'W', 'info': 'I', 'trace': 'T', 'debug': 'D'}`.
+            *types (type or None): Variadic arguments containing all acceptable
+                types for `variables`.  If any values of `variable` are not any
+                of `*types` then a log message will be emitted and a `TypeError`
+                will be raised.  Multiple types may be specified as separate
+                arguments. If no types are specified, then a `RuntimeError` will
+                be raised.
+            allow_none (bool): If `True` then the values of `variables` are
+                allowed to take on the value of `None` without causing the type
+                check to fail.  If `False` (default) then `None` values will
+                cause the type check to fail.
+            **variables (object): Variadic keyword arguments to be examined for
+                acceptable type.  The name of the variable is used in log and
+                error messages while its value is actually check against
+                `types`.  Multiple keyword variables may be specified.  If no
+                variables are specified, then a `RuntimeError` will be raised.
 
         Examples:
             # this will raise a `TypeError` because `foo` is not `None` or a `list` or `tuple`
@@ -287,28 +288,25 @@ class ErrorHandler:
         subclass.
 
         Args:
-            log_code:  str
-                A log code with format `<COR90063501E>` where `COR` is a short
-                code for the library (for `caikit_core` in this example) and
-                where `90063501` is a unique eight-digit identifier and where
-                `E` is an error level short-code, one of `{'fatal': 'F',
-                'error': 'E', 'warning': 'W', 'info': 'I', 'trace': 'T',
+            log_code (str): A log code with format `<COR90063501E>` where `COR`
+                is a short code for the library (for `caikit_core` in this
+                example) and where `90063501` is a unique eight-digit identifier
+                and where `E` is an error level short-code, one of `{'fatal':
+                'F', 'error': 'E', 'warning': 'W', 'info': 'I', 'trace': 'T',
                 'debug': 'D'}`.
-            child_class:  Any
-                The class to be examined for acceptable class inheritance.
-            *parent_classes:  type
-                Variadic arguments containing all acceptable parent types for
-                `child_classes`.  If any values of `child_classes` are not a
-                valid type derived from one of `*parent_classes` then a log
-                message will be emitted and a `TypeError` will be raised.
-                Multiple parent_classes may be specified as separate arguments.
-                If no parent_classes are specified, then a `RuntimeError` will
-                be raised.
-            allow_none:  bool
-                If `True` then the values of `child_classes` are allowed to take
-                on the value of `None` without causing the subclass check to
-                fail.  If `False` (default) then `None` values will cause the
-                subclass check to fail.
+            child_class (Any): The class to be examined for acceptable class
+                inheritance.
+            *parent_classes (type): Variadic arguments containing all acceptable
+                parent types for `child_classes`.  If any values of
+                `child_classes` are not a valid type derived from one of
+                `*parent_classes` then a log message will be emitted and a
+                `TypeError` will be raised. Multiple parent_classes may be
+                specified as separate arguments. If no parent_classes are
+                specified, then a `RuntimeError` will be raised.
+            allow_none (bool): If `True` then the values of `child_classes` are
+                allowed to take on the value of `None` without causing the
+                subclass check to fail.  If `False` (default) then `None` values
+                will cause the subclass check to fail.
 
         Examples:
             # this will raise a `TypeError` because `Foo` is not `None` or
@@ -353,18 +351,17 @@ class ErrorHandler:
         a numerical value has an appropriate range.
 
         Args:
-            log_code:  str
-                A log code with format `<COR55705215E>` where `COR` is a short code for the library
-                (for `caikit_core` in this example) and where `55705215` is a unique eight-digit
-                identifier (example generation in `scripts/cor_log_code`) and where `E` is an error
-                level short-code, one of `{'fatal': 'F', 'error': 'E', 'warning': 'W', 'info': 'I',
-                'trace': 'T', 'debug': 'D'}`.
-            condition:  bool
-                A boolean value that should describe if this check passes `True` or fails `False`.
-                Upon calling this function, this is typically provided as an expression, e.g.,
-                `0 < variable < 1`.
-            *args:
-                A variable set of arguments describing the value check that failed. If no
+            log_code (str): A log code with format `<COR55705215E>` where `COR`
+                is a short code for the library (for `caikit_core` in this
+                example) and where `55705215` is a unique eight-digit identifier
+                (example generation in `scripts/cor_log_code`) and where `E` is
+                an error level short-code, one of `{'fatal': 'F', 'error': 'E',
+                'warning': 'W', 'info': 'I', 'trace': 'T', 'debug': 'D'}`.
+            condition (bool): A boolean value that should describe if this check
+                passes `True` or fails `False`. Upon calling this function, this
+                is typically provided as an expression, e.g., `0 < variable <
+                1`.
+            *args: A variable set of arguments describing the value check that failed. If no
                 args are provided then an empty msg string is assumed and no additional
                 information will be provided, otherwise the first argument will be treated as 'msg'
                 argument. Note that string interpolation can be lazily performed on `msg` using `{}`
@@ -393,16 +390,16 @@ class ErrorHandler:
         error handler and a `FileNotFoundError` will be raised with an appropriate error message.
 
         Args:
-            log_code:  str
-                A log code with format `<COR73692990E>` where `COR` is a short code for the library
-                (for `caikit_core` in this example) and where `55705215` is a unique eight-digit
-                identifier (example generation in `scripts/cor_log_code`) and where `E` is an error
-                level short-code, one of `{'fatal': 'F', 'error': 'E', 'warning': 'W', 'info': 'I',
-                'trace': 'T', 'debug': 'D'}`.
-            *file_paths:  str
-                Variadic argument containing strings specifying the file paths to check.  If any
-                of these file paths does not exist or is not a regular file, then a
-                log message will be emitted and a `FileNotFoundError` will be raised.
+            log_code (str): A log code with format `<COR73692990E>` where `COR`
+                is a short code for the library (for `caikit_core` in this
+                example) and where `55705215` is a unique eight-digit identifier
+                (example generation in `scripts/cor_log_code`) and where `E` is
+                an error level short-code, one of `{'fatal': 'F', 'error': 'E',
+                'warning': 'W', 'info': 'I', 'trace': 'T', 'debug': 'D'}`.
+            *file_paths (str): Variadic argument containing strings specifying
+                the file paths to check.  If any of these file paths does not
+                exist or is not a regular file, then a log message will be
+                emitted and a `FileNotFoundError` will be raised.
         """
         if not get_config().enable_error_checks:
             return
@@ -429,16 +426,17 @@ class ErrorHandler:
         log channel associated with this error handler.
 
         Args:
-            log_code:  str
-                A log code with format `<COR63462828E>` where `COR` is a short code for the library
-                (for `caikit_core` in this example) and where `55705215` is a unique eight-digit
-                identifier (example generation in `scripts/cor_log_code`) and where `E` is an error
-                level short-code, one of `{'fatal': 'F', 'error': 'E', 'warning': 'W', 'info': 'I',
-                'trace': 'T', 'debug': 'D'}`.
-            *dir_paths:  str
-                Variadic argument containing strings specifying the directory paths to check.  If
-                any of these file paths does not exist or is not a regular file, then a log message
-                will be emitted and a `FileNotFoundError` or `NotADirectoryError` will raised.
+            log_code (str): A log code with format `<COR63462828E>` where `COR`
+                is a short code for the library (for `caikit_core` in this
+                example) and where `55705215` is a unique eight-digit identifier
+                (example generation in `scripts/cor_log_code`) and where `E` is
+                an error level short-code, one of `{'fatal': 'F', 'error': 'E',
+                'warning': 'W', 'info': 'I', 'trace': 'T', 'debug': 'D'}`.
+            *dir_paths (str): Variadic argument containing strings specifying
+                the directory paths to check.  If any of these file paths does
+                not exist or is not a regular file, then a log message will be
+                emitted and a `FileNotFoundError` or `NotADirectoryError` will
+                raised.
         """
         if not get_config().enable_error_checks:
             return

--- a/caikit/core/toolkit/fileio.py
+++ b/caikit/core/toolkit/fileio.py
@@ -135,8 +135,7 @@ def compress(dir_path, output_path=None, extension="zip"):
     """Compress a given folder recursively to an archive with a given extension format
 
     Args:
-        dir_path: str
-            Path of directory to compress
+        dir_path (str): Path of directory to compress
         output_path: (Optional) str
             Output path where the archive is created. Defaults to current path + 'archive' +
             format extension
@@ -147,8 +146,7 @@ def compress(dir_path, output_path=None, extension="zip"):
             Defaults to .zip
 
     Returns:
-        str
-            Path to created archive
+        str: Path to created archive
     """
     if not output_path:
         output_path = os.path.join(os.getcwd(), "archive")

--- a/caikit/core/toolkit/quality_evaluation.py
+++ b/caikit/core/toolkit/quality_evaluation.py
@@ -78,8 +78,8 @@ class QualityEvaluator:
         """Main entry point for evaluation.
 
         Args:
-            evaluation_type:  str
-                Which type of evaluation to run. Only a few are currently supported.
+            evaluation_type (str): Which type of evaluation to run. Only a few
+                are currently supported.
             find_label_func: function to fetch labels from any one prediction, used in
                 multiclass multilabel evaluation.
                 eg: if a prediction is of form (token, label), this function should be
@@ -94,20 +94,20 @@ class QualityEvaluator:
                               (currently only for multiclass multilabel eval type)
                               Detailed metrics give us metrics for every example, and
                               metrics using a custom partial match function
-            labels:  list (Optional, defaults to None)
+            labels: list (Optional, defaults to None)
                 Optional list of class labels to evaluate quality on. By default evaluation is done
                 over all class labels. Using this, you can explicitly mention only a subset of
                 labels to include in the quality evaluation.
             partial_match_metrics: flag to indicate whether or not you want partial match
                                    micro avg metrics.
                                    (currently only for multiclass multilabel eval type)
-            max_hierarchy_levels: int
-                Used in hierarchical multilabel multiclass evaluation only. The number of levels
-                in the hierarchy to run model evaluation on, in addition to complete matches.
+            max_hierarchy_levels (int): Used in hierarchical multilabel
+                multiclass evaluation only. The number of levels in the
+                hierarchy to run model evaluation on, in addition to complete
+                matches.
 
         Returns:
-            dict
-                Full results from evaluation on dataset and model.
+            dict: Full results from evaluation on dataset and model.
         """
         if evaluation_type == EvalTypes.MULTILABEL_MULTICLASS:
             return self.multilabel_multiclass_evaluation(
@@ -134,30 +134,22 @@ class QualityEvaluator:
 
         Args:
             Note: here class should be initialized with gold and pred in the following format
-                self.gold: list
-                    list of gold set labels for every example,
-                    where each example can have only one label
-                    eg: ['label1','label2', 'label3', 'label4']
-                self.pred: list
-                    Predicted-by-the-model set labels for every example.
-            labels:  list (Optional, defaults to None)
+            Noneself.gold (list): list of gold set labels for every example, where each example
+                can have only one label eg: ['label1','label2', 'label3','label4']
+            self.pred (list): Predicted-by-the-model set labels for every example.
+            labels: list (Optional, defaults to None)
                 Optional list of class labels to evaluate quality on. By default evaluation is done
                 over all class labels. Using this, you can explicitly mention only a subset of
                 labels to include in the quality evaluation.
 
         Returns:
-            dict
-                Dictionary looks like: {
-                    'per_class_confusion_matrix': {'entity_type': {'true_positive': int ...}}
-                    'macro_precision': 0 <= float <= 1,
-                    'macro_recall': 0 <= float <= 1,
-                    'macro_f1': 0 <= float <= 1,
-                    'micro_precision': 0 <= float <= 1,,
-                    'micro_recall': 0 <= float <= 1,,
-                    'micro_f1': 0 <= float <= 1,
-                    'overall_tp': int,
-                    'overall_fp': int,
-                    'overall_fn': int
+            dict: Dictionary looks like: { 'per_class_confusion_matrix':
+                {'entity_type': {'true_positive': int ...}} 'macro_precision': 0
+                <= float <= 1, 'macro_recall': 0 <= float <= 1, 'macro_f1': 0 <=
+                float <= 1, 'micro_precision': 0 <= float <= 1,, 'micro_recall':
+                0 <= float <= 1,, 'micro_f1': 0 <= float <= 1, 'overall_tp':
+                int, 'overall_fp': int, 'overall_fn': int
+
 
                 }
         """
@@ -220,14 +212,12 @@ class QualityEvaluator:
 
         Args:
             Note: here class should be initialized with gold and pred in the following format
-                self.gold: list(list)
-                    list of gold set labels for every example
-                    eg: [['label1','label2'], ['label1', 'label4']]
-                self.pred: list(list)
-                    Predicted-by-the-model set labels for every example.
+                Noneself.gold (list(list)): list of gold set labels for every example eg:
+                    [['label1','label2'], ['label1', 'label4']]
+                self.pred (list(list)): Predicted-by-the-model set labels for every example.
             find_label_func: function to fetch labels from any one prediction
-            find_label_data_func: function to fetch data that belongs to a certain class
-            labels:  list (Optional, defaults to None)
+            Nonefind_label_data_func: function to fetch data that belongs to a certain class
+            Nonelabels: list (Optional, defaults to None)
                 Optional list of class labels to evaluate quality on. By default evaluation is done
                 over all class labels. Using this, you can explicitly mention only a subset of
                 labels to include in the quality evaluation.
@@ -236,25 +226,20 @@ class QualityEvaluator:
                               metrics using a custom partial match function
             partial_match_metrics: flag to indicate whether or not you want partial match
                                    micro avg metrics.
-            use_labels_for_matching: bool
-                Indicates whether or not we should use the output of find_label_func for metric
-                computations, or the raw data tuples.
+            use_labels_for_matching (bool): Indicates whether or not we should
+                use the output of find_label_func for metric computations, or
+                the raw data tuples.
 
         Returns:
-            dict
-                Dictionary looks like: {
-                    'per_class_confusion_matrix': {'entity_type': {'true_positive': int ...}}
-                    'macro_precision': 0 <= float <= 1,
-                    'macro_recall': 0 <= float <= 1,
-                    'macro_f1': 0 <= float <= 1,
-                    'micro_precision': micro_precision,
-                    'micro_recall': micro_recall,
-                    'micro_f1': micro_f1,
-                    'detailed_metrics' : {'exact_match_precision'..,'partial_match_precision'}
-                    'micro_precision_partial_match': 0 <= float <= 1,
-                    'micro_recall_partial_match': 0 <= float <= 1,
-                    'micro_f1_partial_match': 0 <= float <= 1
-                }
+            dict: Dictionary looks like: { 'per_class_confusion_matrix':
+                {'entity_type': {'true_positive': int ...}} 'macro_precision': 0
+                <= float <= 1, 'macro_recall': 0 <= float <= 1, 'macro_f1': 0 <=
+                float <= 1, 'micro_precision': micro_precision, 'micro_recall':
+                micro_recall, 'micro_f1': micro_f1, 'detailed_metrics' :
+                {'exact_match_precision'..,'partial_match_precision'}
+                'micro_precision_partial_match': 0 <= float <= 1,
+                'micro_recall_partial_match': 0 <= float <= 1,
+                'micro_f1_partial_match': 0 <= float <= 1 }
         """
         gold, pred = self.gold, self.pred
         assert len(gold) == len(
@@ -451,20 +436,20 @@ class QualityEvaluator:
         hierarchy.
 
         Args:
-            find_label_func_builder: function
-                A function that takes in a level number (or None if full hierarchy) and returns a
-                find_label_func for this level that can be passed to the multilabel multiclass
+            find_label_func_builder (function): A function that takes in a level
+                number (or None if full hierarchy) and returns a find_label_func
+                for this level that can be passed to the multilabel multiclass
                 evaluator.
-            find_label_data_func_builder: function
-                A function that takes in a level number (or None if full hierarchy) and returns a
-                find_label_data_func for this level that can be passed to the multilabel multiclass
-                evaluator.
-            max_hierarchy_levels: int
-                The number of levels to run in the hierarchy, in addition to complete match.
+            find_label_data_func_builder (function): A function that takes in a
+                level number (or None if full hierarchy) and returns a
+                find_label_data_func for this level that can be passed to the
+                multilabel multiclass evaluator.
+            max_hierarchy_levels (int): The number of levels to run in the
+                hierarchy, in addition to complete match.
         Returns:
-            dict
-                Dictionary, where each key is a level number, or 'FULL', and maps to the dict
-                returned by multilabel_multiclass_evaluation for that level of the hierarchy.
+            dict: Dictionary, where each key is a level number, or 'FULL', and
+                maps to the dict returned by multilabel_multiclass_evaluation
+                for that level of the hierarchy.
         """
         metrics = {}
         # Levels are None [FULL], and 1...n, where n is the deepest level in the hierarchy (for now,
@@ -491,15 +476,11 @@ class QualityEvaluator:
     def calc_f1_score(gold, pred, match_fun=None):
         """Calculates F1 score
         Args:
-            gold: list
-                List of gold annotations
-            pred: list
-                List of predictions
+            gold (list): List of gold annotations
+            pred (list): List of predictions
             match_fun: Function that finds the matches and returns tuple of matched gold, preds
-
         Returns:
-            tuple
-                Precision, Recall, F1 score
+            tuple: Precision, Recall, F1 score
         """
         if match_fun:
             # In case of partial match, matched predictions need not equal matched gold
@@ -544,16 +525,13 @@ class QualityEvaluator:
            Overlaps are not considered.
 
         Args:
-            groundtruth: list
-                Groundtruth data
-            prediction: list
-                Predictions returned by the model
+            groundtruth (list): Groundtruth data
+            prediction (list): Predictions returned by the model
 
         Returns:
-            tuple
-                gold_matched: set, pred_matched: set
-                    gold annotations that were matched
-                    Predictions that partially or fully matched with groundtruth
+            tuple: gold_matched: set, pred_matched: set gold annotations that
+                were matched Predictions that partially or fully matched with
+                groundtruth
         """
 
         gold_matched = set()
@@ -585,14 +563,14 @@ class QualityEvaluator:
            statistics per class label.
 
         Args:
-            per_class_confusion_matrix: Dict[str, F1Metrics]
-                 Dictionary of statistics per class label. Class labels are keys for the
-                 dictionary. For each class label, there should be a F1Metrics class object with
-                 values true positive, false_positive , false_negative representating the count
-                 of these per class. The dictionary looks like:
-                 per_class_confusion_matrix[label] = F1Metrics(true_positive = val 1,
-                                                                            false_positive = val 2,
-                                                                            false_negative = val 3)
+            per_class_confusion_matrix (Dict[str, F1Metrics]): Dictionary of
+                 statistics per class label. Class labels are keys for the
+                 dictionary. For each class label, there should be a F1Metrics
+                 class object with values true positive, false_positive ,
+                 false_negative representating the count of these per class. The
+                 dictionary looks like: per_class_confusion_matrix[label] =
+                 F1Metrics(true_positive = val 1, false_positive = val 2,
+                 false_negative = val 3)
 
         Returns:
             Returns:
@@ -674,8 +652,8 @@ class QualityEvaluator:
     def convert_F1MetricsContainer_to_dict(metrics_summary: F1MetricsContainer) -> dict:
         """
         Args:
-            metrics_summary: F1MetricsContainer
-                 An object of dataclass F1MetricsContainer
+            metrics_summary (F1MetricsContainer): An object of dataclass
+                 F1MetricsContainer
 
         Returns:
             Returns:

--- a/caikit/core/toolkit/serializers.py
+++ b/caikit/core/toolkit/serializers.py
@@ -30,10 +30,9 @@ class ObjectSerializer(abc.ABC):
         """Serialize the provided object to the specified file path.
 
         Args:
-            obj:  object
-                The object to serialize
-            file_path:  str
-                Absolute path to which the object should be serialized
+            obj (object): The object to serialize
+            file_path (str): Absolute path to which the object should be
+                serialized
         """
 
 
@@ -44,10 +43,9 @@ class JSONSerializer(ObjectSerializer):
         """Serialize the provided object to a JSON file.
 
         Args:
-            obj:  object
-                The object to serialize
-            file_path:  str
-                Absolute path to which the object should be serialized
+            obj (object): The object to serialize
+            file_path (str): Absolute path to which the object should be
+                serialized
         """
         fileio.save_json(obj, file_path)
 
@@ -59,10 +57,9 @@ class TextSerializer(ObjectSerializer):
         """Serialize the provided python list to a text file.
 
         Args:
-            obj:  list(str)
-                The list to serialize
-            file_path:  str
-                Absolute path to which the object should be serialized
+            obj (list(str)): The list to serialize
+            file_path (str): Absolute path to which the object should be
+                serialized
         """
         lines = "\n".join(obj)
         fileio.save_txt(lines, file_path)
@@ -75,10 +72,9 @@ class YAMLSerializer(ObjectSerializer):
         """Serialize the provided object to a YAML file.
 
         Args:
-            obj:  object
-                The object to serialize
-            file_path:  str
-                Absolute path to which the object should be serialized
+            obj (object): The object to serialize
+            file_path (str): Absolute path to which the object should be
+                serialized
         """
         fileio.save_yaml(obj, file_path)
 
@@ -90,10 +86,9 @@ class CSVSerializer(ObjectSerializer):
         """Serialize the provided object to a CSV file.
 
         Args:
-            obj:  object
-                The object to serialize
-            file_path:  str
-                Absolute path to which the object should be serialized
+            obj (object): The object to serialize
+            file_path (str): Absolute path to which the object should be
+                serialized
         """
         fileio.save_csv(obj, file_path)
 
@@ -105,9 +100,8 @@ class PickleSerializer(ObjectSerializer):
         """Serialize the provided object to a CSV file.
 
         Args:
-            obj: any
-                The object to serialize
-            file_path:  str
-                Absolute path to which the object should be serialized
+            obj (any): The object to serialize
+            file_path (str): Absolute path to which the object should be
+                serialized
         """
         fileio.save_pickle(obj, file_path)

--- a/caikit/core/toolkit/wip_decorator.py
+++ b/caikit/core/toolkit/wip_decorator.py
@@ -93,10 +93,9 @@ def work_in_progress(*args, **kwargs):
     when the function / class is used.
 
     Args:
-        category: WipCategory
-            Enum specifying what category of message you want to throw
-        action: Action
-            Enum specifying what type of action you want to take.
+        category (WipCategory): Enum specifying what category of message you
+            want to throw
+        action (Action): Enum specifying what type of action you want to take.
             Example: ERROR or WARNING
 
     Example Usage:
@@ -165,12 +164,11 @@ def _decorator_handler(wrapped_obj, category, action):
     """Utility function to cover common decorator handling
     logic.
     Args:
-        wrapped_obj: Callable
-            Class or function to be decorated
-        category: Enum(WipCategory)
-            Enum specifying the category of the message
-        Action: Enum(Action)
-            Enum specifying the action to be taken with the decorator
+        wrapped_obj (Callable): Class or function to be decorated
+        category (Enum(WipCategory)): Enum specifying the category of the
+            message
+        Action (Enum(Action)): Enum specifying the action to be taken with the
+            decorator
     Returns:
         function:
             Decorator function

--- a/caikit/interfaces/common/data_model/producer.py
+++ b/caikit/interfaces/common/data_model/producer.py
@@ -44,7 +44,7 @@ class ProducerPriority(DataObjectBase):
         """Construct a new ProducerPriority
 
         Args:
-            producers:  list(ProducerId)
+            producers (list(ProducerId))
         """
         error.type_check_all("<COR01353088E>", ProducerId, producers=producers)
         self.producers = producers

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -295,18 +295,13 @@ class RuntimeGRPCServer:
     def _find_port(cls, start=8888, end=None, host="127.0.0.1"):
         """Function to find an available port in a given range
         Args:
-            start: int
-                Starting number for port search (inclusive)
-                Default: 8888
-            end: Optional[int]
-                End number for port search (exclusive)
-                Default: start + 1000
-            host: str
-                Host name or ip address to search on
-                Default: localhost
+            start (int): Starting number for port search (inclusive) Default:
+                8888
+            end (Optional[int]): End number for port search (exclusive) Default:
+                start + 1000
+            host (str): Host name or ip address to search on Default: localhost
         Returns:
-            int
-                Available port
+            int: Available port
         """
         end = start + 1000 if end is None else end
         if start < end:

--- a/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
+++ b/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
@@ -298,7 +298,6 @@ class CaikitRuntimeServerWrapper(grpc.Server):
             if the port is 0, or not specified in the address, then gRPC
             runtime will choose a port.
           server_credentials: A ServerCredentials object.
-
         Returns:
           integer:
           An integer port on which server will accept RPC requests.
@@ -333,7 +332,6 @@ class CaikitRuntimeServerWrapper(grpc.Server):
 
         Args:
           grace: A duration of time in seconds or None.
-
         Returns:
           A threading.Event that will be set when this Server has completely
           stopped, i.e. when running RPCs either complete or are aborted and

--- a/caikit/runtime/metrics/rpc_meter.py
+++ b/caikit/runtime/metrics/rpc_meter.py
@@ -47,8 +47,7 @@ class RPCMeter:
     def update_metrics(self, model_type):
         """Updates metrics, writes to file if max count has reached and resets counters
         Args:
-            model_type: string
-                Type of model the request was made for
+            model_type (string): Type of model the request was made for
         """
         # Locking to ensure that with concurrent updates to counters, the latest metrics are
         # reported

--- a/caikit/runtime/model_management/batcher.py
+++ b/caikit/runtime/model_management/batcher.py
@@ -50,17 +50,13 @@ class Batcher:
         most the given size with the given delay to collect a batch.
 
         Args:
-            model_name:  str
-                The name of this model for error reporting
-            model:  ModuleBase
-                The model instance that will have inputs batched
-            batch_size:  int
-                The maximum size of a batch that will be sent to run_batch.
-                Batches of smaller sizes will be sent if no additional requests
-                are available.
-            batch_collect_delay_s:  Optional[float]
-                Number of seconds to wait for more requests to show up when
-                filling the batch.
+            model_name (str): The name of this model for error reporting
+            model (ModuleBase): The model instance that will have inputs batched
+            batch_size (int): The maximum size of a batch that will be sent to
+                run_batch. Batches of smaller sizes will be sent if no
+                additional requests are available.
+            batch_collect_delay_s (Optional[float]): Number of seconds to wait
+                for more requests to show up when filling the batch.
         """
         self._model_name = model_name
         self._model = model

--- a/caikit/runtime/model_management/model_sizer.py
+++ b/caikit/runtime/model_management/model_sizer.py
@@ -49,9 +49,8 @@ class ModelSizer:
         Returns the estimated memory footprint of a model
         Args:
             model_id: The model identifier, used for informative logging
-            cos_model_path: The path to the model archive in S3 storage
-            model_type: The type of model, used to adjust the memory estimate
-
+            Nonecos_model_path: The path to the model archive in S3 storage
+            Nonemodel_type: The type of model, used to adjust the memory estimate
         Returns:
             The estimated size in bytes of memory that would be used by loading this model
         """

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -34,8 +34,7 @@ def to_protoable_signature(signature: Dict[str, Type]) -> Dict[str, Type]:
     If there is a Union, pick the protoable type
 
     Args:
-        signature: Dict[str, Type]
-            module signature of parameters and types
+        signature (Dict[str, Type]): module signature of parameters and types
     """
     protoables = {}
     log.debug("Building protoable signature for %s", signature)

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -201,9 +201,7 @@ class GlobalPredictServicer:
                 The ID of the loaded model
             aborter (Optional[CallAborter]):
                 If using abortable calls, this is the aborter to use
-            **kwargs:
-                Keyword arguments to pass to the model's run function
-
+            **kwargs: Keyword arguments to pass to the model's run function
         Returns:
             response (Union[DataBase, Iterable[DataBase]]):
                 The object (unary) or objects (output stream) produced by the

--- a/caikit/runtime/utils/import_util.py
+++ b/caikit/runtime/utils/import_util.py
@@ -126,10 +126,8 @@ def _get_cdm_from_lib(lib_name: str, cdm: UnifiedDataModel):
     """Function to get caikit core CDM from library name
 
     Args:
-        lib_name: str
-            Caikit core library name
-        cdm: UnifiedDataModel
-            Caikit core CDM
+        lib_name (str): Caikit core library name
+        cdm (UnifiedDataModel): Caikit core CDM
     Returns:
         cdm: UnifiedDataModel
     """

--- a/caikit/runtime/work_management/destroyable_thread.py
+++ b/caikit/runtime/work_management/destroyable_thread.py
@@ -135,11 +135,11 @@ class DestroyableThread(threading.Thread):
 
     def get_or_throw(self):
         """
-            After the thread has completed it's work, call this to get the output.
-        Returns:
-            The resulting value of runnable_func(*runnable_args, **runnable_kwargs)
+                    After the thread has completed it's work, call this to get the output.
+                Returns:
+                    The resulting value of runnable_func(*runnable_args, **runnable_kwargs)
         Raises:
-            Any exception raised by runnable_func(*runnable_args, **runnable_kwargs)
+                    Any exception raised by runnable_func(*runnable_args, **runnable_kwargs)
         """
         if self.__destroyed:
             log.error(

--- a/scripts/dsconverter.py
+++ b/scripts/dsconverter.py
@@ -1,0 +1,256 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+import argparse
+import ast
+import os
+import re
+import textwrap
+
+
+class CustomDocstringConverter:
+    """A class for converting custom style docstrings to Google style."""
+
+    @staticmethod
+    def extract_docstrings_from_file(file_path):
+        """Extracts docstrings from the specified file.
+        Args:
+            file_path (str): Path to the file.
+        Returns:
+            list: List of extracted docstrings.
+        """
+        with open(file_path, "r") as file:
+            file_contents = file.read()
+
+        # Parse the file contents into an abstract syntax tree (AST)
+        tree = ast.parse(file_contents)
+
+        # Collect all docstrings
+        docstrings = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.ClassDef, ast.Module))
+                and node.body
+            ):
+                # Check if the node has a docstring
+                if isinstance(node.body[0], ast.Expr) and isinstance(
+                    node.body[0].value, ast.Str
+                ):
+                    docstring = node.body[0].value.s
+                    docstrings.append(docstring)
+
+        return docstrings
+
+    def convert_to_google_style(self, custom_docstring):
+        """Converts a docstring to Google style.
+        Args:
+            custom_docstring (str): The original docstring.
+        Returns:
+            str: The converted docstring in Google style.
+        """
+
+        # # Extract the name, data type, and description of arguments using regular expressions
+        # arg_pattern = r"(?!Args)(?!rgs)(?!gs)(?!s)(\*\*\w+|\*\w+|\w+):\s*((?:\w+\s*\
+        #     |\s*)*(?:\w+\s*\|)?\s*(?:\w+(?:\.\w+)*\s+\([^)]+\)|\w+(?:\.\w+)*|\w+(?:\
+        #         .\w+)*\s*\|\s*\w+(?:\.\w+)*))\s*\n\s*((?:(?!:\s*Returns:\s).)*?)($|\n)"
+
+        # # Extract the white space, data type, and description of returns using regular expressions
+        # ret_pattern = r"Returns:(\s*)(?!.*:)([^:\n]+)\n(\s+)((?:.*(?:\n(?!\n)|$).*)*)(\n|\"\"\")"
+
+        # def arg_replacement(match):
+        #     name, data_type, description, _ = match.groups()
+        #     return f"{name} ({data_type}): {textwrap.dedent(description)}\n"
+
+        # # Replace the argument pattern matches with the converted parts
+        # converted_docstring = re.sub(arg_pattern, arg_replacement, converted_docstring)
+
+        # return converted_docstring
+
+        # converted_docstring = custom_docstring
+
+        # # If "Args:" is in custom_docstring
+        #     # Want to grab arguments name (first), argument data type (second, comes after colon), argument description (on new line)
+        #     # Based on indentation, know if it's description or argument name: argument type
+        #         # 1 more indent than Args: arguments name: argument type
+        #         # 2 more indents than Args: argument description
+        #     # Gather arguments as one strings and format each one individually using textwrap
+        #     # We know Args are done when we see the words "Returns:", "Notes:", or """
+        
+        # # If "Returns:" is in custom_docstring
+        #     # Grab returns data type, returns description
+        #     # Based on indentation, know if it's description or return data type
+        #         # 1 more indents than Returns: returns data type
+        #         # 2 more indents than Returns: returns description
+        #     # Gather returns as one string and format using textwrap
+        #     # Know that Returns is done when we see words "Notes:" or """
+        
+        # docstring_list = custom_docstring.split('\n')
+
+        def ret_replacement(match):
+            white_space, data_type, desc_white_space, description = match.groups()
+            if description:
+                cleaned_description = re.sub(r"\s*\n\s*", " ", description.strip())
+                wrapped_lines = textwrap.wrap(
+                    f"{white_space}{data_type}: {cleaned_description}\n", width=72
+                )
+                indented_lines = textwrap.indent(
+                    "\n".join(wrapped_lines[1:]), " " * (len(desc_white_space))
+                )
+                returns_white_space = (" " * (len(white_space)-5))
+                # Accounts for the fact Returns: may be last section
+                if(returns_last):
+                    return f"Returns:\n{wrapped_lines[0]}\n{indented_lines}\n{returns_white_space}"
+                else:
+                    return f"Returns:\n{wrapped_lines[0]}\n{indented_lines}"
+            else:
+                return f"Returns:{white_space}{data_type}\n"
+
+        converted_docstring=custom_docstring
+        args= False
+        returns = False
+        notes = False
+        returns_last = False
+
+        # Determine args, returns, notes start
+        if("Args:" in custom_docstring):
+            args_start = custom_docstring.find("Args:")
+            args = True
+            print("Args start: ",args_start)
+        if("Returns:" in custom_docstring):
+            returns_start = custom_docstring.find("Returns:")
+            returns = True
+            print("Returns start: ",returns_start)
+        if("Notes:" in custom_docstring):
+            notes_start = custom_docstring.find("Notes:")
+            notes = True
+            print("Notes start: ", notes_start)
+
+        docstring_end = custom_docstring.find('"""',custom_docstring.find('"""')+1)
+
+        # Determine args ending
+        if(returns):
+            args_end = returns_start
+        elif(notes):
+            args_end = notes_start
+        else:
+            args_end = docstring_end
+
+        #Determine returns ending
+        if(notes):
+            returns_end = notes_start
+        else:
+            returns_end = docstring_end
+            returns_last = True
+
+        # # Extract the name and data type of arguments using regular expressions
+        # arg_pattern = r"(?!Args)(?!rgs)(?!gs)(?!s)(\*\*\w+|\*\w+|\w+):\s*((?:\w+\s*\
+        #     |\s*)*(?:\w+\s*\|)?\s*(?:\w+(?:\.\w+)*\s+\([^)]+\)|\w+(?:\.\w+)*|\w+(?:\
+        #         .\w+)*\s*\|\s*\w+(?:\.\w+)*))\s*\n\s*($|\n)"
+        
+        # Extract the data type and description of returns using regular expressions
+        ret_pattern = r"(\s*)(?!.*:)([^:\n]+)\n(\s+)((?:.*(?:\n(?!\n)|$).*)*)"
+
+        returns_string = custom_docstring[returns_start+8:returns_end]
+        print(returns_string)
+
+        # Replace the return pattern matches with the converted parts
+        returns_string = re.sub(ret_pattern, ret_replacement, returns_string)
+            
+        converted_docstring = (
+            custom_docstring[:returns_start] + returns_string + custom_docstring[returns_end:]
+        )
+
+        print("Docstring end: ", docstring_end)
+        # docstring_end-1 will be a blank character!
+        print("Docstring end character: ", custom_docstring[docstring_end])
+        print("Args end: ", args_end)
+        print("Returns end: ", returns_end)
+        
+
+        
+
+        return converted_docstring
+
+    def convert_docstrings(docstrings, file_path):
+        """Converts docstrings to Google style and updates the file.
+        Args:
+            docstrings (list): List of docstrings to convert.
+            file_path (str): Path to the file.
+        """
+        with open(file_path, "r") as file:
+            file_contents = file.read()
+
+        # Helper function to find the start and end position of a docstring
+        def find_docstring_position(file_contents, docstring):
+            start = file_contents.find(docstring)
+            end = start + len(docstring)
+            return start, end
+
+        # Iterate over the docstrings and replace them in the file contents
+        for docstring in docstrings:
+            start, end = find_docstring_position(file_contents, docstring)
+            converted_docstring = CustomDocstringConverter().convert_to_google_style(
+                docstring
+            )
+            file_contents = (
+                file_contents[:start] + converted_docstring + file_contents[end:]
+            )
+
+        # Update the file with the modified contents
+        with open(file_path, "w") as file:
+            file.write(file_contents)
+
+
+def main():
+    """The main function for running the Custom Docstring Converter."""
+
+    # Create an ArgumentParser object
+    parser = argparse.ArgumentParser(description="Custom Docstring Converter")
+
+    # Add an argument for the file path
+    parser.add_argument("file_path", type=str, help="Path to the file to convert")
+
+    # Parse the command-line arguments
+    args = parser.parse_args()
+
+    # Extract the file path or directory path from the arguments
+    path = args.file_path
+
+    # Check if the path is a file or directory
+    if os.path.isfile(path):
+        # Path is a file, convert only that file
+        print("Updated: ", path, "\n")
+        docstrings = CustomDocstringConverter.extract_docstrings_from_file(path)
+        CustomDocstringConverter.convert_docstrings(docstrings, path)
+    elif os.path.isdir(path):
+        counter = 0
+        # Path is a directory, convert all .py files in the directory
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                if file.endswith(".py"):
+                    file_path = os.path.join(root, file)
+                    counter += 1
+                    print("Updated: ", file_path, "\n")
+                    docstrings = CustomDocstringConverter.extract_docstrings_from_file(
+                        file_path
+                    )
+                    CustomDocstringConverter.convert_docstrings(docstrings, file_path)
+        print("Done! Updated ", counter, " .py files")
+    else:
+        print("Invalid path provided.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dsconverter.py
+++ b/scripts/dsconverter.py
@@ -89,7 +89,7 @@ class CustomDocstringConverter:
         def ret_replacement(match):
             (white_space, data_type, desc_white_space, description) = match.groups()
             num_words_data_type = len(data_type.split())
-            if num_words_data_type>=10:
+            if num_words_data_type >= 10:
                 return f"{white_space}{data_type}\n{desc_white_space}{description}"
             # If has already been converted, don't convert it again
             if ":" in data_type:

--- a/scripts/dsconverter.py
+++ b/scripts/dsconverter.py
@@ -12,6 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Custom to Google Docstring Converter
+
+This script converts custom style docstrings to Google style. It extracts docstrings from a 
+file or directory, converts them to Google style, and updates the file(s) with the converted 
+docstrings.
+
+Example Usage:
+    python dsconverter.py my_script.py
+    python dsconverter.py my_directory/
+    tox -e dsconverter
+
+Note:
+    - The script assumes that the custom docstrings are written in triple quotes and follow a 
+      specific structure.
+    - It identifies different sections within the docstring such as Args, Returns, Notes, 
+      Examples, Raises, and Attributes, and converts them accordingly.
+    - It assumes docstrings sections are written in the following order 
+      Args -> Returns -> Notes -> Examples -> Attributes -> Raises
+    - The conversion includes formatting the descriptions and arguments, and reorganizing 
+      the sections based on Google style.
+    - Google Python Style Guide:
+      http://google.github.io/styleguide/pyguide.html
+"""
+
+
 # Standard
 import argparse
 import ast
@@ -109,12 +134,17 @@ class CustomDocstringConverter:
                 description,
             ) = match.groups()
             num_words_data_type = len(data_type.split())
-            num_ors_data_type = len(data_type.split("|"))-1
-            num_word_ors_data_type = len(data_type.split("or"))-1
-            num_commas_data_type = len(data_type.split(", "))-1
-            num_arrows_data_type = len(data_type.split("->"))-1
-            num_words_data_type -= (num_ors_data_type * 2) + (num_word_ors_data_type * 2) + (num_commas_data_type) + (num_arrows_data_type * 2)
-            
+            num_ors_data_type = len(data_type.split("|")) - 1
+            num_word_ors_data_type = len(data_type.split("or")) - 1
+            num_commas_data_type = len(data_type.split(", ")) - 1
+            num_arrows_data_type = len(data_type.split("->")) - 1
+            num_words_data_type -= (
+                (num_ors_data_type * 2)
+                + (num_word_ors_data_type * 2)
+                + (num_commas_data_type)
+                + (num_arrows_data_type * 2)
+            )
+
             # If re accidentally absorbs description as data type
             if num_words_data_type >= 2:
                 return (
@@ -147,7 +177,7 @@ class CustomDocstringConverter:
         returns = False
         notes = False
         examples = False
-        raises= False
+        raises = False
         attributes = False
         returns_last = False
 
@@ -186,7 +216,7 @@ class CustomDocstringConverter:
         if "Raises:" in custom_docstring:
             raises_start = custom_docstring.find("Raises:")
             raises = True
-        
+
         if "Attributes:" in custom_docstring:
             attributes_start = custom_docstring.find("Attributes:")
             attributes = True

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -529,6 +529,7 @@ def test_data_type_same_line_returns():
     '''
     )
 
+
 def test_example_usage():
     converter = CustomDocstringConverter()
     test1 = '''
@@ -583,6 +584,7 @@ def test_example_usage():
     
     """
     )
+
 
 def test_example_usage():
     converter = CustomDocstringConverter()
@@ -789,8 +791,6 @@ def test_multiword_args():
     """
     '''
     )
-
-
 
 
 # Run the tests

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Standard
+import os
+
 # Third Party
 # Import the script code
 from dsconverter import CustomDocstringConverter
@@ -21,11 +24,16 @@ import pytest
 # Test case for convert_to_google_style function
 def test_get_docstrings():
     converter = CustomDocstringConverter()
-    test_path = "/Users/mwjohnson/Code/caikit/caikit/core/modules/config.py"
+    # Get the current directory
+    current_directory = os.getcwd()
+
+    # Specify the relative path to the file
+    relative_path = "caikit/core/modules/config.py"
+
+    # Join the current directory and the relative path to get the full file path
+    test_path = os.path.join(current_directory, relative_path)
     docstrings = converter.extract_docstrings_from_file(test_path)
-    for docstring in docstrings:
-        print("foo:\n", docstring)
-    assert 1 == 2
+    assert len(docstrings) == 4
 
 
 def test_basic_custom_docstring():
@@ -51,9 +59,27 @@ def test_basic_custom_docstring():
     '''
 
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Method for extracting pred set from dataset. Implemented in subclass.
+
+        Args:
+            dataset (object): In-memory version of whatever
+            preprocess_func (method): Function used as proxy for any preliminary
+                steps that need to be taken to run the model on the input text.
+                This helper function ultimately leads to the input to this
+                module and may involve executing other modules.
+            foo
+                Description
+            *args, **kwargs (dict): Optional keyword arguments for prediction set extraction.
+        Returns:
+            list: List of labels in the format of the module_type that is being
+                called.
+       """
+    '''
+    )
 
 
 # Test case for convert_to_google_style function
@@ -81,9 +107,28 @@ def test_complex_custom_docstring():
     '''
 
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Time a model `load` call.
+
+        Args:
+            *args (list): Will be passed to `self.load`.
+            **kwargs (dict): Will be passed to `self.load` -- the only way to
+                pass arbitrary arguments to `self.load` from this function.
+
+        Returns:
+            int, caikit.core._ModuleBase: The first return value is the total
+                time spent in the `self.load` call. The second return value is
+                the loaded model.
+
+        Notes:
+            You can pass everything that should go to the run function normally using args/kwargs.
+            Example: `model.timed_load("/model/path/dir")`
+        """
+    '''
+    )
 
 
 def test_no_arg_desc_docstring():
@@ -108,9 +153,27 @@ def test_no_arg_desc_docstring():
     '''
 
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Time a model `load` call.
+
+        Args:
+            *args (list)
+            **kwargs (dict)
+            hello (foo)
+        Returns:
+            int, caikit.core._ModuleBase: The first return value is the total
+                time spent in the `self.load` call. The second return value is
+                the loaded model.
+
+        Notes:
+            You can pass everything that should go to the run function normally using args/kwargs.
+            Example: `model.timed_load("/model/path/dir")`
+        """
+    '''
+    )
 
 
 def test_no_arg_description_returns():
@@ -125,9 +188,19 @@ def test_no_arg_description_returns():
         """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Extract the core list of predictions that is needed for quality evaluation
+
+        Args:
+            pred_set (list)
+        Returns:
+            pred_annotations: list
+        """
+    '''
+    )
 
 
 def test_already_converted():
@@ -151,9 +224,28 @@ def test_already_converted():
         """
         '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Time a model `load` call.
+
+        Args:
+             *args (list): Will be passed to `self.load`.
+             **kwargs (dict): Will be passed to `self.load` -- the only way to
+                pass arbitrary arguments to `self.load` from this function.
+
+        Returns:
+             int, caikit.core._ModuleBase: The first return value is the
+               total time spent in the `self.load` call. The second return value is the
+               loaded model.
+
+        Notes:
+            You can pass everything that should go to the run function normally using args/kwargs.
+            Example: `model.timed_load("/model/path/dir")`
+        """
+        '''
+    )
 
 
 def test_examples_in_docstring():
@@ -181,9 +273,32 @@ def test_examples_in_docstring():
         """
         '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            data (iterable): A list or tuple or other python iterable used to
+                construct a new data stream where each data item contains a
+                single data item.
+
+        Returns:
+            DataStream: A new data stream that produces data items from the
+                elements of `data`.
+
+        Examples:
+            >>> list_stream = DataStream.from_iterable([1, 2, 3])
+            >>> for data_item in list_stream:
+            >>>     print(data_item)
+            1
+            2
+            3
+        """
+        '''
+    )
 
 
 def test_no_data_type_arg():
@@ -203,9 +318,23 @@ def test_no_data_type_arg():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto: A protocol buffer to be populated.
+        Returns:
+            DataStream: A new data stream that produces data items from the
+                elements of `data`.
+       
+
+    """
+    '''
+    )
 
 
 def test_no_data_type_arg_same_line_desc():
@@ -224,9 +353,23 @@ def test_no_data_type_arg_same_line_desc():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto: A protocol buffer to be populated.
+        Returns:
+            DataStream: A new data stream that produces data items from the
+                elements of `data`.
+       
+
+    """
+    '''
+    )
 
 
 def test_no_data_type_arg_multi_line_desc():
@@ -248,9 +391,26 @@ def test_no_data_type_arg_multi_line_desc():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto: A protocol buffer to be populated.
+                More description here
+                More here!
+        
+        Returns:
+            DataStream: A new data stream that produces data items from the
+                elements of `data`.
+       
+
+    """
+    '''
+    )
 
 
 def test_buncha_ors():
@@ -272,9 +432,25 @@ def test_buncha_ors():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto (int | int | int | int | int | int | int ): A protocol buffer
+                to be populated. More description here More here!
+        
+        Returns:
+            DataStream: A new data stream that produces data items from the
+                elements of `data`.
+       
+
+    """
+    '''
+    )
 
 
 def test_fewa_ors():
@@ -292,9 +468,21 @@ def test_fewa_ors():
         """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            obj (str | caikit.core.data_model.DataBase): Object to be augmented.
+        Returns:
+            str | caikit.core.data_model.DataBase: Augmented object of same type
+                as input obj.
+       """
+    '''
+    )
 
 
 def test_data_type_same_line_returns():
@@ -318,9 +506,28 @@ def test_data_type_same_line_returns():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Configure caikit for your usage!
+    Merges into the internal aconfig.Config object with overrides from multiple sources.
+    Sources, last takes precedence:
+        1. The existing configuration from calls to `caikit.configure()`
+        2. The config from `config_yml_path`
+        3. The config from `config_dict`
+        4. The config files specified in the `config_files` configuration
+            (NB: This may be set by the `CONFIG_FILES` environment variable)
+        5. Environment variables, in ALL_CAPS_SNAKE_FORMAT
+    Args:
+        config_yml_path (Optional[str]): The path to the base configuration yaml
+            with overrides for your usage.
+        config_dict (Optional[Dict]): Config overrides in dictionary form
+    Returns: None: This only sets the config object that is returned by
+        `caikit.get_config()`
+"""
+    '''
+    )
 
 def test_example_usage():
     converter = CustomDocstringConverter()
@@ -369,9 +576,13 @@ def test_example_usage():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == """
+    
+    """
+    )
 
 def test_example_usage():
     converter = CustomDocstringConverter()
@@ -420,9 +631,164 @@ def test_example_usage():
     """
     '''
     converted = converter.convert_to_google_style(test1)
-    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
 
-    assert 1 == 2
+    assert (
+        converted
+        == '''
+    """Decorator that can be used to mark a function
+    or a class as "work in progress". It will result in a warning being emitted
+    when the function / class is used.
+
+    Args:
+        category (WipCategory): Enum specifying what category of message you
+            want to throw
+        action (Action): Enum specifying what type of action you want to take.
+            Example: ERROR or WARNING
+
+    Example Usage:
+
+    ### Decorating class
+
+    1. No configuration:
+        @work_in_progress
+        class Foo:
+            pass
+
+    2. Action and category configuration:
+        @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
+        class Foo:
+            pass
+
+    ### Decorating Function:
+
+    1. No configuration:
+        @work_in_progress
+        def foo(*args, **kwargs):
+            pass
+
+    2. Action and category configuration:
+        @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
+         def foo(*args, **kwargs):
+            pass
+
+    ### Sample message:
+
+    foo is still in the BETA phase and subject to change!
+
+    """
+    '''
+    )
+
+
+def test_raises():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Decorator that can be used to mark a function
+    or a class as "work in progress". It will result in a warning being emitted
+    when the function / class is used.
+
+    Args:
+        category: WipCategory
+            Enum specifying what category of message you want to throw
+        action: Action
+            Enum specifying what type of action you want to take.
+            Example: ERROR or WARNING
+
+    Returns: 
+        None
+            This only sets the config object that is returned by `caikit.get_config()`
+
+    Raises:
+        AttributeError if a discrepancy is found between the RPC service
+        descriptor and the Caikit Library CDM, which will prevent an instance of
+        this class from being instantiated
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+
+    assert (
+        converted
+        == '''
+    """Decorator that can be used to mark a function
+    or a class as "work in progress". It will result in a warning being emitted
+    when the function / class is used.
+
+    Args:
+        category (WipCategory): Enum specifying what category of message you
+            want to throw
+        action (Action): Enum specifying what type of action you want to take.
+            Example: ERROR or WARNING
+
+    Returns:
+         None: This only sets the config object that is returned by
+            `caikit.get_config()`
+
+    Raises:
+        AttributeError if a discrepancy is found between the RPC service
+        descriptor and the Caikit Library CDM, which will prevent an instance of
+        this class from being instantiated
+    """
+    '''
+    )
+
+
+def test_multiword_args():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Decorator that can be used to mark a function
+    or a class as "work in progress". It will result in a warning being emitted
+    when the function / class is used.
+
+    Args:
+        category: WipCategory | list | click
+            Enum specifying what category of message you want to throw
+        action: Action | int
+            Enum specifying what type of action you want to take.
+            Example: ERROR or WARNING
+        foo: a very short description
+        signature: Dict[str, Type]
+            module signature of parameters and types
+        foo: int | int | int | int
+            here's some description!
+        var: foo or int or list
+            more description
+        kwarg: hello -> arrow
+            a description
+
+    Returns: 
+        None
+            This only sets the config object that is returned by `caikit.get_config()`
+
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+
+    assert (
+        converted
+        == '''
+    """Decorator that can be used to mark a function
+    or a class as "work in progress". It will result in a warning being emitted
+    when the function / class is used.
+
+    Args:
+        category (WipCategory | list | click): Enum specifying what category of
+            message you want to throw
+        action (Action | int): Enum specifying what type of action you want to
+            take. Example: ERROR or WARNING
+        foo: a very short description
+        Nonesignature (Dict[str, Type]): module signature of parameters and types
+        foo (int | int | int | int): here's some description!
+        var (foo or int or list): more description
+        kwarg (hello -> arrow): a description
+
+    Returns:
+         None: This only sets the config object that is returned by
+            `caikit.get_config()`
+    
+
+    """
+    '''
+    )
 
 
 

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -156,6 +156,277 @@ def test_already_converted():
     assert 1 == 2
 
 
+def test_examples_in_docstring():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            data:  iterable
+                A list or tuple or other python iterable used to construct a new data stream where
+                each data item contains a single data item.
+
+        Returns:
+            DataStream
+                A new data stream that produces data items from the elements of `data`.
+
+        Examples:
+            >>> list_stream = DataStream.from_iterable([1, 2, 3])
+            >>> for data_item in list_stream:
+            >>>     print(data_item)
+            1
+            2
+            3
+        """
+        '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_no_data_type_arg():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto:
+                A protocol buffer to be populated.
+        
+        Returns:
+            DataStream
+                A new data stream that produces data items from the elements of `data`.
+
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_no_data_type_arg_same_line_desc():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto: A protocol buffer to be populated.
+        
+        Returns:
+            DataStream
+                A new data stream that produces data items from the elements of `data`.
+
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_no_data_type_arg_multi_line_desc():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto: 
+                A protocol buffer to be populated.
+                More description here
+                More here!
+        
+        Returns:
+            DataStream
+                A new data stream that produces data items from the elements of `data`.
+
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_buncha_ors():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            proto: int | int | int | int | int | int | int 
+                A protocol buffer to be populated.
+                More description here
+                More here!
+        
+        Returns:
+            DataStream
+                A new data stream that produces data items from the elements of `data`.
+
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_fewa_ors():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Create a new data stream from a python iterable, such as a list or tuple.  This data
+        stream produces a single data item for each element of the iterable..
+
+        Args:
+            obj: str | caikit.core.data_model.DataBase
+                Object to be augmented.
+        Returns:
+            str | caikit.core.data_model.DataBase
+                Augmented object of same type as input obj.
+        """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_data_type_same_line_returns():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Configure caikit for your usage!
+    Merges into the internal aconfig.Config object with overrides from multiple sources.
+    Sources, last takes precedence:
+        1. The existing configuration from calls to `caikit.configure()`
+        2. The config from `config_yml_path`
+        3. The config from `config_dict`
+        4. The config files specified in the `config_files` configuration
+            (NB: This may be set by the `CONFIG_FILES` environment variable)
+        5. Environment variables, in ALL_CAPS_SNAKE_FORMAT
+    Args:
+        config_yml_path (Optional[str]): The path to the base configuration yaml
+            with overrides for your usage.
+        config_dict (Optional[Dict]): Config overrides in dictionary form
+    Returns: None
+        This only sets the config object that is returned by `caikit.get_config()`
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+def test_example_usage():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """The decorator for AI Task classes.
+
+    This defines an output data model type for the task, and a minimal set of required inputs
+    that all public models implementing this task must accept.
+
+    As an example, the `caikit.interfaces.nlp.SentimentTask` might look like::
+
+        @task(
+            required_inputs={
+                "raw_document": caikit.interfaces.nlp.RawDocument
+            },
+            output_type=caikit.interfaces.nlp.SentimentPrediction
+        )
+        class SentimentTask(caikit.TaskBase):
+            pass
+
+    and a public model that implements this task might have a .run function that looks like::
+
+        def run(raw_document: caikit.interfaces.nlp.RawDocument,
+                inference_mode: str = "fast",
+                device: caikit.interfaces.common.HardwareEnum) ->
+                    caikit.interfaces.nlp.SentimentPrediction:
+            # impl
+
+    Note the run function may include other arguments beyond the minimal required inputs for
+    the task.
+
+    Args:
+        required_parameters (Dict[str, ValidInputTypes]): The required parameters that all public
+            models' .run functions must contain. A dictionary of parameter name to parameter
+            type, where the types can be in the set of:
+                - Python primitives
+                - Caikit data models
+                - Iterable containers of the above
+                - Caikit model references (maybe?)
+        output_type (Type[DataBase]): The output type of the task, which all public models'
+            .run functions must return. This must be a caikit data model type.
+
+    Returns:
+        A decorator function for the task class, registering it with caikit's core registry of
+            tasks.
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+def test_example_usage():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Decorator that can be used to mark a function
+    or a class as "work in progress". It will result in a warning being emitted
+    when the function / class is used.
+
+    Args:
+        category: WipCategory
+            Enum specifying what category of message you want to throw
+        action: Action
+            Enum specifying what type of action you want to take.
+            Example: ERROR or WARNING
+
+    Example Usage:
+
+    ### Decorating class
+
+    1. No configuration:
+        @work_in_progress
+        class Foo:
+            pass
+
+    2. Action and category configuration:
+        @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
+        class Foo:
+            pass
+
+    ### Decorating Function:
+
+    1. No configuration:
+        @work_in_progress
+        def foo(*args, **kwargs):
+            pass
+
+    2. Action and category configuration:
+        @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
+         def foo(*args, **kwargs):
+            pass
+
+    ### Sample message:
+
+    foo is still in the BETA phase and subject to change!
+
+    """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+
+
 # Run the tests
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -1,0 +1,161 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Third Party
+# Import the script code
+from dsconverter import CustomDocstringConverter
+import pytest
+
+
+# Test case for convert_to_google_style function
+def test_get_docstrings():
+    converter = CustomDocstringConverter()
+    test_path = "/Users/mwjohnson/Code/caikit/caikit/core/modules/config.py"
+    docstrings = converter.extract_docstrings_from_file(test_path)
+    for docstring in docstrings:
+        print("foo:\n", docstring)
+    assert 1 == 2
+
+
+def test_basic_custom_docstring():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Method for extracting pred set from dataset. Implemented in subclass.
+
+        Args:
+            dataset:  object
+                In-memory version of whatever
+            preprocess_func:  method
+                Function used as proxy for any preliminary steps that need to be taken to run the
+                model on the input text. This helper function ultimately leads to the input to this
+                module and may involve executing other modules.
+            foo
+                Description
+            *args, **kwargs: dict
+                Optional keyword arguments for prediction set extraction.
+        Returns:
+            list
+                List of labels in the format of the module_type that is being called.
+        """
+    '''
+
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+# Test case for convert_to_google_style function
+def test_complex_custom_docstring():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Time a model `load` call.
+
+        Args:
+            *args: list
+                Will be passed to `self.load`.
+            **kwargs:  dict
+                Will be passed to `self.load` -- the only way to pass arbitrary arguments to
+                `self.load` from this function.
+
+        Returns:
+            int, caikit.core._ModuleBase
+                The first return value is the total time spent in the `self.load` call. The second
+                return value is the loaded model.
+
+        Notes:
+            You can pass everything that should go to the run function normally using args/kwargs.
+            Example: `model.timed_load("/model/path/dir")`
+        """
+    '''
+
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_no_arg_desc_docstring():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Time a model `load` call.
+
+        Args:
+            *args: list
+            **kwargs:  dict
+            hello: foo
+
+        Returns:
+            int, caikit.core._ModuleBase
+                The first return value is the total time spent in the `self.load` call. The second
+                return value is the loaded model.
+
+        Notes:
+            You can pass everything that should go to the run function normally using args/kwargs.
+            Example: `model.timed_load("/model/path/dir")`
+        """
+    '''
+
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_no_arg_description_returns():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Extract the core list of predictions that is needed for quality evaluation
+
+        Args:
+            pred_set: list
+        Returns:
+            pred_annotations: list
+        """
+    '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+def test_already_converted():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Time a model `load` call.
+
+        Args:
+             *args (list): Will be passed to `self.load`.
+             **kwargs (dict): Will be passed to `self.load` -- the only way to
+                pass arbitrary arguments to `self.load` from this function.
+
+        Returns:
+             int, caikit.core._ModuleBase: The first return value is the
+               total time spent in the `self.load` call. The second return value is the
+               loaded model.
+
+        Notes:
+            You can pass everything that should go to the run function normally using args/kwargs.
+            Example: `model.timed_load("/model/path/dir")`
+        """
+        '''
+    converted = converter.convert_to_google_style(test1)
+    print("Pre-conversion:\n", test1, "\nPost-conversion:\n", converted)
+
+    assert 1 == 2
+
+
+# Run the tests
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tox.ini
+++ b/tox.ini
@@ -82,3 +82,7 @@ extras = dev-test
 commands =
     pytest tests/core
 
+# Runs dsconverter on caikit
+[testenv:dsconverter]
+description = convert docstrings to google
+commands = python ./scripts/dsconverter.py caikit


### PR DESCRIPTION
Resolves #180 

dsconverter.py converts custom "Gabe" style docstrings into Google style docstrings. This will allow us to have more functionality with tools like Sphinx which autofills caikit's readthedocs. Script takes a file or directory name and changes all custom style docstrings of either that file or all .py files within the file to Google format. I also added a testenv to tox.ini which can be run with 'tox -e dsconverter'. This command will change all the docstrings in the caikit directory to Google style.
