### PR TITLE
Fix example and test

### DIFF
--- a/examples/text-sentiment/requirements.txt
+++ b/examples/text-sentiment/requirements.txt
@@ -1,4 +1,4 @@
-caikit
+caikit[all]
 
 # Only needed for HuggingFace
 scipy

--- a/tests/examples/shared.py
+++ b/tests/examples/shared.py
@@ -58,7 +58,7 @@ def requirements(example: str) -> Tuple[str, str]:
         # Create a venv, install local version of caikit and local version of requirements
         venv.create(env_dir=venv_dir, system_site_packages=False, with_pip=True)
         try:
-            subprocess.run([pip, "install", "-e", caikit_dir], check=True)
+            subprocess.run([pip, "install", caikit_dir + "[all]"], check=True)
             subprocess.run(
                 [
                     pip,


### PR DESCRIPTION
Caikit needs to be installed with "pip install caikit[all]". Add "[all]" to the example requirements.txt to fix the example and to the examples test as well.

The change in the requirements configuration was merged before the example test was, so main is now broken.

This change also remove the delelopment mode from the pip command in the test examples, since it does not work without a setup.py from python3.9 and earlier.