### PR TITLE
Allow task argument subclasses

### DIFF
--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -84,10 +84,25 @@ class _DataObjectBaseMetaClass(_DataBaseMetaClass):
         # Get the annotations that will go into the dataclass
         if name != "DataObjectBase":
             field_names = attrs.get("__annotations__")
-            if field_names is None:
+            parent_dataobjects = [
+                base for base in bases if isinstance(base, _DataBaseMetaClass)
+            ]
+            field_name_sets = [base.fields for base in parent_dataobjects]
+            if field_names is not None:
+                field_name_sets = [field_names] + field_name_sets
+
+            # We need at least one field name set!
+            if not field_name_sets:
                 raise TypeError(
                     "All DataObjectBase classes must follow dataclass syntax"
                 )
+
+            # Flatten the field names
+            field_names = {
+                field_name
+                for field_name_set in field_name_sets
+                for field_name in field_name_set
+            }
             attrs[_DataBaseMetaClass._FWD_DECL_FIELDS] = field_names
 
         # Delegate to the base metaclass

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -232,6 +232,12 @@ class TaskPredictRPC(CaikitRPCBase):
                 current_val = parameters_dict.get(arg_name, arg_type)
                 # TODO: raise runtime error here instead of assert!
                 # TODO: need to resolve Optional[T] vs. T - if both come in, use Optional[T]
+
+                # If the current version of the argument is a base class of the
+                # previous, take the lowest common denominator
+                if current_val != arg_type and issubclass(arg_type, current_val):
+                    arg_type = current_val
+
                 assert (
                     current_val == arg_type
                 ), f"Conflicting value types for arg {arg_name}: {current_val} != {arg_type}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,25 +187,42 @@ def good_model_path() -> str:
 
 
 @pytest.fixture
+def private_model_path() -> str:
+    return Fixtures.get_private_model_path()
+
+
+@pytest.fixture
 def other_good_model_path() -> str:
     return Fixtures.get_other_good_model_path()
 
 
-@pytest.fixture
-def sample_task_model_id(good_model_path) -> str:
+@contextmanager
+def loaded_model(model_path, model_type):
     """Loaded model ID using model manager load model implementation"""
     model_id = _random_id()
     model_manager = ModelManager.get_instance()
     # model load test already tests with archive - just using a model path here
     model_manager.load_model(
         model_id,
-        local_model_path=good_model_path,
-        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
+        local_model_path=model_path,
+        model_type=model_type,  # eventually we'd like to be determining the type from the model itself...
     )
     yield model_id
 
     # teardown
     model_manager.unload_model(model_id)
+
+
+@pytest.fixture
+def sample_task_model_id(good_model_path) -> str:
+    with loaded_model(good_model_path, Fixtures.get_good_model_type()) as model_id:
+        yield model_id
+
+
+@pytest.fixture
+def sample_private_task_model_id(private_model_path) -> str:
+    with loaded_model(private_model_path, Fixtures.get_good_model_type()) as model_id:
+        yield model_id
 
 
 @pytest.fixture

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -876,3 +876,27 @@ def test_dataobject_inheritance(temp_dpool):
     assert inst.foo == 1
     assert inst.bar == "asdf"
     assert inst.baz == "qwer"
+
+
+def test_dataobject_function_inheritance(temp_dpool):
+    """Make sure inheritance works to override functionality without changing
+    the schema of the parent
+    """
+
+    @dataobject
+    class Base(DataObjectBase):
+        foo: int
+
+        def doit(self):
+            return self.foo * 2
+
+    @dataobject
+    class Derived(Base):
+        def doit(self):
+            return self.foo * 3
+
+    b_inst = Base(1)
+    assert b_inst.doit() == 2
+
+    d_inst = Derived(1)
+    assert d_inst.doit() == 3

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -75,6 +75,10 @@ class Fixtures:
         return os.path.join(os.path.dirname(__file__), "models", "foo")
 
     @staticmethod
+    def get_private_model_path():
+        return os.path.join(os.path.dirname(__file__), "models", "foo_private")
+
+    @staticmethod
     def get_other_good_model_path():
         return os.path.join(os.path.dirname(__file__), "models", "bar")
 

--- a/tests/fixtures/models/foo_private/config.yml
+++ b/tests/fixtures/models/foo_private/config.yml
@@ -1,0 +1,11 @@
+module_class: sample_lib.modules.sample_task.sample_implementation.SampleModulePrivate
+module_id: b38be66a-81f2-49e7-a767-f53072f24b8b
+created: "2023-03-14 11:24:58.720898"
+name: SampleModule
+sample_lib_version: 1.2.3
+saved: "2023-03-14 11:24:58.720929"
+tracking_id: 0676cc24-1823-4a31-a3ff-96a45b316699
+train:
+    batch_size: 42
+    learning_rate: 0.0015
+version: 0.0.1

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -15,6 +15,14 @@ class SampleInputType(DataObjectBase):
 
 
 @dataobject(package="caikit_data_model.sample_lib")
+class SampleInputTypePrivate(SampleInputType):
+    """A derived class with 'private' functionality"""
+
+    def secret(self) -> str:
+        return "shhh, don't tell!"
+
+
+@dataobject(package="caikit_data_model.sample_lib")
 class SampleOutputType(DataObjectBase):
     """A simple return type for the `sample_task` task"""
 

--- a/tests/fixtures/sample_lib/modules/sample_task/__init__.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/__init__.py
@@ -4,3 +4,4 @@ from .inner_module import InnerModule
 from .list_implementation import ListModule
 from .primitive_party_implementation import SamplePrimitiveModule
 from .sample_implementation import SampleModule
+from .sample_private_implementation import SampleModulePrivate

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_private_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_private_implementation.py
@@ -1,0 +1,24 @@
+"""
+A sample module for sample things!
+"""
+# Standard
+import os
+
+# Local
+from ...data_model.sample import SampleInputTypePrivate, SampleOutputType, SampleTask
+from .sample_implementation import SampleModule
+import caikit.core
+
+
+@caikit.core.module(
+    "b38be66a-81f2-49e7-a767-f53072f24b8b", "SampleModulePrivate", "0.0.1", SampleTask
+)
+class SampleModulePrivate(SampleModule):
+    """Simple wrapper around SampleModule that swaps the input type to the
+    inherited private type
+    """
+
+    def run(
+        self, sample_input: SampleInputTypePrivate, throw: bool = False
+    ) -> SampleOutputType:
+        return super().run(sample_input, throw)

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -196,6 +196,22 @@ def test_predict_fake_module_ok_response(
     assert actual_response == HAPPY_PATH_RESPONSE
 
 
+def test_predict_fake_private_module_ok_response(
+    sample_private_task_model_id, runtime_grpc_server, sample_inference_service
+):
+    """Test RPC CaikitRuntime.WidgetPredict successful response"""
+    stub = sample_inference_service.stub_class(runtime_grpc_server.make_local_channel())
+
+    # Explicitly use the "public" version of the message on the request side
+    predict_request = sample_inference_service.messages.SampleTaskRequest(
+        sample_input=HAPPY_PATH_INPUT
+    )
+    actual_response = stub.SampleTaskPredict(
+        predict_request, metadata=[("mm-model-id", sample_private_task_model_id)]
+    )
+    assert actual_response == HAPPY_PATH_RESPONSE
+
+
 def test_predict_fake_module_error_response(
     runtime_grpc_server, sample_inference_service
 ):


### PR DESCRIPTION
## Description

This builds on #233 to allow module implementations to use subclassed data model types to implement tasks. Whether or not this is a good idea is definitely up for discussion!