### PR TITLE
Local trainer

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -33,6 +33,7 @@ model_management:
         default:
             type: LOCAL
             config:
+                # Format: XdXhXmXs
                 retention_duration: 1d
                 use_subprocess: false
     finders:

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -32,6 +32,8 @@ model_management:
     trainers:
         default:
             type: LOCAL
+            config:
+                retention_duration: 1d
     finders:
         default:
             type: LOCAL

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -34,6 +34,7 @@ model_management:
             type: LOCAL
             config:
                 retention_duration: 1d
+                use_subprocess: false
     finders:
         default:
             type: LOCAL

--- a/caikit/core/model_management/factories.py
+++ b/caikit/core/model_management/factories.py
@@ -19,10 +19,12 @@ Global factories for model management
 from ..toolkit.factory import Factory
 from .local_model_finder import LocalModelFinder
 from .local_model_initializer import LocalModelInitializer
+from .local_model_trainer import LocalModelTrainer
 
 # Model trainer factory. A trainer is responsible for performing the train
 # operation against a configured framework connection.
 model_trainer_factory = Factory("ModelTrainer")
+model_trainer_factory.register(LocalModelTrainer)
 
 # Model finder factory. A finder is responsible for locating a well defined
 # configuration for a model based on a unique path or id.

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -65,7 +65,7 @@ class LocalModelTrainer(ModelTrainerBase):
 
         def __init__(
             self,
-            parent_name: str,
+            trainer_name: str,
             module_class: Type[ModuleBase],
             *args,
             save_path: Optional[str],
@@ -75,7 +75,7 @@ class LocalModelTrainer(ModelTrainerBase):
             **kwargs,
         ):
             super().__init__(
-                parent_name=parent_name,
+                trainer_name=trainer_name,
                 training_id=str(uuid.uuid4()),
                 save_with_id=save_with_id,
                 save_path=save_path,

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -1,0 +1,259 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The LocalModelTrainer uses a local thread to launch and manage each training job
+"""
+
+# Standard
+from concurrent.futures.thread import _threads_queues
+from datetime import datetime, timedelta
+from typing import Optional, Type
+import os
+import re
+import threading
+import uuid
+
+# First Party
+import aconfig
+import alog
+
+# Local
+from ..modules import ModuleBase
+from ..toolkit.destroyable_thread import DestroyableThread
+from ..toolkit.errors import error_handler
+from .model_trainer_base import ModelTrainerBase
+
+log = alog.use_channel("TH-TAINER")
+error = error_handler.get(log)
+
+
+OOM_EXIT_CODE = 137
+
+
+# 🌶️🌶️🌶️
+# Fix for python3.9, 3.10 and 3.11 issue where forked processes always exit with exitcode 1
+# when it's created inside a ThreadPoolExecutor: https://github.com/python/cpython/issues/88110
+# Fix taken from https://github.com/python/cpython/pull/101940
+# Credit: marmarek, https://github.com/marmarek
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_threads_queues.clear)
+
+
+class LocalModelTrainer(ModelTrainerBase):
+    __doc__ = __doc__
+
+    name = "LOCAL"
+
+    class LocalModelFuture(ModelTrainerBase.ModelFutureBase):
+        """A local model future manages an execution thread for a single train
+        operation
+        """
+
+        def __init__(
+            self,
+            module_class: Type[ModuleBase],
+            *args,
+            save_path: Optional[str],
+            save_with_id: bool,
+            **kwargs,
+        ):
+            self._id = str(uuid.uuid4())
+            self._module_class = module_class
+            self._save_path = ModelTrainerBase.save_path_with_id(
+                save_path, save_with_id, self.id
+            )
+
+            # Placeholder for the time when the future completed
+            self._completion_time = None
+
+            # Set up the worker and start it
+            self._complete_event = threading.Event()
+            self._worker = DestroyableThread(
+                self._complete_event,
+                self._train_and_save,
+                *args,
+                **kwargs,
+            )
+            self._worker.start()
+
+        @property
+        def completion_time(self) -> Optional[datetime]:
+            return self._completion_time
+
+        ## Interface ##
+
+        @property
+        def id(self) -> str:
+            return self._id
+
+        @property
+        def save_path(self) -> str:
+            return self._save_path
+
+        def get_status(self) -> ModelTrainerBase.TrainingStatus:
+            """Every model future must be able to poll the status of the
+            training job
+            """
+            # If the thread is currently alive it's doing work
+            if self._worker.is_alive():
+                return ModelTrainerBase.TrainingStatus.RUNNING
+
+            # If the thread is not alive, threw, and was destroyed, the throw
+            # was caused by a deliberate cancellation
+            if self._worker.destroyed and self._worker.threw:
+                return ModelTrainerBase.TrainingStatus.CANCELED
+
+            # If the worker threw, but was not destroyed, it was an error in the
+            # train function
+            if self._worker.threw:
+                return ModelTrainerBase.TrainingStatus.ERRORED
+
+            # If the thread ran and none of the non-success termination states
+            # is true, it completed successfully
+            if self._worker.ran:
+                return ModelTrainerBase.TrainingStatus.COMPLETED
+
+            # If it's not alive and not done, it hasn't started yet
+            return ModelTrainerBase.TrainingStatus.QUEUED
+
+        def cancel(self):
+            """Terminate the given training"""
+            log.debug("Canceling training %s", self.id)
+            with alog.ContextTimer(
+                log.debug2, "Done canceling training %s in: ", self.id
+            ):
+                self._worker.destroy()
+                self.wait()
+
+        def wait(self):
+            """Block until the job reaches a terminal state"""
+            self._complete_event.wait()
+            self._worker.join()
+
+        def load(self) -> ModuleBase:
+            """Wait for the training to complete, then return the resulting
+            model or raise any errors that happened during training.
+            """
+            self.wait()
+            return self._worker.get_or_throw()
+
+        ## Impl ##
+
+        def _train_and_save(self, *args, **kwargs):
+            """Function that will run in the worker thread"""
+            with alog.ContextTimer(log.debug, "Training %s finished in: ", self.id):
+                trained_model = self._module_class.train(*args, **kwargs)
+            if self.save_path is not None:
+                log.debug("Saving training %s to %s", self.id, self.save_path)
+                with alog.ContextTimer(log.debug, "Training %s saved in: ", self.id):
+                    trained_model.save(self.save_path)
+            self._completion_time = datetime.now()
+            return trained_model
+
+    ## Interface ##
+
+    # Expression for parsing retention policy
+    _timedelta_expr = re.compile(
+        r"^((?P<days>\d+?)d)?((?P<hours>\d+?)hr)?((?P<minutes>\d+?)m)?((?P<seconds>\d*\.?\d*?)s)?$"
+    )
+
+    def __init__(self, config: aconfig.Config):
+        """Initialize with a shared dict of all trainings"""
+        self._retention_duration = config.get("retention_duration")
+        if self._retention_duration is not None:
+            try:
+                self._retention_duration = timedelta(
+                    **{
+                        key: float(val)
+                        for key, val in self._timedelta_expr.match("23d")
+                        .groupdict()
+                        .items()
+                        if val is not None
+                    }
+                )
+            except AttributeError:
+                error(
+                    "<COR63897671E>",
+                    f"Invalid retention_duration: {self._retention_duration}",
+                )
+
+        # The shared dict of futures and a lock to serialize mutations to it
+        self._futures = {}
+        self._futures_lock = threading.Lock()
+
+    def train(
+        self,
+        module_class: Type[ModuleBase],
+        *args,
+        save_path: Optional[str] = None,
+        save_with_id: bool = False,
+        **kwargs,
+    ) -> "LocalModelFuture":
+        """Start training the given module and return a future to the trained
+        model instance
+        """
+        # Always purge old futures
+        self._purge_old_futures()
+
+        # Create the new future
+        model_future = self.LocalModelFuture(
+            module_class,
+            *args,
+            save_path=save_path,
+            save_with_id=save_with_id,
+            **kwargs,
+        )
+
+        # Lock the global futures dict and add it to the dict
+        with self._futures_lock:
+            assert (
+                model_future.id not in self._futures
+            ), f"UUID collision for model future {model_future.id}"
+            self._futures[model_future.id] = model_future
+
+        # Return the future
+        return model_future
+
+    def get_model_future(self, training_id: str) -> "LocalModelFuture":
+        """Look up the model future for the given id"""
+        self._purge_old_futures()
+        if model_future := self._futures.get(training_id):
+            return model_future
+        raise ValueError(f"Unknown training_id: {training_id}")
+
+    ## Impl ##
+
+    def _purge_old_futures(self):
+        """If a retention duration is configured, purge any futures that are
+        older than the policy
+        """
+        if self._retention_duration is None:
+            return
+        now = datetime.now()
+        purged_ids = {
+            fid
+            for fid, future in self._futures.items()
+            if future.completion_time is not None
+            and future.completion_time + self._retention_duration < now
+        }
+        if not purged_ids:
+            log.debug3("No ids to purge")
+            return
+        log.debug3("Purging ids: %s", purged_ids)
+        with self._futures_lock:
+            for fid in purged_ids:
+                # NOTE: Concurrent purges could have already done this, so don't
+                #   error if the id is already gone
+                self._futures.pop(fid, None)

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -191,12 +191,16 @@ class LocalModelTrainer(ModelTrainerBase):
                 error.value_check(
                     "<COR16745216E>",
                     self.save_path,
-                    "Unable to load model trained in subprocess without a save_path",
+                    "Unable to load model from training {} "
+                    + "trained in subprocess without a save_path",
+                    self.id,
                 )
                 error.value_check(
                     "<COR59551640E>",
                     os.path.exists(self.save_path),
-                    "Unable to load model saved in subprocess at {}",
+                    "Unable to load model from training {} "
+                    + "saved in subprocess, path does not exist: {}",
+                    self.id,
                     self.save_path,
                 )
                 result = caikit.load(self.save_path)

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -68,6 +68,7 @@ class LocalModelTrainer(ModelTrainerBase):
             *args,
             save_path: Optional[str],
             save_with_id: bool,
+            external_training_id: Optional[str],
             **kwargs,
         ):
             super().__init__(
@@ -76,6 +77,16 @@ class LocalModelTrainer(ModelTrainerBase):
                 save_with_id=save_with_id,
                 save_path=save_path,
             )
+
+            # If an external id is given, use it explicitly
+            if external_training_id is not None:
+                self._id = external_training_id
+                self._save_path = self._save_path_with_id(
+                    save_path,
+                    save_with_id,
+                    external_training_id,
+                )
+
             self._module_class = module_class
 
             # Placeholder for the time when the future completed
@@ -195,6 +206,7 @@ class LocalModelTrainer(ModelTrainerBase):
         *args,
         save_path: Optional[str] = None,
         save_with_id: bool = False,
+        external_training_id: Optional[str] = None,
         **kwargs,
     ) -> "LocalModelFuture":
         """Start training the given module and return a future to the trained
@@ -210,6 +222,7 @@ class LocalModelTrainer(ModelTrainerBase):
             *args,
             save_path=save_path,
             save_with_id=save_with_id,
+            external_training_id=external_training_id,
             **kwargs,
         )
 

--- a/caikit/core/model_management/model_trainer_base.py
+++ b/caikit/core/model_management/model_trainer_base.py
@@ -68,13 +68,13 @@ class ModelTrainerBase(FactoryConstructible):
 
         def __init__(
             self,
-            parent_name: str,
+            trainer_name: str,
             training_id: str,
             save_with_id: bool,
             save_path: Optional[str],
         ):
             self._id = self.__class__.ID_DELIMITER.join(
-                [ReversibleHasher.hash(parent_name), training_id]
+                [ReversibleHasher.hash(trainer_name), training_id]
             )
             self._save_path = self.__class__._save_path_with_id(
                 save_path,

--- a/caikit/core/toolkit/destroyable_thread.py
+++ b/caikit/core/toolkit/destroyable_thread.py
@@ -74,6 +74,7 @@ class DestroyableThread(threading.Thread, Destroyable):
         self.__runnable_result = None
         self.__runnable_exception = None
         self.__threw = False
+        self.__started = False
         self.__ran = False
 
         # In case `destroy` is called before Python has actually started the thread, we need to
@@ -86,7 +87,7 @@ class DestroyableThread(threading.Thread, Destroyable):
 
     @property
     def canceled(self) -> bool:
-        return self.destroyed and self.threw
+        return self.destroyed and self.__started
 
     @property
     def ran(self) -> bool:
@@ -116,6 +117,7 @@ class DestroyableThread(threading.Thread, Destroyable):
             )
             self.__raise()
 
+        self.__started = True
         try:
             self.__runnable_result = self.runnable_func(
                 *self.runnable_args, **self.runnable_kwargs

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -104,7 +104,7 @@ class TestTrainer(ModelTrainerBase):
 
         def __init__(self, parent, trained_model, save_path, save_with_id):
             super().__init__(
-                parent_name=parent.instance_name,
+                trainer_name=parent.instance_name,
                 training_id=str(uuid.uuid4()),
                 save_path=save_path,
                 save_with_id=save_with_id,

--- a/tests/core/model_management/__init__.py
+++ b/tests/core/model_management/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/core/model_management/test_local_model_trainer.py
+++ b/tests/core/model_management/test_local_model_trainer.py
@@ -1,0 +1,209 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for LocalModelTrainer
+"""
+# Standard
+from datetime import timedelta
+from typing import Optional
+import multiprocessing
+import os
+import tempfile
+import threading
+import time
+
+# Third Party
+import pytest
+
+# First Party
+import aconfig
+
+# Local
+from caikit.core.data_model import DataStream
+from caikit.core.model_management.local_model_trainer import (
+    OOM_EXIT_CODE,
+    LocalModelTrainer,
+)
+from caikit.core.model_management.model_trainer_base import ModelTrainerBase
+from sample_lib.modules import SampleModule
+
+## Helpers #####################################################################
+
+
+def local_trainer(**kwargs) -> LocalModelTrainer:
+    cfg = aconfig.Config(kwargs, override_env_vars=False)
+    return LocalModelTrainer(cfg, "test-instance")
+
+
+@pytest.fixture(params=[True, False])
+def trainer_type_cfg(request):
+    yield {"use_subprocess": request.param}
+
+
+@pytest.fixture
+def save_path():
+    with tempfile.TemporaryDirectory() as workdir:
+        yield os.path.join(workdir, "model_save_dir")
+
+
+def get_event(cfg: dict):
+    return cfg.get("use_subprocess") and multiprocessing.Event() or threading.Event()
+
+
+## Tests #######################################################################
+
+
+def test_train_and_get_status(trainer_type_cfg):
+    """Test that running a training can fetch status correctly"""
+    trainer = local_trainer(**trainer_type_cfg)
+
+    # Launch the training and force it to wait
+    # NOTE: Data stream passed by positional arg to ensure it is passed through
+    #   correctly by position
+    wait_event = get_event(trainer_type_cfg)
+    model_future = trainer.train(
+        SampleModule,
+        DataStream.from_iterable([]),
+        wait_event=wait_event,
+    )
+    assert model_future.get_status() == ModelTrainerBase.TrainingStatus.RUNNING
+    assert not model_future.get_status().is_terminal
+
+    # Let the training proceed and wait for it to complete
+    wait_event.set()
+    model_future.wait()
+    assert model_future.get_status() == ModelTrainerBase.TrainingStatus.COMPLETED
+    assert model_future.get_status().is_terminal
+
+    # Re-fetch the future by ID
+    fetched_future = trainer.get_model_future(model_future.id)
+    assert fetched_future is model_future
+
+
+def test_train_save_and_load(trainer_type_cfg, save_path):
+    """Test that a trained model can be loaded"""
+    trainer = local_trainer(**trainer_type_cfg)
+    model_future = trainer.train(
+        SampleModule,
+        training_data=DataStream.from_iterable([]),
+        save_path=save_path,
+    )
+    model_future.wait()
+
+    # Make sure it can be loaded manually
+    model = SampleModule.load(save_path)
+    assert isinstance(model, SampleModule)
+
+    # Make sure that it can be loaded via the future
+    # NOTE: With a subprocess, this requires that save path is given so that the
+    #   model can be re-loaded from disk
+    model = model_future.load()
+    assert isinstance(model, SampleModule)
+
+
+def test_save_with_id(trainer_type_cfg, save_path):
+    """Test that saving with the training id correctly injects the ID in the
+    save path
+    """
+    trainer = local_trainer(**trainer_type_cfg)
+    model_future = trainer.train(
+        SampleModule,
+        training_data=DataStream.from_iterable([]),
+        save_path=save_path,
+        save_with_id=True,
+    )
+    model_future.wait()
+    assert model_future.save_path != save_path
+    assert model_future.id in model_future.save_path
+    assert os.path.exists(model_future.save_path)
+
+
+def test_cancel_clean_termination(trainer_type_cfg):
+    """Test that cancelling an in-progress training successfully destroys the
+    training when the training is run in a way that can be shut down cleanly
+    """
+    trainer = local_trainer(**trainer_type_cfg)
+    model_future = trainer.train(
+        SampleModule,
+        training_data=DataStream.from_iterable([]),
+        sleep_time=1000,
+    )
+    assert model_future.get_status() == ModelTrainerBase.TrainingStatus.RUNNING
+    assert not model_future.get_status().is_terminal
+
+    # Cancel the future
+    model_future.cancel()
+    assert model_future.get_status() == ModelTrainerBase.TrainingStatus.CANCELED
+    assert model_future.get_status().is_terminal
+    model_future.wait()
+
+
+def test_cancel_without_waiting(trainer_type_cfg):
+    """Test that cancelling an in-progress training that uses a long sleep (and
+    can't be easily destroyed in a thread) still reports CANCELED as the status
+    before the training has fully terminated.
+    """
+    trainer = local_trainer(**trainer_type_cfg)
+    model_future = trainer.train(
+        SampleModule,
+        training_data=DataStream.from_iterable([]),
+        sleep_time=0.5,
+        sleep_increment=0.5,
+    )
+    assert model_future.get_status() == ModelTrainerBase.TrainingStatus.RUNNING
+    assert not model_future.get_status().is_terminal
+
+    # Cancel the future and make sure it reports canceled, even though the
+    # function is still sleeping
+    model_future.cancel()
+    assert model_future.get_status() == ModelTrainerBase.TrainingStatus.CANCELED
+    assert model_future.get_status().is_terminal
+    model_future.wait()
+
+
+def test_no_retention_time(trainer_type_cfg):
+    """Test that constructing with no configured retention period keeps futures
+    forever and doesn't cause errors
+    """
+    trainer = local_trainer(retention_duration=None, **trainer_type_cfg)
+    model_future = trainer.train(SampleModule, DataStream.from_iterable([]))
+    model_future.wait()
+    retrieved_future = trainer.get_model_future(model_future.id)
+    assert retrieved_future is model_future
+
+
+def test_purge_retention_time(trainer_type_cfg):
+    """Test that purging old models works as expected"""
+    trainer = local_trainer(retention_duration="0.1s", **trainer_type_cfg)
+    model_future = trainer.train(SampleModule, DataStream.from_iterable([]))
+    model_future.wait()
+    retrieved_future = trainer.get_model_future(model_future.id)
+    assert retrieved_future is model_future
+    time.sleep(0.2)
+    with pytest.raises(ValueError):
+        trainer.get_model_future(model_future.id)
+
+
+@pytest.mark.parametrize(
+    "test_params",
+    [
+        ("1d", timedelta(days=1)),
+        ("0.1s", timedelta(seconds=0.1)),
+        ("1d12h3m0.2s", timedelta(days=1, hours=12, minutes=3, seconds=0.2)),
+    ],
+)
+def test_retention_duration_parse(test_params):
+    """Make sure the regex for the duration can parse all expected durations"""
+    trainer = local_trainer(retention_duration=test_params[0])
+    assert trainer._retention_duration == test_params[1]

--- a/tests/core/toolkit/test_destroyable_thread.py
+++ b/tests/core/toolkit/test_destroyable_thread.py
@@ -35,7 +35,7 @@ from caikit.core.toolkit.destroyable_thread import (
 def test_threads_can_be_interrupted():
     def infinite_wait():
         while True:
-            time.sleep(0.1)
+            time.sleep(0.001)
 
     thread = DestroyableThread(infinite_wait)
     thread.start()
@@ -71,10 +71,9 @@ def test_threads_canceled_when_interrupt_fails():
     start_event.set()
     thread.destroy()
     assert thread.canceled
-    # NOTE: This assertion can theoretically fail due to the above-mentioned
-    #   race conditions. If it becomes a problem, we can remove it, but it would
-    #   make the test a bit weaker.
-    assert thread.is_alive()
+    # NOTE: We don't assert that thread.is_alive() here since it's potentially
+    #   susceptible to the above mentioned race conditions. It _should_ always
+    #   be true, though, based on reasonable timing.
     thread.join(60)
     assert not thread.is_alive()
 
@@ -87,7 +86,7 @@ def test_threads_can_catch_the_interrupts():
         try:
             started_event.set()
             while True:
-                time.sleep(0.1)
+                time.sleep(0.001)
         except Exception as e:
             caught_event.set()
             raise e

--- a/tests/core/toolkit/test_destroyable_thread.py
+++ b/tests/core/toolkit/test_destroyable_thread.py
@@ -38,11 +38,22 @@ def test_threads_can_be_interrupted():
             time.sleep(0.1)
 
     thread = DestroyableThread(infinite_wait)
-
     thread.start()
     thread.destroy()
+    assert thread.canceled
     thread.join(60)
+    assert not thread.is_alive()
 
+
+def test_threads_canceled_when_interrupt_fails():
+    def long_sleep():
+        time.sleep(0.2)
+
+    thread = DestroyableThread(long_sleep)
+    thread.start()
+    thread.destroy()
+    assert thread.canceled
+    thread.join(60)
     assert not thread.is_alive()
 
 

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -107,8 +107,17 @@ class SampleModule(caikit.core.ModuleBase):
         training_data: DataStream[SampleTrainingType],
         batch_size: int = 64,
         oom_exit: bool = False,
+        **kwargs,
     ) -> "SampleModule":
         """Sample training method that produces a trained model"""
+
+        # If needed, wait for an event
+        # NOTE: We need to pull this from **kwargs because it's not a valid arg
+        #   for train API deduction. It's only needed for testing purposes, so
+        #   this is definitely a non-standard usage pattern!
+        wait_event = kwargs.get("wait_event")
+        if wait_event is not None:
+            wait_event.wait()
 
         if oom_exit:
             # exit with OOM code. Note _exit method is used to exit the

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -4,6 +4,7 @@ A sample module for sample things!
 # Standard
 from typing import Iterable
 import os
+import time
 
 # Local
 from ...data_model.sample import (
@@ -107,6 +108,8 @@ class SampleModule(caikit.core.ModuleBase):
         training_data: DataStream[SampleTrainingType],
         batch_size: int = 64,
         oom_exit: bool = False,
+        sleep_time: float = 0,
+        sleep_increment: float = 0.001,
         **kwargs,
     ) -> "SampleModule":
         """Sample training method that produces a trained model"""
@@ -118,6 +121,16 @@ class SampleModule(caikit.core.ModuleBase):
         wait_event = kwargs.get("wait_event")
         if wait_event is not None:
             wait_event.wait()
+
+        # If needed, wait for a long time
+        # NOTE: DestroyableThread is a "best effort" at destroying a threaded
+        #   work and is not actually capable of destroying many type of work. If
+        #   this is written as time.sleep(sleep_time), the interrupt will not
+        #   work.
+        if sleep_time:
+            start_time = time.time()
+            while time.time() - sleep_time < start_time:
+                time.sleep(sleep_increment)
 
         if oom_exit:
             # exit with OOM code. Note _exit method is used to exit the


### PR DESCRIPTION
## Description

This PR adds the `LocalModelTrainer` implementation of the `ModelTrainerBase` abstraction so that `caikit.train` can use it. It is configurable to use either a `DestroyableThread` or a `DestroyableProcess` to perform the asynchronous training job.

Closes #308 

**Upstream PRs**

* https://github.com/caikit/caikit/pull/304
* https://github.com/caikit/caikit/pull/288
* https://github.com/caikit/caikit/pull/309