### PR TITLE
Fix None edge case of docstring converter

### DIFF
--- a/caikit/core/data_model/streams/validator.py
+++ b/caikit/core/data_model/streams/validator.py
@@ -81,7 +81,7 @@ class DataStreamValidator:
 
         Args:
             data_item: A data object yielded by the stream
-            Nonedata_item_number: The index of the object in the stream
+            data_item_number: The index of the object in the stream
         """
         if isinstance(data_item, dict):
             # From dictionary: error if key doesn't exist

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -262,7 +262,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
         Args:
             *args: Variable length argument list to be passed directly to run().
-            None**kwargs: Arbitrary keyword arguments to be passed directly to run().
+            **kwargs: Arbitrary keyword arguments to be passed directly to run().
         Returns:
             tuple: Iterable of prediction outputs, run as a batch.
         """
@@ -357,7 +357,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
             data_stream (caikit.core.data_model.DataStream): Datastream to be
                 lazily sequentially processed by the module under consideration.
             *args: Variable length argument list to be passed directly to run().
-            None**kwargs: Arbitrary keyword arguments to be passed directly to run().
+            **kwargs: Arbitrary keyword arguments to be passed directly to run().
         Returns:
             protobufs: A DataBase object.
         """
@@ -545,7 +545,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
         Args:
             *args: Variable length argument list to be passed directly to run().
-            None**kwargs: Arbitrary keyword arguments to be passed directly to run().
+            **kwargs: Arbitrary keyword arguments to be passed directly to run().
         Returns:
             int: Inferred batch size based on expandable iterables.
         """

--- a/caikit/core/toolkit/quality_evaluation.py
+++ b/caikit/core/toolkit/quality_evaluation.py
@@ -134,7 +134,7 @@ class QualityEvaluator:
 
         Args:
             Note: here class should be initialized with gold and pred in the following format
-            Noneself.gold (list): list of gold set labels for every example, where each example
+            self.gold (list): list of gold set labels for every example, where each example
                 can have only one label eg: ['label1','label2', 'label3','label4']
             self.pred (list): Predicted-by-the-model set labels for every example.
             labels: list (Optional, defaults to None)
@@ -212,12 +212,12 @@ class QualityEvaluator:
 
         Args:
             Note: here class should be initialized with gold and pred in the following format
-                Noneself.gold (list(list)): list of gold set labels for every example eg:
-                    [['label1','label2'], ['label1', 'label4']]
-                self.pred (list(list)): Predicted-by-the-model set labels for every example.
+            self.gold (list(list)): list of gold set labels for every example eg:
+                [['label1','label2'], ['label1', 'label4']]
+            self.pred (list(list)): Predicted-by-the-model set labels for every example.
             find_label_func: function to fetch labels from any one prediction
-            Nonefind_label_data_func: function to fetch data that belongs to a certain class
-            Nonelabels: list (Optional, defaults to None)
+            find_label_data_func: function to fetch data that belongs to a certain class
+            labels: list (Optional, defaults to None)
                 Optional list of class labels to evaluate quality on. By default evaluation is done
                 over all class labels. Using this, you can explicitly mention only a subset of
                 labels to include in the quality evaluation.

--- a/caikit/runtime/model_management/model_sizer.py
+++ b/caikit/runtime/model_management/model_sizer.py
@@ -49,8 +49,8 @@ class ModelSizer:
         Returns the estimated memory footprint of a model
         Args:
             model_id: The model identifier, used for informative logging
-            Nonecos_model_path: The path to the model archive in S3 storage
-            Nonemodel_type: The type of model, used to adjust the memory estimate
+            cos_model_path: The path to the model archive in S3 storage
+            model_type: The type of model, used to adjust the memory estimate
         Returns:
             The estimated size in bytes of memory that would be used by loading this model
         """

--- a/caikit/runtime/work_management/destroyable_thread.py
+++ b/caikit/runtime/work_management/destroyable_thread.py
@@ -135,11 +135,11 @@ class DestroyableThread(threading.Thread):
 
     def get_or_throw(self):
         """
-                    After the thread has completed it's work, call this to get the output.
-                Returns:
-                    The resulting value of runnable_func(*runnable_args, **runnable_kwargs)
+            After the thread has completed it's work, call this to get the output.
+        Returns:
+            The resulting value of runnable_func(*runnable_args, **runnable_kwargs)
         Raises:
-                    Any exception raised by runnable_func(*runnable_args, **runnable_kwargs)
+            Any exception raised by runnable_func(*runnable_args, **runnable_kwargs)
         """
         if self.__destroyed:
             log.error(

--- a/scripts/dsconverter.py
+++ b/scripts/dsconverter.py
@@ -143,12 +143,15 @@ class CustomDocstringConverter:
                 + (num_word_ors_data_type * 2)
                 + (num_commas_data_type)
                 + (num_arrows_data_type * 2)
-            )
-
+            )   
             # If re accidentally absorbs description as data type
             if num_words_data_type >= 2:
-                return (
-                    f"{white_space}{name}: {data_type}\n{desc_white_space}{description}"
+                if description:
+                    return (
+                        f"{white_space}{name}: {data_type}\n{desc_white_space}{description}"
+                    )
+                return(
+                    f"{white_space}{name}: {data_type}\n{desc_white_space}"
                 )
             if description:
                 # Safety check if description is input incorrectly

--- a/scripts/dsconverter.py
+++ b/scripts/dsconverter.py
@@ -143,16 +143,12 @@ class CustomDocstringConverter:
                 + (num_word_ors_data_type * 2)
                 + (num_commas_data_type)
                 + (num_arrows_data_type * 2)
-            )   
+            )
             # If re accidentally absorbs description as data type
             if num_words_data_type >= 2:
                 if description:
-                    return (
-                        f"{white_space}{name}: {data_type}\n{desc_white_space}{description}"
-                    )
-                return(
-                    f"{white_space}{name}: {data_type}\n{desc_white_space}"
-                )
+                    return f"{white_space}{name}: {data_type}\n{desc_white_space}{description}"
+                return f"{white_space}{name}: {data_type}\n{desc_white_space}"
             if description:
                 # Safety check if description is input incorrectly
                 if (len(white_space.strip("\n"))) == len(desc_white_space):

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -805,9 +805,7 @@ def test_multiword_args():
                 The index of the object in the stream
         """
     '''
-    print(test1)
     converted = converter.convert_to_google_style(test1)
-    print(converted)
     assert (
         converted
         == '''

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -792,6 +792,7 @@ def test_multiword_args():
     '''
     )
 
+
 def test_multiword_args():
     converter = CustomDocstringConverter()
     test1 = '''
@@ -808,7 +809,7 @@ def test_multiword_args():
     converted = converter.convert_to_google_style(test1)
     print(converted)
     assert (
-        converted 
+        converted
         == '''
     """Validate a single data item from a data stream
 

--- a/scripts/test_dsconverter.py
+++ b/scripts/test_dsconverter.py
@@ -792,6 +792,33 @@ def test_multiword_args():
     '''
     )
 
+def test_multiword_args():
+    converter = CustomDocstringConverter()
+    test1 = '''
+    """Validate a single data item from a data stream
+
+        Args:
+            data_item: 
+                A data object yielded by the stream
+            data_item_number: 
+                The index of the object in the stream
+        """
+    '''
+    print(test1)
+    converted = converter.convert_to_google_style(test1)
+    print(converted)
+    assert (
+        converted 
+        == '''
+    """Validate a single data item from a data stream
+
+        Args:
+            data_item: A data object yielded by the stream
+            data_item_number: The index of the object in the stream
+        """
+    '''
+    )
+
 
 # Run the tests
 if __name__ == "__main__":


### PR DESCRIPTION
Addressing an edge case I didn't notice during initial PR #211. arg_replacement function would sometimes append the word "None" in front of an argument when it shouldn't have been there. This is because in another edge case where there is a description but no data type, I forgot to include the case that there might not be additional description past the first line. I also went back and manually fixed where "None" was appended in docstrings from the previous PR.