### PR TITLE
Optional deps 228

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -37,6 +37,9 @@ jobs:
           # Special matrix entry to ensure protobuf 3 compatibility
           - setup: '3.8'
             tox: 'proto3'
+          # Special matrix entry to ensure core tests pass without optional deps
+          - setup: '3.8'
+            tox: 'core'
 
     steps:
       - uses: actions/checkout@v3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,4 +18,8 @@ sphinx:
 # Declare the Python requirements required to build your docs
 python:
     install:
-        - requirements: docs-requirements.txt
+        - method: pip
+          path: .
+          extra_requirements:
+              - all
+              - dev-docs

--- a/caikit/core/signature_parsing/docstrings.py
+++ b/caikit/core/signature_parsing/docstrings.py
@@ -212,14 +212,12 @@ def _get_docstring_type(
 
         # If the type was not fully qualified (like a `ProducerId`), look in a couple well known
         # places - the caikit core data model itself
-        candidate_type = _extract_type_from_pymodule(
-            caikit.interfaces.common.data_model, type_name
-        )
+        candidate_type = _extract_type_from_pymodule(caikit.core.data_model, type_name)
         if candidate_type is not None:
             valid_candidates.append(candidate_type)
             log.debug2(
                 # pylint: disable=line-too-long
-                f"Found valid candidate type on caikit.interfaces.common.data_model: {candidate_type}"
+                f"Found valid candidate type on caikit.core.data_model: {candidate_type}"
             )
             continue
         # ...And the data model within the interfaces, including those defined in library

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,0 @@
-# For API doc generation
-sphinx>=4.0.2,<8.0
-sphinx-autoapi>=2.1.0
-sphinx-rtd-theme~=1.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,15 +33,49 @@ dependencies = [
 
 [project.optional-dependencies]
 
-"runtime.grpc" = [
+## Runtime Extra Sets ##
+
+runtime-grpc = [
     "grpcio-health-checking>=1.35.0,<2.0",
     "grpcio-reflection>=1.35.0,<2.0",
     "prometheus_client>=0.12.0,<1.0",
     "py-grpc-prometheus>=0.7.0,<0.8",
 ]
 
+# NOTE: This is "all" from the user perspective, not the dev perspective
 all = [
-    "caikit[runtime.grpc]",
+    "caikit[runtime-grpc]",
+]
+
+## Dev Extra Sets ##
+
+dev-test = [
+    "pytest>=6.2.5,<7.0",
+    "pytest-cov>=2.10.1,<3.0",
+    "pytest-html>=3.1.1,<4.0",
+    "tls_test_tools>=0.1.1",
+    "wheel>=0.38.4",
+]
+
+dev-docs = [
+    "sphinx>=4.0.2,<8.0",
+    "sphinx-autoapi>=2.1.0",
+    "sphinx-rtd-theme~=1.2.1",
+]
+
+dev-fmt = [
+    "pre-commit>=3.0.4,<4.0",
+    "pylint>=2.16.2,<3.0",
+    "pydeps==1.12.3",
+]
+
+dev-build = [
+    "flit==3.8",
+]
+
+# NOTE: This is "all" from the user and dev perspective
+all-dev = [
+    "caikit[all, dev-test, dev-docs, dev-fmt, dev-build]"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,35 @@ requires-python = "~=3.8"
 classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
+
 dependencies = [
     "alchemy-config>=1.1.1,<2.0.0",
     "alchemy-logging>=1.0.4,<2.0.0",
     "anytree>=2.7.0,<3.0",
     "docstring-parser>=0.14.1,<0.16.0",
-    "grpcio-health-checking>=1.35.0,<2.0",
-    "grpcio-reflection>=1.35.0,<2.0",
     "grpcio>=1.35.0,<2.0,!=1.55.0",
     "ijson>=3.1.4,<3.3.0",
     "munch>=2.5.0,<4.0",
     "numpy>=1.20,<2",
-    "prometheus_client>=0.12.0,<1.0",
     "protobuf>=3.19.0,<5",
-    "py-grpc-prometheus>=0.7.0,<0.8",
     "py-to-proto>=0.3.0,<0.4.0,!=0.2.1",
     "PyYAML>=6.0,<7.0",
-    "requests>=2.26.0,<3.0",
     "semver>=2.13.0,<4.0",
     "six>=1.16.0,<2.0.0",
     "tqdm>=4.59.0,<5.0.0",
+]
+
+[project.optional-dependencies]
+
+"runtime.grpc" = [
+    "grpcio-health-checking>=1.35.0,<2.0",
+    "grpcio-reflection>=1.35.0,<2.0",
+    "prometheus_client>=0.12.0,<1.0",
+    "py-grpc-prometheus>=0.7.0,<0.8",
+]
+
+all = [
+    "caikit[runtime.grpc]",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,20 +4,15 @@ This sets up global test configs when pytest starts
 
 # Standard
 from contextlib import contextmanager
-from typing import Type
 from unittest.mock import patch
 import copy
 import json
 import os
 import sys
 import tempfile
-import threading
-import time
 import uuid
 
 # Third Party
-from grpc_health.v1 import health_pb2, health_pb2_grpc
-import grpc
 import pytest
 
 # First Party
@@ -25,14 +20,7 @@ import alog
 
 # Local
 from caikit import get_config
-from caikit.core.data_model.dataobject import render_dataobject_protos
 from caikit.core.toolkit import logging
-from caikit.runtime.grpc_server import RuntimeGRPCServer
-from caikit.runtime.model_management.model_manager import ModelManager
-from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
-from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
-from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
-from tests.fixtures import Fixtures
 import caikit
 
 log = alog.use_channel("TEST-CONFTEST")
@@ -69,171 +57,19 @@ def test_environment():
     # No cleanup required...?
 
 
-@pytest.fixture(scope="session")
-def sample_inference_service(render_protos) -> ServicePackage:
-    """Service package pointing to `sample_lib` for testing"""
-    inference_service = ServicePackageFactory().get_service_package(
-        ServicePackageFactory.ServiceType.INFERENCE,
-    )
-    if render_protos:
-        render_dataobject_protos("tests/protos")
-    return inference_service
-
-
-@pytest.fixture(scope="session")
-def sample_predict_servicer(sample_inference_service) -> GlobalPredictServicer:
-    servicer = GlobalPredictServicer(inference_service=sample_inference_service)
-    yield servicer
-    # Make sure to not leave the rpc_meter hanging
-    # (It does try to clean itself up on destruction, but just to be sure)
-    servicer.rpc_meter.end_writer_thread()
-
-
-@pytest.fixture(scope="session")
-def sample_train_service(render_protos) -> ServicePackage:
-    """Service package pointing to `sample_lib` for testing"""
-    training_service = ServicePackageFactory().get_service_package(
-        ServicePackageFactory.ServiceType.TRAINING,
-    )
-    if render_protos:
-        render_dataobject_protos("tests/protos")
-    return training_service
-
-
-@pytest.fixture(scope="session")
-def sample_train_servicer(sample_train_service) -> GlobalTrainServicer:
-    servicer = GlobalTrainServicer(training_service=sample_train_service)
-    yield servicer
-
-
-@contextmanager
-def runtime_grpc_test_server(*args, **kwargs):
-    """Helper to wrap creation of RuntimeGRPCServer in temporary configurations"""
-    with tempfile.TemporaryDirectory() as workdir:
-        temp_log_dir = os.path.join(workdir, "metering_logs")
-        temp_save_dir = os.path.join(workdir, "training_output")
-        os.makedirs(temp_log_dir)
-        os.makedirs(temp_save_dir)
-        with temp_config(
-            {
-                "runtime": {
-                    "metering": {"log_dir": temp_log_dir},
-                    "training": {"output_dir": temp_save_dir},
-                }
-            },
-            "merge",
-        ):
-            with RuntimeGRPCServer(*args, **kwargs) as server:
-                # Give tests access to the workdir
-                server.workdir = workdir
-                yield server
-
-
-@pytest.fixture(scope="session")
-def runtime_grpc_server(
-    sample_inference_service, sample_train_service
-) -> RuntimeGRPCServer:
-    with runtime_grpc_test_server(
-        inference_service=sample_inference_service,
-        training_service=sample_train_service,
-    ) as server:
-        _check_server_readiness(server)
-        yield server
-
-
-@pytest.fixture(scope="session")
-def inference_stub(sample_inference_service, runtime_grpc_server) -> Type:
-    inference_stub = sample_inference_service.stub_class(
-        runtime_grpc_server.make_local_channel()
-    )
-    return inference_stub
-
-
-@pytest.fixture(scope="session")
-def train_stub(sample_train_service, runtime_grpc_server) -> Type:
-    train_stub = sample_train_service.stub_class(
-        runtime_grpc_server.make_local_channel()
-    )
-    return train_stub
-
-
-@pytest.fixture(scope="session")
-def training_management_stub(runtime_grpc_server) -> Type:
-    training_management_service: ServicePackage = (
-        ServicePackageFactory().get_service_package(
-            ServicePackageFactory.ServiceType.TRAINING_MANAGEMENT,
-        )
-    )
-
-    training_management_stub = training_management_service.stub_class(
-        runtime_grpc_server.make_local_channel()
-    )
-    return training_management_stub
-
-
 @pytest.fixture
 def good_model_path() -> str:
-    return Fixtures.get_good_model_path()
+    return os.path.join(FIXTURES_DIR, "models", "foo")
 
 
 @pytest.fixture
 def streaming_model_path() -> str:
-    return os.path.join(os.path.dirname(__file__), "fixtures", "dummy_streaming_module")
+    return os.path.join(FIXTURES_DIR, "dummy_streaming_module")
 
 
 @pytest.fixture
 def other_good_model_path() -> str:
-    return Fixtures.get_other_good_model_path()
-
-
-@pytest.fixture
-def sample_task_model_id(good_model_path) -> str:
-    """Loaded model ID using model manager load model implementation"""
-    model_id = _random_id()
-    model_manager = ModelManager.get_instance()
-    # model load test already tests with archive - just using a model path here
-    model_manager.load_model(
-        model_id,
-        local_model_path=good_model_path,
-        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
-    )
-    yield model_id
-
-    # teardown
-    model_manager.unload_model(model_id)
-
-
-@pytest.fixture
-def streaming_task_model_id(streaming_model_path) -> str:
-    """Loaded model ID using model manager load model implementation"""
-    model_id = _random_id()
-    model_manager = ModelManager.get_instance()
-    model_manager.load_model(
-        model_id,
-        local_model_path=streaming_model_path,
-        model_type=Fixtures.get_good_model_type(),
-    )
-    yield model_id
-
-    # teardown
-    model_manager.unload_model(model_id)
-
-
-@pytest.fixture
-def other_task_model_id(other_good_model_path) -> str:
-    """Loaded model ID using model manager load model implementation"""
-    model_id = _random_id()
-    model_manager = ModelManager.get_instance()
-    # model load test already tests with archive - just using a model path here
-    model_manager.load_model(
-        model_id,
-        local_model_path=other_good_model_path,
-        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
-    )
-    yield model_id
-
-    # teardown
-    model_manager.unload_model(model_id)
+    return os.path.join(FIXTURES_DIR, "models", "bar")
 
 
 @contextmanager
@@ -258,12 +94,15 @@ def temp_config(config_overrides: dict, merge_strategy="override"):
 
 # fixtures to optionally generate the protos for easier debugging
 def pytest_addoption(parser):
-    parser.addoption(
-        "--render-protos",
-        action="store_true",
-        default=False,
-        help="Render test protos for debug?",
-    )
+    try:
+        parser.addoption(
+            "--render-protos",
+            action="store_true",
+            default=False,
+            help="Render test protos for debug?",
+        )
+    except ValueError:
+        pass
 
 
 @pytest.fixture(scope="session")
@@ -312,7 +151,7 @@ def sample_int_file() -> str:
 
 @pytest.fixture
 def fixtures_dir():
-    yield os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
+    yield FIXTURES_DIR
 
 
 @pytest.fixture
@@ -328,20 +167,3 @@ def toolkit_fixtures_dir(fixtures_dir):
 # IMPLEMENTATION DETAILS ############################################################
 def _random_id():
     return str(uuid.uuid4())
-
-
-def _check_server_readiness(server):
-    """Check server readiness"""
-
-    channel = grpc.insecure_channel(f"localhost:{server.port}")
-
-    done = False
-    while not done:
-        try:
-            stub = health_pb2_grpc.HealthStub(channel)
-            health_check_request = health_pb2.HealthCheckRequest()
-            stub.Check(health_check_request)
-            done = True
-        except grpc.RpcError:
-            log.debug("[RpcError]; will try to reconnect to test server in 0.1 second.")
-            time.sleep(0.1)

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,210 @@
+"""
+This sets up global test configs when pytest starts
+"""
+
+# Standard
+from contextlib import contextmanager
+from typing import Type
+from unittest.mock import patch
+import copy
+import json
+import os
+import sys
+import tempfile
+import time
+import uuid
+
+# Third Party
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+import grpc
+import pytest
+
+# First Party
+import alog
+
+# Local
+from caikit import get_config
+from caikit.core.data_model.dataobject import render_dataobject_protos
+from caikit.core.toolkit import logging
+from caikit.runtime.grpc_server import RuntimeGRPCServer
+from caikit.runtime.model_management.model_manager import ModelManager
+from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
+from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
+from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
+from tests.conftest import *
+from tests.fixtures import Fixtures
+import caikit
+
+log = alog.use_channel("TEST-CONFTEST")
+
+
+@pytest.fixture(scope="session")
+def sample_inference_service(render_protos) -> ServicePackage:
+    """Service package pointing to `sample_lib` for testing"""
+    inference_service = ServicePackageFactory().get_service_package(
+        ServicePackageFactory.ServiceType.INFERENCE,
+    )
+    if render_protos:
+        render_dataobject_protos("tests/protos")
+    return inference_service
+
+
+@pytest.fixture(scope="session")
+def sample_predict_servicer(sample_inference_service) -> GlobalPredictServicer:
+    servicer = GlobalPredictServicer(inference_service=sample_inference_service)
+    yield servicer
+    # Make sure to not leave the rpc_meter hanging
+    # (It does try to clean itself up on destruction, but just to be sure)
+    servicer.rpc_meter.end_writer_thread()
+
+
+@pytest.fixture(scope="session")
+def sample_train_service(render_protos) -> ServicePackage:
+    """Service package pointing to `sample_lib` for testing"""
+    training_service = ServicePackageFactory().get_service_package(
+        ServicePackageFactory.ServiceType.TRAINING,
+    )
+    if render_protos:
+        render_dataobject_protos("tests/protos")
+    return training_service
+
+
+@pytest.fixture(scope="session")
+def sample_train_servicer(sample_train_service) -> GlobalTrainServicer:
+    servicer = GlobalTrainServicer(training_service=sample_train_service)
+    yield servicer
+
+
+@contextmanager
+def runtime_grpc_test_server(*args, **kwargs):
+    """Helper to wrap creation of RuntimeGRPCServer in temporary configurations"""
+    with tempfile.TemporaryDirectory() as workdir:
+        temp_log_dir = os.path.join(workdir, "metering_logs")
+        temp_save_dir = os.path.join(workdir, "training_output")
+        os.makedirs(temp_log_dir)
+        os.makedirs(temp_save_dir)
+        with temp_config(
+            {
+                "runtime": {
+                    "metering": {"log_dir": temp_log_dir},
+                    "training": {"output_dir": temp_save_dir},
+                }
+            },
+            "merge",
+        ):
+            with RuntimeGRPCServer(*args, **kwargs) as server:
+                # Give tests access to the workdir
+                server.workdir = workdir
+                yield server
+
+
+@pytest.fixture(scope="session")
+def runtime_grpc_server(
+    sample_inference_service, sample_train_service
+) -> RuntimeGRPCServer:
+    with runtime_grpc_test_server(
+        inference_service=sample_inference_service,
+        training_service=sample_train_service,
+    ) as server:
+        _check_server_readiness(server)
+        yield server
+
+
+@pytest.fixture(scope="session")
+def inference_stub(sample_inference_service, runtime_grpc_server) -> Type:
+    inference_stub = sample_inference_service.stub_class(
+        runtime_grpc_server.make_local_channel()
+    )
+    return inference_stub
+
+
+@pytest.fixture(scope="session")
+def train_stub(sample_train_service, runtime_grpc_server) -> Type:
+    train_stub = sample_train_service.stub_class(
+        runtime_grpc_server.make_local_channel()
+    )
+    return train_stub
+
+
+@pytest.fixture(scope="session")
+def training_management_stub(runtime_grpc_server) -> Type:
+    training_management_service: ServicePackage = (
+        ServicePackageFactory().get_service_package(
+            ServicePackageFactory.ServiceType.TRAINING_MANAGEMENT,
+        )
+    )
+
+    training_management_stub = training_management_service.stub_class(
+        runtime_grpc_server.make_local_channel()
+    )
+    return training_management_stub
+
+
+@pytest.fixture
+def sample_task_model_id(good_model_path) -> str:
+    """Loaded model ID using model manager load model implementation"""
+    model_id = random_test_id()
+    model_manager = ModelManager.get_instance()
+    # model load test already tests with archive - just using a model path here
+    model_manager.load_model(
+        model_id,
+        local_model_path=good_model_path,
+        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
+    )
+    yield model_id
+
+    # teardown
+    model_manager.unload_model(model_id)
+
+
+@pytest.fixture
+def streaming_task_model_id(streaming_model_path) -> str:
+    """Loaded model ID using model manager load model implementation"""
+    model_id = random_test_id()
+    model_manager = ModelManager.get_instance()
+    model_manager.load_model(
+        model_id,
+        local_model_path=streaming_model_path,
+        model_type=Fixtures.get_good_model_type(),
+    )
+    yield model_id
+
+    # teardown
+    model_manager.unload_model(model_id)
+
+
+@pytest.fixture
+def other_task_model_id(other_good_model_path) -> str:
+    """Loaded model ID using model manager load model implementation"""
+    model_id = random_test_id()
+    model_manager = ModelManager.get_instance()
+    # model load test already tests with archive - just using a model path here
+    model_manager.load_model(
+        model_id,
+        local_model_path=other_good_model_path,
+        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
+    )
+    yield model_id
+
+    # teardown
+    model_manager.unload_model(model_id)
+
+
+# IMPLEMENTATION DETAILS ############################################################
+
+
+def _check_server_readiness(server):
+    """Check server readiness"""
+
+    channel = grpc.insecure_channel(f"localhost:{server.port}")
+
+    done = False
+    while not done:
+        try:
+            stub = health_pb2_grpc.HealthStub(channel)
+            health_check_request = health_pb2.HealthCheckRequest()
+            stub.Check(health_check_request)
+            done = True
+        except grpc.RpcError:
+            log.debug("[RpcError]; will try to reconnect to test server in 0.1 second.")
+            time.sleep(0.1)

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -63,8 +63,9 @@ from sample_lib.data_model import (
     SampleOutputType,
     SampleTrainingType,
 )
-from tests.conftest import random_test_id, runtime_grpc_test_server, temp_config
+from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
+from tests.runtime.conftest import runtime_grpc_test_server
 import caikit
 import sample_lib
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,3 +73,12 @@ commands =
     pip uninstall grpcio-health-checking grpcio-reflection -y
     pip install protobuf==3.19.0 grpcio-health-checking grpcio-reflection --upgrade
     pytest --cov=caikit --cov-report=html {posargs:tests}
+
+# Ensure tests targeting caikit.core can be run with no optional dependencies
+[testenv:core]
+description = run tests against caikit.core without any extras
+base = ""
+extras = dev-test
+commands =
+    pytest tests/core
+

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,9 @@ envlist = py, lint, fmt, proto3
 
 [testenv]
 description = run tests with pytest with coverage
-deps =
-    pytest>=6.2.5,<7.0
-    pytest-cov>=2.10.1,<3.0
-    pytest-html>=3.1.1,<4.0
-    tls_test_tools>=0.1.1
-    wheel>=0.38.4
-extras = all
+extras =
+    all
+    dev-test
 passenv =
     LOG_LEVEL
     LOG_FILTERS
@@ -25,72 +21,45 @@ package=wheel
 
 [testenv:docs]
 recreate = True
-deps =
-    -r {toxinidir}/docs-requirements.txt
-    alchemy-config>=1.1.1,<2.0.0
-    alchemy-logging>=1.0.4,<2.0.0
-    anytree>=2.7.0,<3.0
-    docstring-parser>=0.14.1,<0.16.0
-    grpcio-health-checking>=1.35.0,<2.0
-    grpcio>=1.35.0,<2.0
-    ijson>=3.1.4,<3.3.0
-    munch>=2.5.0,<4.0
-    protobuf>=3.19.0,<5
-    prometheus_client>=0.12.0,<1.0
-    py-grpc-prometheus>=0.7.0,<0.8
-    PyYAML>=6.0,<7.0
-    requests>=2.26.0,<3.0
-    semver>=2.13.0,<4.0
-    six>=1.16.0,<2.0.0
-    tqdm>=4.59.0,<5.0.0
-    py-to-proto>=0.2.0,<0.3.0
-    import-tracker>=3.1.5,<4
+extras = dev-docs
 changedir = docs/source
 
 ; Disabled '-W' flag as warnings in the files
 ; TOTO: Add back in once build warnings fixed
 commands =
   sphinx-build -E -a -b html -T . _build/html
-skip_install = True
 
 [testenv:fmt]
 description = format with pre-commit
-deps = pre-commit>=3.0.4,<4.0
+extras = dev-fmt
 commands = ./scripts/fmt.sh
 allowlist_externals = ./scripts/fmt.sh
-skip_install = True # Skip package install since fmt doesn't need to execute code, for ⚡⚡⚡
 
 [testenv:lint]
 description = lint with pylint
-deps = pylint>=2.16.2,<3.0
+extras =
+    all
+    dev-fmt
 commands = pylint caikit
 
 [testenv:imports]
 description = enforce internal import rules
-deps = pydeps==1.12.3
+extras = dev-fmt
 commands = ./scripts/check_deps.sh
 allowlist_externals = ./scripts/check_deps.sh
-skip_install = True
 
 [testenv:publish]
 description = publish wheel to pypi
-deps = flit==3.8
+extras = dev-build
 passenv =
     FLIT_PASSWORD
 setenv =
     FLIT_USERNAME = __token__
 commands = flit publish
-skip_install = True
 
 # Ensure compatibility is maintained with protobuf 3.X
 [testenv:proto3]
 description = run tests with pytest with coverage
-deps =
-    pytest>=6.2.5,<7.0
-    pytest-cov>=2.10.1,<3.0
-    pytest-html>=3.1.1,<4.0
-    tls_test_tools>=0.1.1
-    wheel>=0.38.4
 commands =
     pip uninstall grpcio-health-checking grpcio-reflection -y
     pip install protobuf==3.19.0 grpcio-health-checking grpcio-reflection --upgrade

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest-html>=3.1.1,<4.0
     tls_test_tools>=0.1.1
     wheel>=0.38.4
+extras = all
 passenv =
     LOG_LEVEL
     LOG_FILTERS

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,15 @@ extras = dev-fmt
 commands = ./scripts/check_deps.sh
 allowlist_externals = ./scripts/check_deps.sh
 
+[testenv:build]
+description = build wheel
+extras = dev-build
+passenv =
+    FLIT_PASSWORD
+setenv =
+    FLIT_USERNAME = __token__
+commands = flit build
+
 [testenv:publish]
 description = publish wheel to pypi
 extras = dev-build


### PR DESCRIPTION
## Description

This PR sets up the framework for optional dependencies in `caikit` and refactors the existing dependency management into the following sets:

Closes: #228 

### User Deps
* `caikit`: Dependencies for `caikit.core`
* `caikit[runtime-grpc]`: Dependencies for the `grpc` runtime
* `caikit[all]`: All dependencies for user functionality in `caikit` (currently core + `runtime-grpc`)

### Developer Deps
* `dev-test`: Dependencies for running unit tests
* `dev-docs`: Dependencies for building documentation
* `dev-fmt`: Dependencies for formatting, linting, and other stylistic checks
* `dev-build`: Dependencies for building the wheel
* `all-dev`: All developer dependencies (including all user dependencies)

**NOTE**: The choice of `-` as a delimiter seems to be required when using `flit` as our build tool. I had originally used `.` which seemed a little cleaner to me, but the `flit` build commands used to build the temporary wheel that `tox` then used to create the venvs was not being built correctly.