### PR TITLE
:sparkles: add http example

### DIFF
--- a/examples/text-sentiment/README.md
+++ b/examples/text-sentiment/README.md
@@ -15,10 +15,15 @@ Install the dependencies: `pip install -r requirements.txt`
 
 ## Running the Caikit runtime
 
-In one terminal, start the runtime server:
+In one terminal, start the runtime grpc server:
 
 ```shell
 python3 start_runtime.py
+```
+
+You can alternatively start the REST server with
+```shell
+python3 start_runtime.py --protocol http
 ```
 
 You should see output similar to the following:
@@ -57,6 +62,10 @@ In another terminal, run the client code:
 
 ```shell
 python3 client.py
+```
+Or, for the REST client:
+```shell
+python3 client.py --protocol http
 ```
 
 The client code calls the model and queries it for sentiment analysis on 2 different pieces of text.

--- a/examples/text-sentiment/client.py
+++ b/examples/text-sentiment/client.py
@@ -13,30 +13,54 @@
 # limitations under the License.
 
 # Third Party
+from start_runtime import protocol_arg
 import grpc
+import requests
 
 # Local
 from caikit.runtime.service_factory import ServicePackageFactory
 from text_sentiment.data_model import TextInput
 
-inference_service = ServicePackageFactory().get_service_package(
-    ServicePackageFactory.ServiceType.INFERENCE,
-)
+if __name__ == "__main__":
 
-port = 8085
-
-# Setup the client
-channel = grpc.insecure_channel(f"localhost:{port}")
-client_stub = inference_service.stub_class(channel)
-
-# Run inference for two sample prompts
-for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
-    input_text_proto = TextInput(text=text).to_proto()
-    request = inference_service.messages.HuggingFaceSentimentTaskRequest(
-        text_input=input_text_proto
+    inference_service = ServicePackageFactory().get_service_package(
+        ServicePackageFactory.ServiceType.INFERENCE,
     )
-    response = client_stub.HuggingFaceSentimentTaskPredict(
-        request, metadata=[("mm-model-id", "text_sentiment")]
-    )
-    print("Text:", text)
-    print("RESPONSE:", response)
+
+    protocol = protocol_arg()
+
+    model_id = "text_sentiment"
+
+    if protocol == "grpc":
+        # Setup the client
+        port = 8085
+        channel = grpc.insecure_channel(f"localhost:{port}")
+        client_stub = inference_service.stub_class(channel)
+
+        # Run inference for two sample prompts
+        for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
+            input_text_proto = TextInput(text=text).to_proto()
+            request = inference_service.messages.HuggingFaceSentimentTaskRequest(
+                text_input=input_text_proto
+            )
+            response = client_stub.HuggingFaceSentimentTaskPredict(
+                request, metadata=[("mm-model-id", model_id)], timeout=1
+            )
+            print("Text:", text)
+            print("RESPONSE:", response)
+
+    elif protocol == "http":
+        port = 8080
+        # Run inference for two sample prompts
+        for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
+            payload = {"inputs": {"text_input": {"text": text}}}
+            response = requests.post(
+                f"http://localhost:{port}/api/v1/{model_id}/task/hugging-face-sentiment",
+                json=payload,
+                timeout=1,
+            )
+            print("Text:", text)
+            print("RESPONSE:", response.json())
+
+    else:
+        print("--protocol must be one of [grpc, http]")

--- a/examples/text-sentiment/requirements.txt
+++ b/examples/text-sentiment/requirements.txt
@@ -1,7 +1,9 @@
-caikit[all]
+caikit[runtime-grpc, runtime-http]
 
 # Only needed for HuggingFace
 scipy
 torch
 transformers~=4.27.2
 
+# For http client
+requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev-fmt = [
     "pre-commit>=3.0.4,<4.0",
     "pylint>=2.16.2,<3.0",
     "pydeps==1.12.10",
+    "requests==2.31.0"
 ]
 
 dev-build = [

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ description = lint with pylint
 extras =
     all
     dev-fmt
+    dev-test
 commands = pylint caikit examples/text-sentiment/text_sentiment examples/text-sentiment/*.py examples/*.py
 
 [testenv:imports]


### PR DESCRIPTION
For the non-bug part of #323 

This adds a `--protocol` flag to the example scripts to run the http server as well.
This does not yet fix the bug in the http server itself, where the response for this huggingface model is not returned. I hope to get to that soon, just wanted to get this example out here and then come in with a fix and tests.