### PR TITLE
✨ Support input streams in servicer

### DIFF
--- a/caikit/core/task.py
+++ b/caikit/core/task.py
@@ -417,11 +417,6 @@ def task(
         if _STREAM_PARAMS_ANNOTATION in cls_annotations:
             params_dict = cls.get_required_parameters(input_streaming=True)
             error.type_check("<COR19556230E>", dict, params_dict=params_dict)
-            error.value_check(
-                "<COR56569734E>",
-                len(params_dict) == 1,
-                "Only a single streaming input type supported",
-            )
             error.type_check_all(
                 "<COR58796465E>", str, params_dict_keys=params_dict.keys()
             )

--- a/caikit/core/task.py
+++ b/caikit/core/task.py
@@ -199,7 +199,7 @@ class TaskBase:
     @classmethod
     def get_required_parameters(
         cls, input_streaming: bool
-    ) -> Dict[str, ValidInputTypes]:
+    ) -> Dict[str, Union[ValidInputTypes, Type[Iterable[ValidInputTypes]]]]:
         """Get the set of input types required by this task"""
         if not input_streaming:
             if _UNARY_PARAMS_ANNOTATION not in cls.__annotations__:

--- a/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
+++ b/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
@@ -200,14 +200,9 @@ class CaikitRuntimeServerWrapper(grpc.Server):
                     original_rpc_handler = handler.service(DummyHandlerCallDetails(fqm))
 
                     # Find the Caikit RPC that maps to this rpc
-                    matching_rpcs = [
-                        rpc
-                        for rpc in self._intercepted_svc_package.caikit_rpcs
-                        if rpc.name == method
-                    ]
-                    if len(matching_rpcs) != 1:
+                    caikit_rpc = self._intercepted_svc_package.caikit_rpcs.get(method, None)
+                    if not caikit_rpc:
                         raise ValueError(f"No Caikit RPC Found for method: {method}")
-                    caikit_rpc = matching_rpcs[0]
 
                     # Now, swap out the original unary-unary callable with our
                     # generic predict method, and add this newly re-routed RPC

--- a/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
+++ b/caikit/runtime/interceptors/caikit_runtime_server_wrapper.py
@@ -200,7 +200,9 @@ class CaikitRuntimeServerWrapper(grpc.Server):
                     original_rpc_handler = handler.service(DummyHandlerCallDetails(fqm))
 
                     # Find the Caikit RPC that maps to this rpc
-                    caikit_rpc = self._intercepted_svc_package.caikit_rpcs.get(method, None)
+                    caikit_rpc = self._intercepted_svc_package.caikit_rpcs.get(
+                        method, None
+                    )
                     if not caikit_rpc:
                         raise ValueError(f"No Caikit RPC Found for method: {method}")
 

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -15,7 +15,7 @@
 # Standard
 from enum import Enum
 from types import ModuleType
-from typing import Callable, Set, Type
+from typing import Callable, Set, Type, Dict
 import dataclasses
 
 # Third Party
@@ -73,7 +73,7 @@ class ServicePackage:
     ]
     stub_class: Type
     messages: ModuleType
-    caikit_rpcs: Set[CaikitRPCBase]
+    caikit_rpcs: Dict[str, CaikitRPCBase]
 
 
 class ServicePackageFactory:
@@ -111,7 +111,7 @@ class ServicePackageFactory:
                 registration_function=grpc_service.registration_function,
                 stub_class=grpc_service.client_stub_class,
                 messages=None,  # we don't need messages here
-                caikit_rpcs=set(),  # No caikit RPCs
+                caikit_rpcs={},  # No caikit RPCs
             )
 
         # First make sure we import the data model for the correct library
@@ -162,7 +162,7 @@ class ServicePackageFactory:
             registration_function=grpc_service.registration_function,
             stub_class=grpc_service.client_stub_class,
             messages=client_module,
-            caikit_rpcs=set(rpc_list),
+            caikit_rpcs={rpc.name: rpc for rpc in rpc_list},
         )
 
     # Implementation details for pure python service packages #

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -15,7 +15,7 @@
 # Standard
 from enum import Enum
 from types import ModuleType
-from typing import Callable, Set, Type, Dict
+from typing import Callable, Dict, Set, Type
 import dataclasses
 
 # Third Party

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -91,7 +91,7 @@ def handle_protoables_in_union(arg_type: Type) -> Type:
     log.debug("Skipping non-protoable argument type [%s]", arg_type)
 
 
-def extract_data_model_type_from_union(arg_type: Type) -> Type:
+def get_protoable_return_type(arg_type: Type) -> Type:
     """Helper function that determines the right data model type to use from a Union"""
 
     # Decompose this type using typing to determine if it's a useful typing hint
@@ -109,7 +109,16 @@ def extract_data_model_type_from_union(arg_type: Type) -> Type:
             log.debug2(
                 "Found data model types in Union: [%s], taking first one", dm_types
             )
-            return extract_data_model_type_from_union(dm_types[0])
+            return get_protoable_return_type(dm_types[0])
+
+    # Handle iterables by returning `Iterable[T]`
+    # py38 compatibility here
+    try:
+        iter(arg_type)
+        if typing_origin:
+            return typing.Iterable[typing_args]
+    except TypeError:
+        pass
 
     # if it's anything else we just return as is
     # we don't actually want to throw errors from service generation

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -254,8 +254,14 @@ class TaskPredictRPC(CaikitRPCBase):
         )
 
         # Validate that the return_type of all modules in the grouping matches
-        return_types = {protoable.get_protoable_return_type(method.return_type) for method in method_signatures}
-        assert len(return_types) == 1, f"Found multiple return types for task [{task}], rpc: [{self._task_to_rpc_name()}. Return types: {return_types}]"
+        return_types = {
+            protoable.get_protoable_return_type(method.return_type)
+            for method in method_signatures
+        }
+        assert (
+            len(return_types) == 1
+        ), f"Found multiple return types for task [{task}], rpc: [{self._task_to_rpc_name()}. " \
+           f"Return types: {return_types}]"
         self.return_type = list(return_types)[0]
 
         # Create the rpc name based on the module type

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -258,10 +258,10 @@ class TaskPredictRPC(CaikitRPCBase):
             protoable.get_protoable_return_type(method.return_type)
             for method in method_signatures
         }
-        assert (
-            len(return_types) == 1
-        ), f"Found multiple return types for task [{task}], rpc: [{self._task_to_rpc_name()}. " \
-           f"Return types: {return_types}]"
+        assert len(return_types) == 1, (
+            f"Found multiple return types for task [{task}], rpc: [{self._task_to_rpc_name()}. "
+            f"Return types: {return_types}]"
+        )
         self.return_type = list(return_types)[0]
 
         # Create the rpc name based on the module type

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -254,10 +254,9 @@ class TaskPredictRPC(CaikitRPCBase):
         )
 
         # Validate that the return_type of all modules in the grouping matches
-        return_types = {method.return_type for method in method_signatures}
-        assert len(return_types) == 1, f"Found multiple return types for task [{task}]"
-        return_type = list(return_types)[0]
-        self.return_type = protoable.extract_data_model_type_from_union(return_type)
+        return_types = {protoable.get_protoable_return_type(method.return_type) for method in method_signatures}
+        assert len(return_types) == 1, f"Found multiple return types for task [{task}], rpc: [{self._task_to_rpc_name()}. Return types: {return_types}]"
+        self.return_type = list(return_types)[0]
 
         # Create the rpc name based on the module type
         self._name = self._task_to_rpc_name()

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -273,6 +273,14 @@ class TaskPredictRPC(CaikitRPCBase):
     def request(self) -> "_RequestMessage":
         return self._req
 
+    @property
+    def input_streaming(self) -> bool:
+        return self._input_streaming
+
+    @property
+    def output_streaming(self) -> bool:
+        return self._output_streaming
+
     def _handle_task_inputs(self, method_params: Dict[str, Any]) -> Dict[str, Any]:
         """Overrides input params with types specified in the Task"""
         new_params = {}

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -362,9 +362,11 @@ class GlobalPredictServicer:
         stream_num += 1
 
         for param in streaming_params.keys():
+
             def build_getter_from_request_dict(param_name: str) -> Any:
                 def get_fn(request_dict):
                     return request_dict.get(param_name)
+
                 return get_fn
 
             param_stream = (

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -130,7 +130,7 @@ class GlobalPredictServicer:
 
     def Predict(
         self,
-        request: ProtobufMessage,
+        request: ProtobufMessage | Iterable[ProtobufMessage],
         context: ServicerContext,
         *_,
         **__,

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -132,7 +132,7 @@ class GlobalPredictServicer:
 
     def Predict(
         self,
-        request: ProtobufMessage | Iterable[ProtobufMessage],
+        request: Union[ProtobufMessage, Iterable[ProtobufMessage]],
         context: ServicerContext,
         caikit_rpc: TaskPredictRPC,
         *_,

--- a/caikit/runtime/utils/servicer_util.py
+++ b/caikit/runtime/utils/servicer_util.py
@@ -14,11 +14,11 @@
 """A generic module to help Predict and Train servicers
 """
 # Standard
-from typing import Any, Dict, Iterable, Iterator, Union
+from typing import Any, Dict, Iterable, Iterator
 import traceback
 
 # Third Party
-from google.protobuf.descriptor import Descriptor, FieldDescriptor, ServiceDescriptor
+from google.protobuf.descriptor import FieldDescriptor, ServiceDescriptor
 from google.protobuf.message import Message as ProtoMessageType
 import grpc
 

--- a/caikit/runtime/utils/servicer_util.py
+++ b/caikit/runtime/utils/servicer_util.py
@@ -261,14 +261,14 @@ def validate_data_model(
 
 
 def build_caikit_library_request_dict(
-    request: Union[Descriptor, ProtoMessageType],
+    request: ProtoMessageType,
     module_signature: CaikitMethodSignature,
 ) -> Dict[str, Any]:
     """Build the request kwargs dict.
 
     Args:
-        request (Union[Descriptor, ProtoMessageType]):
-            The request proto name or descriptor to deserialize from
+        request (ProtoMessageType):
+            The request proto message to deserialize from
         module_signature (CaikitMethodSignature):
             Module signature or metadata about method on a module
 

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -56,6 +56,14 @@ class OtherTask(TaskBase):
     """Another sample `task` for our test models"""
 
 
+@task(
+    streaming_parameters={"lats": Iterable[float], "lons": Iterable[float]},
+    streaming_output_type=Iterable[SampleOutputType],
+)
+class GeoSpatialTask(TaskBase):
+    """A task that flexes streaming capabilities"""
+
+
 # NB: Backwards compatibility test
 @task(
     required_parameters={"sample_input": SampleInputType},

--- a/tests/fixtures/sample_lib/modules/__init__.py
+++ b/tests/fixtures/sample_lib/modules/__init__.py
@@ -6,3 +6,6 @@ from .sample_task import (
     SampleModule,
     SamplePrimitiveModule,
 )
+from .geospatial import (
+    GeoStreamingModule
+)

--- a/tests/fixtures/sample_lib/modules/__init__.py
+++ b/tests/fixtures/sample_lib/modules/__init__.py
@@ -1,11 +1,9 @@
 # Local
+from .geospatial import GeoStreamingModule
 from .other_task import OtherModule
 from .sample_task import (
     CompositeModule,
     InnerModule,
     SampleModule,
     SamplePrimitiveModule,
-)
-from .geospatial import (
-    GeoStreamingModule
 )

--- a/tests/fixtures/sample_lib/modules/geospatial/__init__.py
+++ b/tests/fixtures/sample_lib/modules/geospatial/__init__.py
@@ -1,1 +1,2 @@
+# Local
 from .geo_streaming_module import GeoStreamingModule

--- a/tests/fixtures/sample_lib/modules/geospatial/__init__.py
+++ b/tests/fixtures/sample_lib/modules/geospatial/__init__.py
@@ -1,0 +1,1 @@
+from .geo_streaming_module import GeoStreamingModule

--- a/tests/fixtures/sample_lib/modules/geospatial/geo_streaming_module.py
+++ b/tests/fixtures/sample_lib/modules/geospatial/geo_streaming_module.py
@@ -1,0 +1,38 @@
+"""
+A sample module for sample things!
+"""
+# Standard
+import os
+from typing import Iterable
+
+# Local
+from ...data_model.sample import (
+    SampleInputType,
+    SampleOutputType,
+    SampleTask,
+    SampleTrainingType, GeoSpatialTask,
+)
+from caikit.core.data_model import DataStream
+from caikit.core.modules import ModuleLoader, ModuleSaver
+import caikit.core
+
+
+@caikit.core.module(
+    "e0e1e9b1-3cbb-411d-b066-3b8e1a19e46d", "WhyAreNamesStillHere", "0.0.1", GeoSpatialTask
+)
+class GeoStreamingModule(caikit.core.ModuleBase):
+
+    @SampleTask.taskmethod(input_streaming=True, output_streaming=True)
+    def run_bidi_stream(
+            self, lats: DataStream[float], lons: DataStream[float], name: str
+    ) -> Iterable[SampleOutputType]:
+        """
+        Args:
+            sample_inputs (caikit.core.data_model.DataStream[sample_lib.data_model.SampleInputType]): the input
+
+        Returns:
+            caikit.core.data_model.DataStream[sample_lib.data_model.SampleOutputType]: The output
+                stream
+        """
+        for lat, lon in zip(lats, lons):
+            yield SampleOutputType(greeting=f"Hello from {name} at {lat}°, {lon}°")

--- a/tests/fixtures/sample_lib/modules/geospatial/geo_streaming_module.py
+++ b/tests/fixtures/sample_lib/modules/geospatial/geo_streaming_module.py
@@ -2,15 +2,16 @@
 A sample module for sample things!
 """
 # Standard
-import os
 from typing import Iterable
+import os
 
 # Local
 from ...data_model.sample import (
+    GeoSpatialTask,
     SampleInputType,
     SampleOutputType,
     SampleTask,
-    SampleTrainingType, GeoSpatialTask,
+    SampleTrainingType,
 )
 from caikit.core.data_model import DataStream
 from caikit.core.modules import ModuleLoader, ModuleSaver
@@ -18,13 +19,15 @@ import caikit.core
 
 
 @caikit.core.module(
-    "e0e1e9b1-3cbb-411d-b066-3b8e1a19e46d", "WhyAreNamesStillHere", "0.0.1", GeoSpatialTask
+    "e0e1e9b1-3cbb-411d-b066-3b8e1a19e46d",
+    "WhyAreNamesStillHere",
+    "0.0.1",
+    GeoSpatialTask,
 )
 class GeoStreamingModule(caikit.core.ModuleBase):
-
-    @SampleTask.taskmethod(input_streaming=True, output_streaming=True)
+    @GeoSpatialTask.taskmethod(input_streaming=True, output_streaming=True)
     def run_bidi_stream(
-            self, lats: DataStream[float], lons: DataStream[float], name: str
+        self, lats: DataStream[float], lons: DataStream[float], name: str
     ) -> Iterable[SampleOutputType]:
         """
         Args:
@@ -34,5 +37,5 @@ class GeoStreamingModule(caikit.core.ModuleBase):
             caikit.core.data_model.DataStream[sample_lib.data_model.SampleOutputType]: The output
                 stream
         """
-        for lat, lon in zip(lats, lons):
+        for lat, lon in DataStream.zip(lats, lons):
             yield SampleOutputType(greeting=f"Hello from {name} at {lat}°, {lon}°")

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -2,8 +2,8 @@
 A sample module for sample things!
 """
 # Standard
-import os
 from typing import Iterable
+import os
 
 # Local
 from ...data_model.sample import (
@@ -73,7 +73,7 @@ class SampleModule(caikit.core.ModuleBase):
 
     @SampleTask.taskmethod(input_streaming=True, output_streaming=True)
     def run_bidi_stream(
-            self, sample_inputs: DataStream[SampleInputType]
+        self, sample_inputs: DataStream[SampleInputType]
     ) -> Iterable[SampleOutputType]:
         """
         Args:
@@ -85,7 +85,6 @@ class SampleModule(caikit.core.ModuleBase):
         """
         for sample_input in sample_inputs:
             yield self.run(sample_input)
-
 
     def save(self, model_path):
         module_saver = ModuleSaver(

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -3,6 +3,7 @@ A sample module for sample things!
 """
 # Standard
 import os
+from typing import Iterable
 
 # Local
 from ...data_model.sample import (
@@ -69,6 +70,22 @@ class SampleModule(caikit.core.ModuleBase):
         ]
         stream = DataStream.from_iterable(list_)
         return stream
+
+    @SampleTask.taskmethod(input_streaming=True, output_streaming=True)
+    def run_bidi_stream(
+            self, sample_inputs: DataStream[SampleInputType]
+    ) -> Iterable[SampleOutputType]:
+        """
+        Args:
+            sample_inputs (caikit.core.data_model.DataStream[sample_lib.data_model.SampleInputType]): the input
+
+        Returns:
+            caikit.core.data_model.DataStream[sample_lib.data_model.SampleOutputType]: The output
+                stream
+        """
+        for sample_input in sample_inputs:
+            yield self.run(sample_input)
+
 
     def save(self, model_path):
         module_saver = ModuleSaver(

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -18,7 +18,6 @@ import pytest
 # First Party
 import alog
 
-import caikit.runtime.service_factory
 # Local
 from caikit.core.data_model.dataobject import render_dataobject_protos
 from caikit.runtime.grpc_server import RuntimeGRPCServer
@@ -29,6 +28,7 @@ from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServic
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
+import caikit.runtime.service_factory
 
 log = alog.use_channel("TEST-CONFTEST")
 
@@ -193,7 +193,9 @@ def sample_task_unary_rpc(sample_inference_service: ServicePackage) -> TaskPredi
 
 
 @pytest.fixture
-def sample_task_streaming_rpc(sample_inference_service: ServicePackage) -> TaskPredictRPC:
+def sample_task_streaming_rpc(
+    sample_inference_service: ServicePackage,
+) -> TaskPredictRPC:
     return sample_inference_service.caikit_rpcs["ServerStreamingSampleTaskPredict"]
 
 

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -18,11 +18,13 @@ import pytest
 # First Party
 import alog
 
+import caikit.runtime.service_factory
 # Local
 from caikit.core.data_model.dataobject import render_dataobject_protos
 from caikit.runtime.grpc_server import RuntimeGRPCServer
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
+from caikit.runtime.service_generation.rpcs import TaskPredictRPC
 from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from tests.conftest import random_test_id, temp_config
@@ -183,6 +185,16 @@ def sample_task_model_id(good_model_path) -> str:
 
     # teardown
     model_manager.unload_model(model_id)
+
+
+@pytest.fixture
+def sample_task_unary_rpc(sample_inference_service: ServicePackage) -> TaskPredictRPC:
+    return sample_inference_service.caikit_rpcs["SampleTaskPredict"]
+
+
+@pytest.fixture
+def sample_task_streaming_rpc(sample_inference_service: ServicePackage) -> TaskPredictRPC:
+    return sample_inference_service.caikit_rpcs["ServerStreamingSampleTaskPredict"]
 
 
 @pytest.fixture

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -28,7 +28,6 @@ from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServic
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
-import caikit.runtime.service_factory
 
 log = alog.use_channel("TEST-CONFTEST")
 

--- a/tests/runtime/service_generation/test_create_service.py
+++ b/tests/runtime/service_generation/test_create_service.py
@@ -50,7 +50,7 @@ def test_create_inference_rpcs_uses_task_from_module_decorator():
 
     # SampleModule also implements `SampleTask`
     rpcs = create_inference_rpcs([NewModule, SampleModule])
-    assert len(rpcs) == 2  # SampleModule has 2 streaming flavors
+    assert len(rpcs) == 3  # SampleModule has 3 streaming flavors
     assert NewModule in rpcs[0].module_list
     assert SampleModule in rpcs[0].module_list
 
@@ -143,7 +143,7 @@ def test_create_inference_rpcs_uses_task_from_module_decorator_with_streaming():
         input_streaming=True,
         output_streaming=True,
         expected_name="BidiStreamingSampleTaskPredict",
-        expected_module_list=[NewStreamingModule2],
+        expected_module_list=[NewStreamingModule2, SampleModule],
     )  # bidi stream
     _test_rpc(
         rpcs,
@@ -209,7 +209,7 @@ def _test_rpc(
 
 def test_create_inference_rpcs():
     rpcs = create_inference_rpcs([widget_class])
-    assert len(rpcs) == 2  # SampleModule has inference methods for 2 streaming flavors
+    assert len(rpcs) == 3  # SampleModule has inference methods for 3 streaming flavors
     assert widget_class in rpcs[0].module_list
 
 
@@ -221,22 +221,24 @@ def test_create_inference_rpcs_for_multiple_modules_of_same_type():
     ]
     rpcs = create_inference_rpcs(module_list)
 
-    # only 3 RPCs, SampleModule and SamplePrimitiveModule have task SampleTask but SampleModule has 2 flavors for streaming, OtherModule has task OtherTask
-    assert len(rpcs) == 3
+    # 4 RPCs, SampleModule and SamplePrimitiveModule have task SampleTask with 3 flavors for
+    # streaming, OtherModule has task OtherTask
+    assert len(rpcs) == 4
     assert sample_lib.modules.sample_task.SampleModule in rpcs[0].module_list
     assert sample_lib.modules.sample_task.SamplePrimitiveModule in rpcs[0].module_list
     assert sample_lib.modules.sample_task.SampleModule in rpcs[1].module_list
-    assert sample_lib.modules.other_task.OtherModule in rpcs[2].module_list
+    assert sample_lib.modules.sample_task.SampleModule in rpcs[2].module_list
+    assert sample_lib.modules.other_task.OtherModule in rpcs[-1].module_list
 
 
 def test_create_inference_rpcs_removes_modules_with_no_task():
     module_list = [
-        sample_lib.modules.sample_task.SampleModule,  # has a task, has 2 streaming flavors
+        sample_lib.modules.sample_task.SampleModule,  # has a task, has 3 streaming flavors
         sample_lib.modules.sample_task.InnerModule,  # does not have a task
     ]
     rpcs = create_inference_rpcs(module_list)
 
-    assert len(rpcs) == 2
+    assert len(rpcs) == 3
     assert sample_lib.modules.sample_task.SampleModule in rpcs[0].module_list
     assert sample_lib.modules.sample_task.InnerModule not in rpcs[0].module_list
 

--- a/tests/runtime/service_generation/test_protoable.py
+++ b/tests/runtime/service_generation/test_protoable.py
@@ -100,16 +100,13 @@ def test_to_output_dm_type_with_dm():
 
 
 def test_to_output_dm_type_with_union_dm():
-    assert (
-            get_protoable_return_type(Union[SampleOutputType, str])
-            == SampleOutputType
-    )
+    assert get_protoable_return_type(Union[SampleOutputType, str]) == SampleOutputType
 
 
 def test_to_output_dm_type_with_union_optional_dm():
     assert (
-            get_protoable_return_type(Union[Optional[SampleOutputType], str])
-            == SampleOutputType
+        get_protoable_return_type(Union[Optional[SampleOutputType], str])
+        == SampleOutputType
     )
 
 

--- a/tests/runtime/service_generation/test_protoable.py
+++ b/tests/runtime/service_generation/test_protoable.py
@@ -6,7 +6,7 @@ import pytest
 
 # Local
 from caikit.runtime.service_generation.protoable import (
-    extract_data_model_type_from_union,
+    get_protoable_return_type,
     to_protoable_signature,
 )
 from sample_lib.data_model import SampleInputType, SampleOutputType
@@ -88,28 +88,28 @@ def test_to_protoable_signature_no_protoable_types():
 
 
 def test_to_output_dm_type_with_None():
-    assert extract_data_model_type_from_union(None) == None
+    assert get_protoable_return_type(None) == None
 
 
 def test_to_output_dm_type_with_raw_primitive():
-    assert extract_data_model_type_from_union(str) == str
+    assert get_protoable_return_type(str) == str
 
 
 def test_to_output_dm_type_with_dm():
-    assert extract_data_model_type_from_union(SampleOutputType) == SampleOutputType
+    assert get_protoable_return_type(SampleOutputType) == SampleOutputType
 
 
 def test_to_output_dm_type_with_union_dm():
     assert (
-        extract_data_model_type_from_union(Union[SampleOutputType, str])
-        == SampleOutputType
+            get_protoable_return_type(Union[SampleOutputType, str])
+            == SampleOutputType
     )
 
 
 def test_to_output_dm_type_with_union_optional_dm():
     assert (
-        extract_data_model_type_from_union(Union[Optional[SampleOutputType], str])
-        == SampleOutputType
+            get_protoable_return_type(Union[Optional[SampleOutputType], str])
+            == SampleOutputType
     )
 
 

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -15,6 +15,7 @@
 from typing import Iterator
 from unittest.mock import MagicMock, patch
 
+# Local
 from sample_lib.modules.geospatial import GeoStreamingModule
 
 try:
@@ -94,7 +95,10 @@ def test_global_predict_works_on_bidirectional_streaming_rpcs(
     sample_inference_service, sample_predict_servicer, sample_task_model_id
 ):
     """Simple test that our SampleModule's bidirectional stream inference fn is supported"""
-    def req_iterator() -> Iterator[sample_inference_service.messages.BidiStreamingSampleTaskRequest]:
+
+    def req_iterator() -> Iterator[
+        sample_inference_service.messages.BidiStreamingSampleTaskRequest
+    ]:
         for i in range(100):
             yield sample_inference_service.messages.BidiStreamingSampleTaskRequest(
                 sample_inputs=HAPPY_PATH_INPUT
@@ -103,7 +107,9 @@ def test_global_predict_works_on_bidirectional_streaming_rpcs(
     response_stream = sample_predict_servicer.Predict(
         req_iterator(),
         Fixtures.build_context(sample_task_model_id),
-        caikit_rpc=sample_inference_service.caikit_rpcs["BidiStreamingSampleTaskPredict"]
+        caikit_rpc=sample_inference_service.caikit_rpcs[
+            "BidiStreamingSampleTaskPredict"
+        ],
     )
     count = 0
     for response in response_stream:
@@ -120,23 +126,25 @@ def test_global_predict_works_on_bidirectional_streaming_rpcs_with_multiple_stre
     mock_manager = MagicMock()
     mock_manager.retrieve_model.return_value = GeoStreamingModule()
 
-    def req_iterator() -> Iterator[sample_inference_service.messages.BidiStreamingGeoSpatialTaskRequest]:
+    def req_iterator() -> Iterator[
+        sample_inference_service.messages.BidiStreamingGeoSpatialTaskRequest
+    ]:
         for i in range(100):
             yield sample_inference_service.messages.BidiStreamingGeoSpatialTaskRequest(
-                lats=i,
-                lons=100-i,
-                name="Gabe"
+                lats=i, lons=100 - i, name="Gabe"
             )
 
     with patch.object(sample_predict_servicer, "_model_manager", mock_manager):
         response_stream = sample_predict_servicer.Predict(
             req_iterator(),
             Fixtures.build_context(sample_task_model_id),
-            caikit_rpc=sample_inference_service.caikit_rpcs["BidiStreamingGeoSpatialTaskPredict"]
+            caikit_rpc=sample_inference_service.caikit_rpcs[
+                "BidiStreamingGeoSpatialTaskPredict"
+            ],
         )
         count = 0
-        for i, response in response_stream:
-            assert response.greeting == f"Hello from Gabe at {i+1}°, {99-i}°"
+        for i, response in enumerate(response_stream):
+            assert response.greeting == f"Hello from Gabe at {i}.0°, {100-i}.0°"
             count += 1
         assert count == 100
 

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -95,12 +95,13 @@ def test_global_predict_works_on_bidirectional_streaming_rpcs(
     def req_iterator() -> Iterator[sample_inference_service.messages.BidiStreamingSampleTaskRequest]:
         for i in range(100):
             yield sample_inference_service.messages.BidiStreamingSampleTaskRequest(
-                sample_input=HAPPY_PATH_INPUT
+                sample_inputs=HAPPY_PATH_INPUT
             )
 
     response_stream = sample_predict_servicer.Predict(
         req_iterator(),
         Fixtures.build_context(sample_task_model_id),
+        caikit_rpc=sample_inference_service.caikit_rpcs["BidiStreamingSampleTaskPredict"]
     )
     count = 0
     for response in response_stream:

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -34,6 +34,7 @@ from sample_lib.data_model.sample import (
 from sample_lib.modules.sample_task.sample_implementation import SampleModule
 from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
+from tests.runtime.conftest import sample_task_unary_rpc
 import caikit.core
 
 ## Helpers #####################################################################
@@ -62,6 +63,7 @@ def test_global_train_sample_task(
     sample_train_servicer,
     sample_inference_service,
     sample_predict_servicer,
+    sample_task_unary_rpc,
 ):
     """Global train of TrainRequest returns a training job with the correct
     model name, and some training id for a basic train function that doesn't
@@ -101,6 +103,7 @@ def test_global_train_sample_task(
             sample_input=SampleInputType(name="Gabe").to_proto()
         ),
         Fixtures.build_context(training_response.model_name),
+        caikit_rpc=sample_task_unary_rpc,
     )
     assert (
         inference_response
@@ -152,6 +155,7 @@ def test_global_train_other_task(
             sample_input=SampleInputType(name="Gabe").to_proto()
         ),
         Fixtures.build_context(training_response.model_name),
+        caikit_rpc=sample_inference_service.caikit_rpcs["OtherTaskPredict"],
     )
     assert (
         inference_response
@@ -167,6 +171,7 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_no
     sample_train_servicer,
     sample_inference_service,
     sample_predict_servicer,
+    sample_task_unary_rpc,
 ):
     """Global train of TrainRequest returns a training job with the correct model name, and some training id for a train function that requires another loaded model"""
     sample_model = caikit.interfaces.runtime.data_model.ModelPointer(
@@ -203,6 +208,7 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_no
             sample_input=SampleInputType(name="Gabe").to_proto()
         ),
         Fixtures.build_context(training_response.model_name),
+        caikit_rpc=sample_task_unary_rpc,
     )
     assert (
         inference_response
@@ -213,7 +219,10 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_no
 
 
 def test_run_train_job_works_with_wait(
-    sample_train_service, sample_inference_service, sample_predict_servicer
+    sample_train_service,
+    sample_inference_service,
+    sample_predict_servicer,
+    sample_task_unary_rpc,
 ):
     """Check if run_train_job works as expected for syncronous requests"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
@@ -243,6 +252,7 @@ def test_run_train_job_works_with_wait(
                 sample_input=SampleInputType(name="Test").to_proto()
             ),
             Fixtures.build_context(training_response.model_name),
+            caikit_rpc=sample_task_unary_rpc,
         )
         assert (
             inference_response

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -32,9 +32,8 @@ from sample_lib.data_model.sample import (
     SampleTrainingType,
 )
 from sample_lib.modules.sample_task.sample_implementation import SampleModule
-from tests.conftest import random_test_id, temp_config
+from tests.conftest import random_test_id
 from tests.fixtures import Fixtures
-from tests.runtime.conftest import sample_task_unary_rpc
 import caikit.core
 
 ## Helpers #####################################################################


### PR DESCRIPTION
Mostly addresses #287 

This adds grpc api support for input streams, allowing all 4 flavors of streaming to be used.

This is a little bit rough at the moment to get things out the door, we'll be following up with integration into https://github.com/caikit/caikit-nlp and fixing edge cases as they pop up.

A known issue here is that we check if the output of a model is iterable to determine whether or not to stream the output, but that information should come from the rpc metadata instead.