### PR TITLE
:bug: Fix incorrect cancellation of training request for thread executor

### DIFF
--- a/caikit/runtime/work_management/train_executors.py
+++ b/caikit/runtime/work_management/train_executors.py
@@ -90,13 +90,6 @@ class LocalTrainSaveExecutor(TrainSaveExecutorBase):
 
         self.__cancel_event = cancel_event
 
-    def __del__(self):
-        """
-        NOTE: This is NOT how execution should be cancelled.
-        This function is designed to make sure cleanup happens.
-        """
-        self.cancel()
-
     # pylint: disable=arguments-differ
     def train_and_save_model(
         self,


### PR DESCRIPTION
### Changes
- Currently the local thread executor is incorrectly calling `cancel` function when getting to `__del__` function at the end. This will cause false alarms where training gets successfully completed but at the end we would see `Terminated` error message, which can cause confusion.
- Add fix to overcome python3.9-3.11 bug where if you create a subprocess inside a ThreadPoolExecutor then it will always exit with `exitcode` 1 thus signaling error.