### PR TITLE
:mute: remove WIP warning on local backend

### DIFF
--- a/caikit/core/module_backends/local_backend.py
+++ b/caikit/core/module_backends/local_backend.py
@@ -28,9 +28,9 @@ from ..modules.base import ModuleBase
 from ..modules.config import ModuleConfig
 from ..registries import module_registry
 from ..toolkit.errors import error_handler
+from ..toolkit.wip_decorator import TempDisableWIP
 from .backend_types import register_backend_type
 from .base import SharedLoadBackendBase, SharedTrainBackendBase
-from ..toolkit.wip_decorator import TempDisableWIP
 
 log = alog.use_channel("LCLBKND")
 error = error_handler.get(log)

--- a/caikit/core/module_backends/local_backend.py
+++ b/caikit/core/module_backends/local_backend.py
@@ -30,6 +30,7 @@ from ..registries import module_registry
 from ..toolkit.errors import error_handler
 from .backend_types import register_backend_type
 from .base import SharedLoadBackendBase, SharedTrainBackendBase
+from ..toolkit.wip_decorator import TempDisableWIP
 
 log = alog.use_channel("LCLBKND")
 error = error_handler.get(log)
@@ -80,4 +81,5 @@ class LocalBackend(SharedLoadBackendBase, SharedTrainBackendBase):
 
 
 # Register local backend
-register_backend_type(LocalBackend)
+with TempDisableWIP():
+    register_backend_type(LocalBackend)


### PR DESCRIPTION
For @evaline-ju 

The context is that this warning could be misleading for any `caikit` module users. While the local backend is registered by default. the "WIP" (work in progress/beta) message shows up in any library using caikit, and individual caikit library module users would not be dealing with the backend directly.