### PR TITLE
🐛 Fix multi-processing exception handling and train_location_handling fixture

### DIFF
--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -44,7 +44,11 @@ def set_train_location(request, sample_train_servicer):
     """This fixture ensures that all tests in this file will be run with both
     subprocess and local training styles
     """
+    prev_value = sample_train_servicer.use_subprocess
     sample_train_servicer.use_subprocess = request.param
+    yield
+    # Reset use_subprocess to previous value
+    sample_train_servicer.use_subprocess = prev_value
 
 
 # Train tests for the GlobalTrainServicer class ############################################################

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -345,7 +345,6 @@ def test_global_train_Edge_Case_Widget_should_raise_when_error_surfaces_from_mod
         jsondata=stream_type.JsonData(data=[SampleTrainingType(1)])
     ).to_proto()
 
-    sample_train_servicer.auto_load_trained_model = False
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=random_test_id(),
         batch_size=999,


### PR DESCRIPTION
### Changes
- Fix `set_train_location` fixture, which was not setting the `sample_train_servicer.use_subprocess` value correctly because:
    1. The format of config had changed
    2. The scope of `sample_train_servicer` was `session`, so the value of use_subprocess was not getting changed by test. Additionally, the GlobalTrainServicer interacts with service generation etc, changing the scope to `function` for this fixture would create errors.
- The `error` in `_ErrorCaptureProcess` was actually never getting set in case of exception. The reason for that is after forking another process, the instance with parent process of `_ErrorCaptureProcess` will not be same as with the child process. So even if child process sets the value of `self.error` it will not get propagated to the parent and thus the `SubProcessTrainExecutor` will never get any value in `self._worker.error`. In this fix, I am using python multiprocessing Pipe mechanism to communicate between child and parent.