### PR TITLE
:sparkles: Add rpc validation on inference

### DIFF
--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -36,7 +36,7 @@ from caikit.interfaces.runtime.data_model import (
     TrainingInfoResponse,
 )
 from caikit.runtime import service_generation
-from caikit.runtime.service_generation.rpcs import snake_to_upper_camel
+from caikit.runtime.service_generation.rpcs import CaikitRPCBase, snake_to_upper_camel
 from caikit.runtime.utils import import_util
 import caikit.core
 
@@ -73,6 +73,7 @@ class ServicePackage:
     ]
     stub_class: Type
     messages: ModuleType
+    caikit_rpcs: Set[CaikitRPCBase]
 
 
 class ServicePackageFactory:
@@ -110,6 +111,7 @@ class ServicePackageFactory:
                 registration_function=grpc_service.registration_function,
                 stub_class=grpc_service.client_stub_class,
                 messages=None,  # we don't need messages here
+                caikit_rpcs=set(),  # No caikit RPCs
             )
 
         # First make sure we import the data model for the correct library
@@ -160,6 +162,7 @@ class ServicePackageFactory:
             registration_function=grpc_service.registration_function,
             stub_class=grpc_service.client_stub_class,
             messages=client_module,
+            caikit_rpcs=set(task_rpc_list),
         )
 
     # Implementation details for pure python service packages #

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # Standard
 from importlib.metadata import version
+from typing import Set
 import traceback
 
 # Third Party
@@ -25,9 +26,11 @@ import alog
 
 # Local
 from caikit import get_config
+from caikit.core import ModuleBase
 from caikit.runtime.metrics.rpc_meter import RPCMeter
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.service_factory import ServicePackage
+from caikit.runtime.service_generation.rpcs import TaskPredictRPC
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import clean_lib_names
 from caikit.runtime.utils.servicer_util import (
@@ -135,9 +138,9 @@ class GlobalPredictServicer:
                 A Caikit Library data model response object
         """
         desc_name = request.DESCRIPTOR.name
-        outer_scope_name = "GlobalPredictServicerMock.Predict:%s" % desc_name
+        outer_scope_name = "GlobalPredictServicer.Predict:%s" % desc_name
         inner_scope_name = (
-            "GlobalPredictServicerImpl.Predict.caikit_library_run:%s" % desc_name
+            "GlobalPredictServicer.Predict.caikit_library_run:%s" % desc_name
         )
 
         try:
@@ -147,6 +150,8 @@ class GlobalPredictServicer:
                 # Retrieve the model from the model manager
                 log.debug("<RUN52259029D>", "Retrieving model '%s'", model_id)
                 model = self._model_manager.retrieve_model(model_id)
+
+                self._verify_model_task(model, desc_name)
 
                 model_class = type(model)
                 # Unmarshall the request object into the required module run argument(s)
@@ -235,3 +240,34 @@ class GlobalPredictServicer:
             raise CaikitRuntimeException(
                 StatusCode.INTERNAL, "Unhandled exception during prediction"
             ) from e
+
+    def _verify_model_task(self, model: ModuleBase, request_name: str):
+        """Raise if the model is not supported for the task"""
+        rpc_set: Set[TaskPredictRPC] = self._inference_service.caikit_rpcs
+        module_rpc: TaskPredictRPC = next(
+            (
+                rpc
+                for rpc in rpc_set
+                if any(
+                    issubclass(type(model), module_class)
+                    for module_class in rpc.module_list
+                )
+            ),
+            None,
+        )
+
+        if not module_rpc:
+            raise CaikitRuntimeException(
+                status_code=StatusCode.INVALID_ARGUMENT,
+                message=f"Inference for model class {type(model)} not supported by this runtime",
+            )
+
+        request_rpc: TaskPredictRPC = next(
+            (rpc for rpc in rpc_set if rpc.request.name == request_name), None
+        )
+        if request_rpc != module_rpc:
+            raise CaikitRuntimeException(
+                status_code=StatusCode.INVALID_ARGUMENT,
+                message=f"Wrong inference RPC invoked for model class {type(model)}. "
+                f"Use {request_rpc.name} instead of {request_name}",
+            )

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -245,14 +245,7 @@ class GlobalPredictServicer:
         """Raise if the model is not supported for the task"""
         rpc_set: Set[TaskPredictRPC] = self._inference_service.caikit_rpcs
         module_rpc: TaskPredictRPC = next(
-            (
-                rpc
-                for rpc in rpc_set
-                if any(
-                    issubclass(type(model), module_class)
-                    for module_class in rpc.module_list
-                )
-            ),
+            (rpc for rpc in rpc_set if model.TASK_CLASS == rpc.task),
             None,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,7 @@ def other_good_model_path() -> str:
 
 
 @pytest.fixture
-def loaded_model_id(good_model_path) -> str:
+def sample_task_model_id(good_model_path) -> str:
     """Loaded model ID using model manager load model implementation"""
     model_id = _random_id()
     model_manager = ModelManager.get_instance()
@@ -209,7 +209,7 @@ def loaded_model_id(good_model_path) -> str:
 
 
 @pytest.fixture
-def other_loaded_model_id(other_good_model_path) -> str:
+def other_task_model_id(other_good_model_path) -> str:
     """Loaded model ID using model manager load model implementation"""
     model_id = _random_id()
     model_manager = ModelManager.get_instance()

--- a/tests/fixtures/sample_lib/modules/sample_task/inner_module.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/inner_module.py
@@ -3,6 +3,7 @@ A hypothetical inner module that transforms some output type rather than taking 
 """
 # Local
 from ...data_model.sample import SampleOutputType
+from caikit.core import ModuleSaver
 import caikit.core
 
 
@@ -15,3 +16,15 @@ class InnerModule(caikit.core.ModuleBase):
 
     def run(self, some_input: SampleOutputType) -> SampleOutputType:
         return SampleOutputType(f"nested greeting: {some_input.greeting}")
+
+    def save(self, model_path):
+        module_saver = ModuleSaver(
+            self,
+            model_path=model_path,
+        )
+        with module_saver:
+            pass
+
+    @classmethod
+    def load(cls, model_path):
+        return cls()

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -161,7 +161,7 @@ def test_global_train_other_task(
 
 
 def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_not_raise(
-    loaded_model_id,
+    sample_task_model_id,
     sample_train_service,
     sample_train_servicer,
     sample_inference_service,
@@ -169,7 +169,7 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_no
 ):
     """Global train of TrainRequest returns a training job with the correct model name, and some training id for a train function that requires another loaded model"""
     sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
-        model_id=loaded_model_id
+        model_id=sample_task_model_id
     ).to_proto()
 
     training_request = (


### PR DESCRIPTION
This PR adds some more robust checks that the module loaded for inference is supported by the inference rpc invoked.

This should actually be helpful for users, so that they don't just get serialization errors back when they invoke the wrong rpc for a model. (Which I just did and floundered around for a while wondering what was wrong).

Closes #215 