### PR TITLE
🐛 caikit.interfaces.common bug fix

### DIFF
--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -31,6 +31,7 @@ from caikit.core.data_model.dataobject import _make_oneof_init, make_dataobject
 from caikit.core.data_model.streams.data_stream import DataStream
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import caikit
+import caikit.interfaces.common
 
 # This global holds the mapping of element types to their respective
 # DataStreamSource wrappers so that the same message is not recreated

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -31,6 +31,8 @@ from caikit.core.data_model.dataobject import _make_oneof_init, make_dataobject
 from caikit.core.data_model.streams.data_stream import DataStream
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import caikit
+
+# import common explicitly since this module needs it
 import caikit.interfaces.common
 
 # This global holds the mapping of element types to their respective


### PR DESCRIPTION
Import `caikit.interfaces.common` explicitly in `caikit/runtime/service_generation/data_stream_source.py` since this module needs it.