### PR TITLE
Don't error out of the training manager when not started

### DIFF
--- a/caikit/runtime/model_management/training_manager.py
+++ b/caikit/runtime/model_management/training_manager.py
@@ -38,7 +38,12 @@ class TrainingManager:
                 return TrainingStatus.FAILED
             return TrainingStatus.COMPLETED
 
-        raise RuntimeError("Unexpected error")
+        if future.cancelled():
+            return TrainingStatus.HALTED
+
+        # If it's not running and it's not done in some way, it hasn't started
+        # yet!
+        return TrainingStatus.NOT_STARTED
 
     @classmethod
     def get_instance(cls) -> "TrainingManager":


### PR DESCRIPTION
The test was flakey because it was hitting a race where the future had not yet started or completed and fell through to the Unexpected Error below. That error was there to handle shutdown and cancellation which seems unnecessary.

Closes: https://github.com/caikit/caikit/issues/258