### PR TITLE
feat: Make it possible to override the domain and package names

### DIFF
--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -15,7 +15,7 @@
 # Standard
 from enum import Enum
 from types import ModuleType
-from typing import Callable, Dict, Set, Type
+from typing import Callable, Set, Type
 import dataclasses
 
 # Third Party
@@ -78,7 +78,7 @@ class ServicePackage:
     ]
     stub_class: Type
     messages: ModuleType
-    caikit_rpcs: Dict[str, CaikitRPCBase]
+    caikit_rpcs: Set[CaikitRPCBase]
 
 
 class ServicePackageFactory:
@@ -116,7 +116,7 @@ class ServicePackageFactory:
                 registration_function=grpc_service.registration_function,
                 stub_class=grpc_service.client_stub_class,
                 messages=None,  # we don't need messages here
-                caikit_rpcs={},  # No caikit RPCs
+                caikit_rpcs=set(),  # No caikit RPCs
             )
 
         # First make sure we import the data model for the correct library
@@ -174,7 +174,7 @@ class ServicePackageFactory:
             registration_function=grpc_service.registration_function,
             stub_class=grpc_service.client_stub_class,
             messages=client_module,
-            caikit_rpcs={rpc.name: rpc for rpc in rpc_list},
+            caikit_rpcs=set(rpc_list),
         )
 
     # Implementation details for pure python service packages #

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -123,21 +123,14 @@ class ServicePackageFactory:
         # !!!! This will use the `caikit_library` config
         _ = import_util.get_data_model()
 
-        caikit_config = get_config()
-        lib = caikit_config.runtime.library
-        default_ai_domain_name = snake_to_upper_camel(lib.replace("caikit_", ""))
-        ai_domain_name = (
-            caikit_config.runtime.service_generation.domain or default_ai_domain_name
-        )
-
-        default_package_name = f"caikit.runtime.{ai_domain_name}"
-        package_name = (
-            caikit_config.runtime.service_generation.package or default_package_name
-        )
+        # Get the names for the AI domain and the proto package
+        ai_domain_name = service_generation.get_ai_domain()
+        package_name = service_generation.get_runtime_service_package()
 
         # Then do API introspection to come up with all the API definitions to support
+        caikit_config = get_config()
         clean_modules = ServicePackageFactory._get_and_filter_modules(
-            caikit_config, lib
+            caikit_config, caikit_config.runtime.library
         )
 
         if service_type == cls.ServiceType.INFERENCE:

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -36,7 +36,7 @@ from caikit.interfaces.runtime.data_model import (
     TrainingStatusResponse,
 )
 from caikit.runtime import service_generation
-from caikit.runtime.service_generation.rpcs import CaikitRPCBase, snake_to_upper_camel
+from caikit.runtime.service_generation.rpcs import CaikitRPCBase
 from caikit.runtime.utils import import_util
 import caikit.core
 

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -15,7 +15,7 @@
 # Standard
 from enum import Enum
 from types import ModuleType
-from typing import Callable, Set, Type
+from typing import Callable, Dict, Set, Type
 import dataclasses
 
 # Third Party
@@ -78,7 +78,7 @@ class ServicePackage:
     ]
     stub_class: Type
     messages: ModuleType
-    caikit_rpcs: Set[CaikitRPCBase]
+    caikit_rpcs: Dict[str, CaikitRPCBase]
 
 
 class ServicePackageFactory:
@@ -116,7 +116,7 @@ class ServicePackageFactory:
                 registration_function=grpc_service.registration_function,
                 stub_class=grpc_service.client_stub_class,
                 messages=None,  # we don't need messages here
-                caikit_rpcs=set(),  # No caikit RPCs
+                caikit_rpcs={},  # No caikit RPCs
             )
 
         # First make sure we import the data model for the correct library
@@ -174,7 +174,7 @@ class ServicePackageFactory:
             registration_function=grpc_service.registration_function,
             stub_class=grpc_service.client_stub_class,
             messages=client_module,
-            caikit_rpcs=set(rpc_list),
+            caikit_rpcs={rpc.name: rpc for rpc in rpc_list},
         )
 
     # Implementation details for pure python service packages #

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -125,8 +125,15 @@ class ServicePackageFactory:
 
         caikit_config = get_config()
         lib = caikit_config.runtime.library
-        ai_domain_name = snake_to_upper_camel(lib.replace("caikit_", ""))
-        package_name = f"caikit.runtime.{ai_domain_name}"
+        default_ai_domain_name = snake_to_upper_camel(lib.replace("caikit_", ""))
+        ai_domain_name = (
+            caikit_config.runtime.service_generation.domain or default_ai_domain_name
+        )
+
+        default_package_name = f"caikit.runtime.{ai_domain_name}"
+        package_name = (
+            caikit_config.runtime.service_generation.package or default_package_name
+        )
 
         # Then do API introspection to come up with all the API definitions to support
         clean_modules = ServicePackageFactory._get_and_filter_modules(

--- a/caikit/runtime/service_generation/__init__.py
+++ b/caikit/runtime/service_generation/__init__.py
@@ -1,3 +1,4 @@
 # Local
 from . import create_service
 from .create_service import create_inference_rpcs, create_training_rpcs
+from .proto_package import get_ai_domain, get_runtime_service_package

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -36,6 +36,7 @@ from caikit.interfaces.common.data_model.stream_sources import (
     ListOfFiles,
     S3Files,
 )
+from caikit.runtime.service_generation.proto_package import get_runtime_service_package
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import caikit
 
@@ -220,7 +221,7 @@ def make_data_stream_source(data_element_type: Type) -> Type[DataBase]:
         # this class can be referenced within the Union annotation for the
         # outer class itself. This class needs to be created dynamically because
         # it encapsulates type information about the elements of the data stream.
-        package = "caikit_data_model.runtime"
+        package = get_runtime_service_package()
         JsonData = make_dataobject(
             package=package,
             proto_name=f"{cls_name}JsonData",

--- a/caikit/runtime/service_generation/proto_package.py
+++ b/caikit/runtime/service_generation/proto_package.py
@@ -1,0 +1,47 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module holds the common helpers for managing the protobuf package name for
+the runtime
+"""
+
+# Local
+from ...config import get_config
+
+
+def snake_to_upper_camel(string: str) -> str:
+    """Simple snake -> upper camel conversion"""
+    return "".join([part[0].upper() + part[1:] for part in string.split("_")])
+
+
+def get_ai_domain() -> str:
+    """Get the string name for the AI domain"""
+    caikit_config = get_config()
+    lib = caikit_config.runtime.library
+    default_ai_domain_name = snake_to_upper_camel(lib.replace("caikit_", ""))
+    ai_domain_name = (
+        caikit_config.runtime.service_generation.domain or default_ai_domain_name
+    )
+    return ai_domain_name
+
+
+def get_runtime_service_package() -> str:
+    """This helper will get the common runtime package"""
+    caikit_config = get_config()
+    ai_domain_name = get_ai_domain()
+    default_package_name = f"caikit.runtime.{ai_domain_name}"
+    package_name = (
+        caikit_config.runtime.service_generation.package or default_package_name
+    )
+    return package_name

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -34,6 +34,7 @@ from ...interfaces.common.data_model.stream_sources import S3Path
 from . import protoable, type_helpers
 from .compatibility_checker import ApiFieldNames
 from .data_stream_source import make_data_stream_source
+from .proto_package import snake_to_upper_camel
 from caikit.core import ModuleBase, TaskBase
 from caikit.core.data_model.base import DataBase
 from caikit.core.data_model.dataobject import make_dataobject
@@ -386,8 +387,3 @@ class _RequestMessage:
             self.triples.append((typ, item_name, num))
 
         self.triples.sort(key=lambda x: x[2])
-
-
-def snake_to_upper_camel(string: str) -> str:
-    """Simple snake -> upper camel conversion"""
-    return "".join([part[0].upper() + part[1:] for part in string.split("_")])

--- a/caikit/runtime/utils/servicer_util.py
+++ b/caikit/runtime/utils/servicer_util.py
@@ -41,7 +41,6 @@ from caikit.runtime.service_generation.data_stream_source import (
     DataStreamSourceBase,
     make_data_stream_source,
 )
-from caikit.runtime.service_generation.proto_package import snake_to_upper_camel
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import get_data_model
 

--- a/caikit/runtime/utils/servicer_util.py
+++ b/caikit/runtime/utils/servicer_util.py
@@ -41,6 +41,7 @@ from caikit.runtime.service_generation.data_stream_source import (
     DataStreamSourceBase,
     make_data_stream_source,
 )
+from caikit.runtime.service_generation.proto_package import snake_to_upper_camel
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import get_data_model
 
@@ -182,11 +183,6 @@ def get_metadata(context, key, required=True):
                 grpc.StatusCode.INVALID_ARGUMENT,
                 "Could not read required metadata: {}".format(key),
             ) from e
-
-
-def snake_to_upper_camel(string: str) -> str:
-    """Simple snake -> upper camel conversion"""
-    return "".join([part[0].upper() + part[1:] for part in string.split("_")])
 
 
 def validate_data_model(

--- a/tests/core/data_model/test_base.py
+++ b/tests/core/data_model/test_base.py
@@ -28,6 +28,7 @@ from caikit.core.data_model.dataobject import DataObjectBase
 from tests.data_model_helpers import (
     justify_script_string,
     make_proto_def,
+    reset_global_protobuf_registry,
     temp_data_model,
     temp_module,
 )
@@ -55,6 +56,12 @@ class AccessCounterBackend(DataModelBackendBase):
 
     def access_count(self, name):
         return self.access_counter.get(name, 0)
+
+
+@pytest.fixture(autouse=True)
+def auto_reset_global_protobuf_registry():
+    with reset_global_protobuf_registry():
+        yield
 
 
 ## Tests #######################################################################

--- a/tests/core/data_model/test_timestamp.py
+++ b/tests/core/data_model/test_timestamp.py
@@ -25,9 +25,7 @@ import pytest
 from caikit.core import DataObjectBase, dataobject
 from caikit.core.data_model import timestamp
 from caikit.interfaces.common.data_model.stream_sources import S3Path
-from tests.core.data_model.test_dataobject import reset_global_protobuf_registry
-
-f = reset_global_protobuf_registry
+from tests.core.data_model.test_dataobject import auto_reset_global_protobuf_registry
 
 
 def test_timestamp_to_proto_to_timestamp():
@@ -51,7 +49,7 @@ def test_proto_to_timestamp_invalid_type():
         timestamp.proto_to_datetime(non_timestamp_proto)
 
 
-def test_timestamp_roundtrip_serialization(reset_global_protobuf_registry):
+def test_timestamp_roundtrip_serialization():
     @dataobject(package="test")
     class FooTimestamps(DataObjectBase):
         time: datetime.datetime

--- a/tests/data_model_helpers.py
+++ b/tests/data_model_helpers.py
@@ -109,10 +109,17 @@ def temp_dpool(inherit_global: bool = False, skip_inherit: Optional[List[str]] =
         # Third Party
         from google.protobuf.message_factory import GetMessageClassesForFiles
 
-        for fd_proto in all_fd_protos:
-            msgs = GetMessageClassesForFiles([fd_proto.name], dpool)
-            for key in msgs:
-                _ = msgs[key]
+        # Extra HACK! It seems that the below loop which _should_ do exactly
+        # this somehow does not and by switching to it, the segfault reappears.
+        msgs = GetMessageClassesForFiles(["google/protobuf/struct.proto"], dpool)
+        _ = msgs["google.protobuf.Struct"]
+        _ = msgs["google.protobuf.Value"]
+        _ = msgs["google.protobuf.ListValue"]
+
+        # for fd_proto in all_fd_protos:
+        #     msgs = GetMessageClassesForFiles([fd_proto.name], dpool)
+        #     for key in msgs:
+        #         _ = msgs[key]
 
     # Nothing to do for protobuf 3.X
     except ImportError:

--- a/tests/runtime/test_service_factory.py
+++ b/tests/runtime/test_service_factory.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 """Unit tests for the service factory"""
+import tempfile
+from pathlib import Path
 
-# Third Party
-import pytest
+import caikit
+from caikit.runtime.dump_services import dump_grpc_services
 
 # Local
 from caikit.runtime.service_factory import ServicePackageFactory
 from sample_lib.modules.sample_task import ListModule
 from tests.conftest import temp_config
-import caikit
+
+# Third Party
 
 ### Private method tests #############################################################
 
@@ -31,6 +34,7 @@ MODULE_LIST = [
     for module_class in caikit.core.registries.module_registry().values()
     if module_class.__module__.partition(".")[0] == "sample_lib"
 ]
+
 
 ### Test ServicePackageFactory._get_and_filter_modules function
 def test_get_and_filter_modules_respects_excluded_task_type():
@@ -56,7 +60,6 @@ def test_get_and_filter_modules_respects_excluded_modules():
             }
         }
     ) as cfg:
-
         clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
         assert "ListModule" not in str(clean_modules)
         assert "SampleModule" in str(clean_modules)
@@ -75,7 +78,6 @@ def test_get_and_filter_modules_respects_excluded_modules_and_excluded_task_type
             }
         }
     ) as cfg:
-
         clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
         assert "ListModule" not in str(clean_modules)
         assert "OtherModule" not in str(clean_modules)
@@ -93,7 +95,6 @@ def test_get_and_filter_modules_respects_included_modules_and_included_task_type
             }
         }
     ) as cfg:
-
         clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
         assert len(clean_modules) == 2
         assert "OtherModule" in str(clean_modules)
@@ -110,7 +111,6 @@ def test_get_and_filter_modules_respects_included_modules():
             }
         }
     ) as cfg:
-
         clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
         assert len(clean_modules) == 1
         assert "ListModule" in str(clean_modules)
@@ -127,7 +127,6 @@ def test_get_and_filter_modules_respects_included_task_types():
             }
         }
     ) as cfg:
-
         clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
         assert "SampleModule" in str(clean_modules)
         assert "OtherModule" not in str(clean_modules)
@@ -146,7 +145,150 @@ def test_get_and_filter_modules_respects_included_task_types_and_excluded_module
             }
         }
     ) as cfg:
-
         clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
         assert "SampleModule" in str(clean_modules)
         assert "ListModule" not in str(clean_modules)
+
+
+def test_override_domain():
+    """
+    Test override of gRPC domain generation from config.
+    The feature allows achieving backwards compatibility with earlier gRPC client.
+    """
+    domain_override = "OverrideDomainName"
+    with temp_config(
+        {
+            "runtime": {
+                "library": "sample_lib",
+                "service_generation": {
+                    "task_types": {"included": ["SampleTask"]},
+                    "domain": domain_override,
+                },
+            }
+        }
+    ) as cfg:
+        with tempfile.TemporaryDirectory() as output_dir:
+            dump_grpc_services(output_dir)
+
+            output_dir_path = Path(output_dir)
+            for proto_file in output_dir_path.glob("*.proto"):
+                # print(proto_file)
+                with open(proto_file, "rb") as f:
+                    lines = f.readlines()
+                    for line in lines:
+                        line = line.strip().decode("utf-8")
+                        if line.startswith("service "):
+                            service_name = line.split()[1]
+                            domain_override_lower = domain_override.lower()
+                            if proto_file.name.startswith(domain_override_lower):
+                                if proto_file.stem.endswith("trainingservice"):
+                                    assert (
+                                        service_name
+                                        == f"{domain_override}TrainingService"
+                                    )
+                                else:
+                                    assert service_name == f"{domain_override}Service"
+                            print(f"{service_name}: {proto_file}", flush=True)
+
+            # Just double-check that basics are good.
+            clean_modules = ServicePackageFactory._get_and_filter_modules(
+                cfg, "sample_lib"
+            )
+            assert "SampleModule" in str(clean_modules)
+
+def test_override_package():
+    """
+    Test override of gRPC package generation from config.
+    The feature allows achieving backwards compatibility with earlier gRPC client.
+    """
+    package_override = "foo.runtime.yada.v0"
+    with temp_config(
+        {
+            "runtime": {
+                "library": "sample_lib",
+                "service_generation": {
+                    "task_types": {"included": ["SampleTask"]},
+                    "package": package_override,
+                },
+            }
+        }
+    ) as cfg:
+        with tempfile.TemporaryDirectory() as output_dir:
+            dump_grpc_services(output_dir)
+
+            output_dir_path = Path(output_dir)
+            for proto_file in output_dir_path.glob("*.proto"):
+                # print(proto_file)
+                with open(proto_file, "rb") as f:
+                    lines = f.readlines()
+                    for line in lines:
+                        line = line.strip().decode("utf-8")
+                        if line.startswith("package "):
+                            package_name = line.split()[1]
+                            assert package_name[-1] == ";"
+                            package_name = package_name[0:-1]
+                            root_package_name = package_name.split(".")[0]
+                            if root_package_name not in {"caikit_data_model", "caikit"}:
+                                assert package_name == package_override
+                            print(f"{package_name}: {proto_file}", flush=True)
+
+            # Just double-check that basics are good.
+            clean_modules = ServicePackageFactory._get_and_filter_modules(
+                cfg, "sample_lib"
+            )
+            assert "SampleModule" in str(clean_modules)
+
+def test_override_package_and_domain():
+    """
+    Test override of both package and domain, to make sure they work together.
+    The feature allows achieving backwards compatibility with earlier gRPC client.
+    """
+    package_override = "foo.runtime.yada.v0"
+    domain_override = "OverrideDomainName"
+    with temp_config(
+        {
+            "runtime": {
+                "library": "sample_lib",
+                "service_generation": {
+                    "task_types": {"included": ["SampleTask"]},
+                    "package": package_override,
+                    "domain": domain_override,
+                },
+            }
+        }
+    ) as cfg:
+        with tempfile.TemporaryDirectory() as output_dir:
+            dump_grpc_services(output_dir)
+
+            output_dir_path = Path(output_dir)
+            for proto_file in output_dir_path.glob("*.proto"):
+                # print(proto_file)
+                with open(proto_file, "rb") as f:
+                    lines = f.readlines()
+                    for line in lines:
+                        line = line.strip().decode("utf-8")
+                        if line.startswith("package "):
+                            package_name = line.split()[1]
+                            assert package_name[-1] == ";"
+                            package_name = package_name[0:-1]
+                            root_package_name = package_name.split(".")[0]
+                            if root_package_name not in {"caikit_data_model", "caikit"}:
+                                assert package_name == package_override
+                            print(f"{package_name}: {proto_file}", flush=True)
+                        elif line.startswith("service "):
+                            service_name = line.split()[1]
+                            domain_override_lower = domain_override.lower()
+                            if proto_file.name.startswith(domain_override_lower):
+                                if proto_file.stem.endswith("trainingservice"):
+                                    assert (
+                                        service_name
+                                        == f"{domain_override}TrainingService"
+                                    )
+                                else:
+                                    assert service_name == f"{domain_override}Service"
+
+            # Just double-check that basics are good.
+            clean_modules = ServicePackageFactory._get_and_filter_modules(
+                cfg, "sample_lib"
+            )
+            assert "SampleModule" in str(clean_modules)

--- a/tests/runtime/test_service_factory.py
+++ b/tests/runtime/test_service_factory.py
@@ -13,21 +13,20 @@
 # limitations under the License.
 
 """Unit tests for the service factory"""
-import tempfile
+# Standard
 from pathlib import Path
 from typing import Tuple
-
-from google.protobuf.message import Message
-
-import caikit
-from caikit.core.data_model import render_dataobject_protos
-
-# Local
-from caikit.runtime.service_factory import ServicePackageFactory, ServicePackage
-from sample_lib.modules.sample_task import ListModule
-from tests.conftest import temp_config
+import tempfile
 
 # Third Party
+from google.protobuf.message import Message
+
+# Local
+from caikit.core.data_model import render_dataobject_protos
+from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
+from sample_lib.modules.sample_task import ListModule
+from tests.conftest import temp_config
+import caikit
 
 ### Private method tests #############################################################
 


### PR DESCRIPTION
In order to achieve backwards compatibility with an earlier gRPC client, I need to be able to override the domain and package names in the config file:

Example:
```
runtime:
    service_generation:
        package: whatever.runtime.foofoo.v0
        domain: WhatEver
```

Fixes https://github.com/caikit/caikit/issues/334

