### PR TITLE
Add a way to disable just the test_exaples

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,6 +25,7 @@ from tests.examples.shared import requirements, waitForPort
 
 
 @pytest.mark.examples
+@pytest.mark.skipif(getenv("SKIP_EXAMPLES") == "1", reason="It's really slow!")
 def test_example_text_sentiment():
     # Example specific grpc port
     grpc_port = 8085


### PR DESCRIPTION
They're really slow and I'm not touching them right now!

Supports: https://github.com/caikit/caikit/issues/54