### PR TITLE
💥  API changes for py-to-proto 0.3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "prometheus_client>=0.12.0,<1.0",
     "protobuf>=3.19.0,<5",
     "py-grpc-prometheus>=0.7.0,<0.8",
-    "py-to-proto>=0.2.0,<0.3.0,!=0.2.1",
+    "py-to-proto>=0.3.0,<0.4.0,!=0.2.1",
     "PyYAML>=6.0,<7.0",
     "requests>=2.26.0,<3.0",
     "semver>=2.13.0,<4.0",

--- a/tests/core/data_model/data_backends/test_dict_backend.py
+++ b/tests/core/data_model/data_backends/test_dict_backend.py
@@ -138,7 +138,7 @@ def test_dict_backend_oneof():
         backend = DictBackend(data_dict)
         msg = dm.Foo.from_backend(backend)
         assert msg.foo == "asdf"
-        assert msg.which_oneof("foo") == "foostr"
+        assert msg.which_oneof("foo") == "foo_str"
 
 
 def test_dict_backend_invalid_field_error():

--- a/tests/core/data_model/test_base.py
+++ b/tests/core/data_model/test_base.py
@@ -227,17 +227,17 @@ def test_compiled_proto_oneof():
         assert isinstance(dm.ThingOne, type)
         assert issubclass(dm.ThingOne, DataBase)
         assert not issubclass(dm.ThingOne, DataObjectBase)
-        assert set(dm.ThingOne.fields) == {"foostr", "fooint"}
+        assert set(dm.ThingOne.fields) == {"foo_str", "foo_int"}
 
         # Construct with the oneof name
         inst = dm.ThingOne(foo=1)
         assert inst.foo == 1
-        assert inst.which_oneof("foo") == "fooint"
+        assert inst.which_oneof("foo") == "foo_int"
 
         # Construct with field name
-        inst = dm.ThingOne(foostr="asdf")
+        inst = dm.ThingOne(foo_str="asdf")
         assert inst.foo == "asdf"
-        assert inst.which_oneof("foo") == "foostr"
+        assert inst.which_oneof("foo") == "foo_str"
 
         # Conflicting args
         with pytest.raises(TypeError):

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -530,19 +530,19 @@ def test_dataobject_oneof_from_backend():
     class Foo(DataObjectBase):
         foo: Union[int, str]
 
-    data_dict1 = {"fooint": 1234}
+    data_dict1 = {"foo_int": 1234}
     backend1 = DictBackend(data_dict1)
     msg1 = Foo.from_backend(backend1)
     assert msg1.foo == 1234
-    assert msg1.fooint == 1234
-    assert msg1.which_oneof("foo") == "fooint"
+    assert msg1.foo_int == 1234
+    assert msg1.which_oneof("foo") == "foo_int"
 
     data_dict2 = {"foo": 1234}
     backend2 = DictBackend(data_dict2)
     msg2 = Foo.from_backend(backend2)
     assert msg2.foo == 1234
-    assert msg2.fooint == 1234
-    assert msg2.which_oneof("foo") == "fooint"
+    assert msg2.foo_int == 1234
+    assert msg2.which_oneof("foo") == "foo_int"
 
 
 def test_dataobject_round_trip_json():

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -124,8 +124,8 @@ def test_global_train_other_task(
         training_data=training_data,
         # either of the below lines work since it's a Union now
         # TODO create a separate test, lazy
-        # sample_inputsampleinputtype=SampleInputType(name="Gabe").to_proto(),
-        sample_inputstr="sample",
+        # sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
+        sample_input_str="sample",
         batch_size=batch_size,
     )
 
@@ -148,7 +148,7 @@ def test_global_train_other_task(
 
     inference_response = sample_predict_servicer.Predict(
         sample_inference_service.messages.OtherTaskRequest(
-            sample_inputsampleinputtype=SampleInputType(name="Gabe").to_proto()
+            sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto()
         ),
         Fixtures.build_context(training_response.model_name),
     )

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -219,7 +219,7 @@ def test_rpc_validation_on_predict(
     """Check that the server catches models sent to the wrong task RPCs"""
     stub = sample_inference_service.stub_class(runtime_grpc_server.make_local_channel())
     predict_request = sample_inference_service.messages.OtherTaskRequest(
-        sample_inputsampleinputtype=HAPPY_PATH_INPUT
+        sample_input_sampleinputtype=HAPPY_PATH_INPUT
     )
     with pytest.raises(grpc.RpcError) as context:
         stub.OtherTaskPredict(
@@ -352,7 +352,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
 
     train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
         model_name="Bar Training",
-        sample_inputsampleinputtype=SampleInputType(name="Gabe").to_proto(),
+        sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
         batch_size=100,
         training_data=training_data,
     )
@@ -366,7 +366,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
 
     # make sure the trained model can run inference, and the batch size 100 was used
     predict_request = sample_inference_service.messages.OtherTaskRequest(
-        sample_inputsampleinputtype=HAPPY_PATH_INPUT
+        sample_input_sampleinputtype=HAPPY_PATH_INPUT
     )
     trained_inference_response = inference_stub.OtherTaskPredict(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -344,7 +344,7 @@ def test_global_train_build_caikit_library_request_dict_ok_with_DataStreamSource
 
     train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
         model_name="Bar Training",
-        sample_inputsampleinputtype=SampleInputType(name="Gabe").to_proto(),
+        sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
         batch_size=100,
         training_data=training_data,
     )


### PR DESCRIPTION
⬆️ bump `py-to-proto` to 0.3.x

This adds an underscore between the field name and the type for generated oneof field names