### PR TITLE
Sync to async iter wrapper 224

### DIFF
--- a/caikit/core/toolkit/sync_to_async.py
+++ b/caikit/core/toolkit/sync_to_async.py
@@ -15,12 +15,15 @@
 wrapper functions
 """
 # Standard
-from typing import AsyncGenerator, Iterable
+from concurrent.futures import ThreadPoolExecutor
+from typing import AsyncGenerator, Iterable, Optional
 import asyncio
-import threading
 
 
-def async_wrap_iter(it: Iterable) -> AsyncGenerator:
+def async_wrap_iter(
+    it: Iterable,
+    pool: Optional[ThreadPoolExecutor] = None,
+) -> AsyncGenerator:
     """Wrap blocking iterable into an asynchronous one
 
     CITE: https://stackoverflow.com/a/62297994
@@ -55,5 +58,5 @@ def async_wrap_iter(it: Iterable) -> AsyncGenerator:
         finally:
             asyncio.run_coroutine_threadsafe(q.put(_END), loop).result()
 
-    threading.Thread(target=iter_to_queue).start()
+    loop.run_in_executor(pool, iter_to_queue)
     return yield_queue_items()

--- a/caikit/core/toolkit/sync_to_async.py
+++ b/caikit/core/toolkit/sync_to_async.py
@@ -1,0 +1,59 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds utilities for wrapping synchronous functionality into async
+wrapper functions
+"""
+# Standard
+from typing import AsyncGenerator, Iterable
+import asyncio
+import threading
+
+
+def async_wrap_iter(it: Iterable) -> AsyncGenerator:
+    """Wrap blocking iterable into an asynchronous one
+
+    CITE: https://stackoverflow.com/a/62297994
+
+    This function manages a single thread for the iteration that shuttles the
+    synchronous outputs back to the async generator using a queue
+    """
+    loop = asyncio.get_event_loop()
+    q = asyncio.Queue(1)
+    exception = None
+    _END = object()
+
+    async def yield_queue_items():
+        while True:
+            next_item = await q.get()
+            if next_item is _END:
+                break
+            yield next_item
+        if exception is not None:
+            # the iterator has raised, propagate the exception
+            raise exception
+
+    def iter_to_queue():
+        nonlocal exception
+        try:
+            for item in it:
+                # This runs outside the event loop thread, so we
+                # must use thread-safe API to talk to the queue.
+                asyncio.run_coroutine_threadsafe(q.put(item), loop).result()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            exception = e
+        finally:
+            asyncio.run_coroutine_threadsafe(q.put(_END), loop).result()
+
+    threading.Thread(target=iter_to_queue).start()
+    return yield_queue_items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,10 @@ all = [
 ## Dev Extra Sets ##
 
 dev-test = [
-    "pytest>=6.2.5,<8.0",
+    "pytest-asyncio>=0.21.0,<1",
     "pytest-cov>=2.10.1,<5.0",
     "pytest-html>=3.1.1,<4.0",
+    "pytest>=6.2.5,<8.0",
     "tls_test_tools>=0.1.1",
     "wheel>=0.38.4",
 ]

--- a/tests/core/toolkit/test_sync_to_async.py
+++ b/tests/core/toolkit/test_sync_to_async.py
@@ -1,0 +1,96 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for sync -> async wrappers"""
+# Standard
+import asyncio
+import time
+
+# Third Party
+import pytest
+
+# Local
+from caikit.core.toolkit.sync_to_async import async_wrap_iter
+
+## Helpers #####################################################################
+
+
+class IterableHelper:
+    def __init__(self, iterable, delay=0, raise_element=None):
+        self.iterable = iterable
+        self.delay = delay
+        self.raise_element = raise_element
+        self.idx = 0
+        self.iter = iter(self.iterable)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.delay:
+            time.sleep(self.delay)
+        next_element = next(self.iter)
+        if self.idx == self.raise_element:
+            raise RuntimeError("Raising")
+        self.idx += 1
+        return next_element
+
+
+async def azip(*aiterables):
+    aiterators = [aiterable.__aiter__() for aiterable in aiterables]
+    while aiterators:
+        results = await asyncio.gather(
+            *[ait.__anext__() for ait in aiterators],
+            return_exceptions=True,
+        )
+        if any(isinstance(result, StopAsyncIteration) for result in results):
+            return
+        yield tuple(results)
+
+
+## Tests #######################################################################
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_iter_happy():
+    """Make sure a simple iterable can be wrapped as async and round trip
+    cleanly
+    """
+    lst = [1, 2, 3, 4]
+    async_round_trip = [x async for x in async_wrap_iter(lst)]
+    assert lst == async_round_trip
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_iter_concurrent():
+    """Make sure that multiple wrapped synchronous iterators can interleve in
+    the event loop
+    """
+    lst1 = [1, 2, 3]
+    lst2 = [4, 5, 6]
+    iter1 = IterableHelper(lst1)
+    iter2 = IterableHelper(lst2)
+    aiter1 = async_wrap_iter(iter1)
+    aiter2 = async_wrap_iter(iter2)
+    zipped = [elt async for elt in azip(aiter1, aiter2)]
+    assert zipped == list(zip(lst1, lst2))
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_iter_exception_propagation():
+    """Make sure exceptions thrown during iteration are raised in the parent
+    async context
+    """
+    with pytest.raises(RuntimeError):
+        async for _ in async_wrap_iter(IterableHelper([1, 2, 3], raise_element=1)):
+            pass


### PR DESCRIPTION
## Description

Closes #224 

Depends on #241 

This PR adds a utility for wrapping synchronous iterators as `async` generators. It is needed for support of SSE streaming in the HTTP server.