### PR TITLE
Lazy local model loading 324

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -73,6 +73,9 @@ runtime:
     library: sample_lib # TODO: replace with libraries below when runtime can support multiple libraries
     local_models_dir: models
 
+    # Number of threads to make available for load jobs (null => all)
+    load_threads: null
+
     # TLS configs
     tls:
         server:

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -73,7 +73,14 @@ runtime:
     library: sample_lib # TODO: replace with libraries below when runtime can support multiple libraries
     local_models_dir: models
 
+    # If enabled, the models in local_models_dir will be periodically sync'ed
+    # with the in-memory models. New models that are not in-memory that are
+    # found in local_models_dir will be loaded and existing models that were
+    # previously loaded from local_models_dir, but are no longer present will be
+    # unloaded.
     lazy_load_local_models: false
+    lazy_load_poll_period_seconds: 10
+
     # Number of threads to make available for load jobs (null => all)
     load_threads: null
 

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -73,6 +73,7 @@ runtime:
     library: sample_lib # TODO: replace with libraries below when runtime can support multiple libraries
     local_models_dir: models
 
+    lazy_load_local_models: false
     # Number of threads to make available for load jobs (null => all)
     load_threads: null
 

--- a/caikit/core/model_management/model_trainer_base.py
+++ b/caikit/core/model_management/model_trainer_base.py
@@ -97,6 +97,10 @@ class ModelTrainerBase(FactoryConstructible):
 
         ## Common Impl ##
 
+        def result(self) -> ModuleBase:
+            """Support result() to match concurrent.futures.Future"""
+            return self.load()
+
         @classmethod
         def _save_path_with_id(
             cls,

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -472,7 +472,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
         if get_origin(field_type) is Annotated:
             return cls._get_pydantic_type(get_args(field_type)[0])
         if get_origin(field_type) is Union:
-            return Union.__getitem__(
+            return Union.__getitem__(  # pylint: disable=unnecessary-dunder-call
                 tuple(
                     (
                         cls._get_pydantic_type(arg_type)

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -472,14 +472,14 @@ class RuntimeHTTPServer(RuntimeServerBase):
         if get_origin(field_type) is Annotated:
             return cls._get_pydantic_type(get_args(field_type)[0])
         if get_origin(field_type) is Union:
-            return Union.__getitem__(  # pylint: disable=unnecessary-dunder-call
+            return Union[  # type: ignore
                 tuple(
                     (
                         cls._get_pydantic_type(arg_type)
                         for arg_type in get_args(field_type)
                     )
                 )
-            )
+            ]
         if get_origin(field_type) is list:
             return List[cls._get_pydantic_type(get_args(field_type)[0])]
 

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -55,8 +55,6 @@ class LoadedModel:
         def model_future(
             self, caikit_model_future: CaikitModelFuture
         ) -> "LoadedModel.Builder":
-            """Set a model future (mutually exclusive with model)"""
-            error.value_check("<RUN47705258E>", self._model_to_build._model is None)
             self._model_to_build._caikit_model_future = caikit_model_future
             return self
 

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -60,14 +60,6 @@ class LoadedModel:
             self._model_to_build._caikit_model_future = caikit_model_future
             return self
 
-        def model(self, caikit_model: ModuleBase) -> "LoadedModel.Builder":
-            """Set a pre-loaded model (mutually exclusive with model_future)"""
-            error.value_check(
-                "<RUN47705258E>", self._model_to_build._caikit_model_future is None
-            )
-            self._model_to_build._model = caikit_model
-            return self
-
         def fail_callback(self, callback: Callable) -> "LoadedModel.Builder":
             self._model_to_build._fail_callback = callback
             return self
@@ -87,16 +79,12 @@ class LoadedModel:
         def build(self) -> "LoadedModel":
             error.value_check(
                 "<RUN12786023E>",
-                (
-                    self._model_to_build._caikit_model_future
-                    or self._model_to_build._model
-                )
+                self._model_to_build._caikit_model_future
                 and self._model_to_build._model_id
                 and self._model_to_build._model_type,
                 "Cannot build LoadedModel with incomplete required fields."
-                + " Future: {}, Model: {}, ID: {}, Type: {}",
+                + " Future: {}, ID: {}, Type: {}",
                 self._model_to_build._caikit_model_future,
-                self._model_to_build._model,
                 self._model_to_build._model_id,
                 self._model_to_build._model_type,
             )

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -37,7 +37,7 @@ error = error_handler.get(log)
 # NOTE: 3.9 introduced subscript typing for Futures
 try:
     CaikitModelFuture = Future[ModuleBase]  # pylint: disable=unsubscriptable-object
-except TypeError:
+except TypeError:  # pragma: no cover
     CaikitModelFuture = Future
 
 
@@ -136,8 +136,8 @@ class LoadedModel:
             self._size = model_size
         elif self._size != model_size:
             log.warning(
-                "COM62206343W",
-                "Attempted to set size of model %s to %v, but it was already %v",
+                "<RUN46815705W>",
+                "Attempted to set size of model %s to %s, but it was already %s",
                 self.id(),
                 model_size,
                 self.size(),

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -36,7 +36,7 @@ error = error_handler.get(log)
 # A future object that will yield an instance of a caikit module (a model)
 # NOTE: 3.9 introduced subscript typing for Futures
 try:
-    CaikitModelFuture = Future[ModuleBase]
+    CaikitModelFuture = Future[ModuleBase]  # pylint: disable=unsubscriptable-object
 except TypeError:
     CaikitModelFuture = Future
 

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -66,8 +66,7 @@ class ModelLoader:
         aborter: Optional[ActionAborter] = None,
         fail_callback: Optional[Callable] = None,
     ) -> LoadedModel:
-        """Load a model using model_path (in Cloud Object Storage) & give it a
-        model ID
+        """Start loading a model from disk and associate the ID/size with it
 
         Args:
             model_id (str): Model ID string for the model to load.

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -102,7 +102,9 @@ class ModelLoader:
         # Return the built model
         return model_builder.build()
 
-    def _load_module(self, model_path, model_id, model_type):
+    def _load_module(
+        self, model_path: str, model_id: str, model_type: str
+    ) -> LoadedModel:
         try:
             log.info("<RUN89711114I>", "Loading model '%s'", model_id)
 

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # Standard
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 # Third Party
 from grpc import StatusCode
@@ -65,9 +65,10 @@ class ModelLoader:
         model_type: str,
         wait: bool = True,
         aborter: Optional[ActionAborter] = None,
+        fail_callback: Optional[Callable] = None,
     ) -> LoadedModel:
-        """Load a model using model_path (in Cloud Object Storage) & give it a model ID.
-        This always cleans up files on disk, no matter if the load succeeds or fails
+        """Load a model using model_path (in Cloud Object Storage) & give it a
+        model ID
 
         Args:
             model_id (str): Model ID string for the model to load.
@@ -76,12 +77,18 @@ class ModelLoader:
             wait (bool): Whether or not to wait for the load to complete
             aborter (Optional[ActionAborter]): An aborter to use that will allow
                 the call's parent to abort the load
+            fail_callback (Optional[Callable]): Optional no-arg callback to call
+                on load failure
         Returns:
             model (LoadedModel) : The model that was loaded
         """
         # Set up the basics of the model's metadata
         model_builder = (
-            LoadedModel.Builder().id(model_id).type(model_type).path(local_model_path)
+            LoadedModel.Builder()
+            .id(model_id)
+            .type(model_type)
+            .path(local_model_path)
+            .fail_callback(fail_callback)
         )
 
         # Set up the loading to be async or sync

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -400,8 +400,8 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
         #   sync going forward
         try:
             disk_models = os.listdir(self._local_models_dir)
-        except FileNotFoundError:
-            raise StopIteration()
+        except FileNotFoundError as err:
+            raise StopIteration() from err
 
         # Find all models that aren't currently loaded
         new_models = [

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -172,7 +172,6 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
                             model_id,
                             local_model_path,
                             model_type,
-                            wait=False,
                             aborter=aborter,
                             fail_callback=partial(self.unload_model, model_id),
                         )

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -318,7 +318,13 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
 
         # Delete the model and remove it from the model map
         try:
-            del self.loaded_models[model_id]
+            model = self.loaded_models.pop(model_id)
+            # If the model is still loading, we need to wait for it to finish so
+            # that we can do our best to fully free it
+            model.wait()
+            del model
+        except CaikitRuntimeException:
+            raise
         except Exception as ex:
             log.debug("Model '%s' failed to unload with error: %s", model_id, repr(ex))
             raise CaikitRuntimeException(

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -61,7 +61,7 @@ LOAD_MODEL_DURATION_SUMMARY = Summary(
 LOCAL_MODEL_TYPE = "LOCAL"
 
 
-class ModelManager:
+class ModelManager:  # pylint: disable=too-many-instance-attributes
     """Model Manager class. The singleton class contains the core implementational details
     for the Model Runtime (i.e., load/unload functionality, etc). It does not provide the core
     details for predict calls."""

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -278,7 +278,7 @@ class ModelManager:
                 StatusCode.NOT_FOUND, msg, {"model_id": model_id}
             )
 
-        return self.loaded_models[model_id].module()
+        return self.loaded_models[model_id].model()
 
     def __report_total_model_size_metric(self):
         # Just a happy little lock to ensure that with concurrent loading and unloading,

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -85,7 +85,7 @@ class ModelManager:
         self._loaded_models_lock = threading.Lock()
 
         # Optionally load models mounted into a local directory
-        self._local_models_dir = get_config().runtime.local_models_dir
+        self._local_models_dir = get_config().runtime.local_models_dir or ""
         if (
             os.path.exists(self._local_models_dir)
             and len(os.listdir(self._local_models_dir)) > 0
@@ -184,6 +184,8 @@ class ModelManager:
         Args:
             wait (bool): Wait for loading to complete
         """
+        if not self._local_models_dir:
+            return
 
         # Get the list of models on disk
         disk_models = os.listdir(self._local_models_dir)
@@ -367,7 +369,7 @@ class ModelManager:
 
         # Now retrieve the model
         model_loaded = model_id in self.loaded_models
-        if not model_loaded and self._lazy_load_local_models:
+        if not model_loaded and self._lazy_load_local_models and self._local_models_dir:
             local_model_path = os.path.join(self._local_models_dir, model_id)
             if os.path.exists(local_model_path):
                 log.debug2(

--- a/caikit/runtime/service_generation/protoable.py
+++ b/caikit/runtime/service_generation/protoable.py
@@ -125,7 +125,7 @@ def get_union_list_type(field_name: str, union_protoables: List) -> Type[DataBas
             )
         else:
             param_list.append(arg)
-    return Union.__getitem__(tuple((param_list)))
+    return Union[tuple(param_list)]  # type: ignore
 
 
 def get_protoable_return_type(arg_type: Type) -> Type:

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -46,7 +46,7 @@ from caikit.runtime.utils.servicer_util import (
     validate_data_model,
 )
 from caikit.runtime.work_management.abortable_action import AbortableAction
-from caikit.runtime.work_management.call_aborter import CallAborter
+from caikit.runtime.work_management.rpc_aborter import RpcAborter
 
 PREDICT_RPC_COUNTER = Counter(
     "predict_rpc_count",
@@ -196,9 +196,7 @@ class GlobalPredictServicer:
                     request_name,
                     model_id,
                     inference_func_name=inference_signature.method_name,
-                    aborter=CallAborter(context)
-                    if self.use_abortable_threads
-                    else None,
+                    aborter=RpcAborter(context) if self.use_abortable_threads else None,
                     **caikit_library_request,
                 )
 
@@ -217,7 +215,7 @@ class GlobalPredictServicer:
         request_name: str,
         model_id: str,
         inference_func_name: str = "run",
-        aborter: Optional[CallAborter] = None,
+        aborter: Optional[RpcAborter] = None,
         **kwargs,
     ) -> Union[DataBase, Iterable[DataBase]]:
         """Run a prediction against the given model using the raw arguments to
@@ -230,7 +228,7 @@ class GlobalPredictServicer:
                 The ID of the loaded model
             inference_func_name (str):
                 The name of the inference function to run
-            aborter (Optional[CallAborter]):
+            aborter (Optional[RpcAborter]):
                 If using abortable calls, this is the aborter to use
             **kwargs: Keyword arguments to pass to the model's run function
         Returns:

--- a/caikit/runtime/servicers/model_runtime_servicer.py
+++ b/caikit/runtime/servicers/model_runtime_servicer.py
@@ -25,7 +25,7 @@ from caikit.runtime.protobufs import model_runtime_pb2, model_runtime_pb2_grpc
 from caikit.runtime.types.aborted_exception import AbortedException
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.work_management.abortable_action import AbortableAction
-from caikit.runtime.work_management.call_aborter import CallAborter
+from caikit.runtime.work_management.rpc_aborter import RpcAborter
 
 log = alog.use_channel("MR-SERVICR-I")
 
@@ -57,7 +57,7 @@ class ModelRuntimeServicerImpl(model_runtime_pb2_grpc.ModelRuntimeServicer):
             )
             caikit_config = get_config()
             if caikit_config.runtime.use_abortable_threads:
-                aborter = CallAborter(context)
+                aborter = RpcAborter(context)
                 work = AbortableAction(
                     aborter,
                     self.model_manager.load_model,

--- a/caikit/runtime/servicers/model_runtime_servicer.py
+++ b/caikit/runtime/servicers/model_runtime_servicer.py
@@ -57,12 +57,14 @@ class ModelRuntimeServicerImpl(model_runtime_pb2_grpc.ModelRuntimeServicer):
             )
             caikit_config = get_config()
             if caikit_config.runtime.use_abortable_threads:
+                aborter = CallAborter(context)
                 work = AbortableAction(
-                    CallAborter(context),
+                    aborter,
                     self.model_manager.load_model,
                     request.modelId,
                     request.modelPath,
                     request.modelType,
+                    aborter=aborter,
                 )
                 model_size = work.do()
             else:

--- a/caikit/runtime/work_management/abortable_action.py
+++ b/caikit/runtime/work_management/abortable_action.py
@@ -57,13 +57,13 @@ class AbortableAction:
         Instances of this class create a threading.Event, which will be used to signal that either:
         - The RPC was terminated
         - The heavy work that we wanted to complete is done
-        This is done by using a CallAborter and a DestroyableThread.
-        Registering the event with the CallAborter will cause it to set when the RPC is
+        This is done by using a RpcAborter and a DestroyableThread.
+        Registering the event with the RpcAborter will cause it to set when the RPC is
         terminated, and creating a DestroyableThread with the event will cause it to set when
         the thread terminates.
 
         The action will start the DestroyableThread and then wait on the event. When it wakes, it
-        will check the reason and destroy the thread if it was woken by the CallAborter or return
+        will check the reason and destroy the thread if it was woken by the RpcAborter or return
         the result if it was woken by the thread completing.
     """
 

--- a/caikit/runtime/work_management/abortable_action.py
+++ b/caikit/runtime/work_management/abortable_action.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Standard
+from typing import Callable
+import abc
 import threading
 
 # First Party
@@ -23,6 +25,21 @@ from caikit.core.toolkit.destroyable_thread import DestroyableThread
 from caikit.runtime.types.aborted_exception import AbortedException
 
 log = alog.use_channel("ABORT-ACTION")
+
+
+class ActionAborter(abc.ABC):
+    """Simple interface to wrap up a notification that an action must abort.
+
+    Children of this class can bind to any notification tool (e.g. grpc context)
+    """
+
+    @abc.abstractmethod
+    def must_abort(self) -> bool:
+        """Indicate whether or not the action must be aborted"""
+
+    @abc.abstractmethod
+    def add_event(self, event: threading.Event):
+        """Add an event to notify when abort happens"""
 
 
 class AbortableAction:
@@ -50,7 +67,13 @@ class AbortableAction:
         the result if it was woken by the thread completing.
     """
 
-    def __init__(self, call_aborter, runnable_func, *args, **kwargs):
+    def __init__(
+        self,
+        call_aborter: ActionAborter,
+        runnable_func: Callable,
+        *args,
+        **kwargs,
+    ):
         """
         Args:
             call_aborter - call aborter capable of aborting the runnable_func
@@ -71,7 +94,7 @@ class AbortableAction:
             self.__runnable_func,
             *args,
             work_done_event=self.__done_or_aborted_event,
-            **kwargs
+            **kwargs,
         )
 
     def do(self):

--- a/caikit/runtime/work_management/call_aborter.py
+++ b/caikit/runtime/work_management/call_aborter.py
@@ -26,11 +26,12 @@ import alog
 
 # Local
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+from caikit.runtime.work_management.abortable_action import ActionAborter
 
 log = alog.use_channel("CALL-ABORTER")
 
 
-class CallAborter:
+class CallAborter(ActionAborter):
     """
     This class registers a callback with a grpc context, to be called in the event of rpc
     termination. Termination could be nominal (we returned a response) but we should have

--- a/caikit/runtime/work_management/rpc_aborter.py
+++ b/caikit/runtime/work_management/rpc_aborter.py
@@ -31,7 +31,7 @@ from caikit.runtime.work_management.abortable_action import ActionAborter
 log = alog.use_channel("CALL-ABORTER")
 
 
-class CallAborter(ActionAborter):
+class RpcAborter(ActionAborter):
     """
     This class registers a callback with a grpc context, to be called in the event of rpc
     termination. Termination could be nominal (we returned a response) but we should have

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -3,6 +3,7 @@ This sets up global test configs when pytest starts
 """
 
 # Standard
+from concurrent.futures import Future
 from contextlib import contextmanager
 from typing import Type, Union
 import os
@@ -246,13 +247,12 @@ def register_trained_model(
     the old auto-load feature which was only needed for unit tests
     """
     model_future = MODEL_MANAGER.get_model_future(training_id)
-    model = model_future.load()
     loaded_model = (
         LoadedModel.Builder()
         .id(model_id)
         .type("trained")
         .path("")
-        .module(model)
+        .model(model_future.load())
         .build()
     )
     if isinstance(servicer, RuntimeGRPCServer):

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -252,7 +252,7 @@ def register_trained_model(
         .id(model_id)
         .type("trained")
         .path("")
-        .model(model_future.load())
+        .model_future(model_future)
         .build()
     )
     if isinstance(servicer, RuntimeGRPCServer):

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -309,7 +309,7 @@ class TestModelManager(unittest.TestCase):
 
         with patch.object(self.model_manager, "model_loader", mock_loader):
             with patch.object(self.model_manager, "model_sizer", mock_sizer):
-                mock_loader.load_model.return_value = LoadedModel.Builder().build()
+                mock_loader.load_model.return_value = LoadedModel()
                 mock_sizer.get_model_size.return_value = expected_model_size
 
                 model_size = self.model_manager.load_model(
@@ -350,7 +350,11 @@ class TestModelManager(unittest.TestCase):
             with patch.object(self.model_manager, "model_sizer", mock_sizer):
                 mock_sizer.get_model_size.return_value = 1
                 mock_loader.load_model.return_value = (
-                    LoadedModel.Builder().module(expected_module).build()
+                    LoadedModel.Builder()
+                    .model(expected_module)
+                    .id("foo")
+                    .type("bar")
+                    .build()
                 )
                 self.model_manager.load_model(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)
 
@@ -366,7 +370,7 @@ class TestModelManager(unittest.TestCase):
 
         with patch.object(self.model_manager, "model_loader", mock_loader):
             with patch.object(self.model_manager, "model_sizer", mock_sizer):
-                mock_loader.load_model.return_value = LoadedModel.Builder().build()
+                mock_loader.load_model.return_value = LoadedModel()
                 mock_sizer.get_model_size.return_value = expected_model_size
 
                 self.model_manager.load_model(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Standard
+from concurrent.futures import Future
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
@@ -463,7 +464,6 @@ def test_load_model():
                 ANY_MODEL_PATH,
                 ANY_MODEL_TYPE,
             )
-            assert call_args.kwargs["wait"] == False
             assert call_args.kwargs["aborter"] is None
             assert "fail_callback" in call_args.kwargs
             mock_sizer.get_model_size.assert_called_once_with(
@@ -496,9 +496,11 @@ def test_retrieve_model_returns_the_module_from_the_model_loader():
     with patch.object(MODEL_MANAGER, "model_loader", mock_loader):
         with patch.object(MODEL_MANAGER, "model_sizer", mock_sizer):
             mock_sizer.get_model_size.return_value = 1
+            model_future = Future()
+            model_future.result = lambda *_, **__: expected_module
             mock_loader.load_model.return_value = (
                 LoadedModel.Builder()
-                .model(expected_module)
+                .model_future(model_future)
                 .id("foo")
                 .type("bar")
                 .build()

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -84,6 +84,20 @@ def test_load_model_ok_response():
     assert model_size > 0
 
 
+def test_load_model_no_size_update():
+    model_id = random_test_id()
+    model_size = MODEL_MANAGER.load_model(
+        model_id=model_id,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert model_size > 0
+    loaded_model = MODEL_MANAGER.loaded_models[model_id]
+    assert loaded_model.size() == model_size
+    loaded_model.set_size(model_size * 2)
+    assert loaded_model.size() == model_size
+
+
 def test_load_local_models():
     with TemporaryDirectory() as tempdir:
         shutil.copytree(Fixtures.get_good_model_path(), os.path.join(tempdir, "model1"))

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -335,13 +335,16 @@ def test_load_model():
                 model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
             )
             assert expected_model_size == model_size
-            mock_loader.load_model.assert_called_once_with(
+            mock_loader.load_model.assert_called_once()
+            call_args = mock_loader.load_model.call_args
+            assert call_args.args == (
                 model_id,
                 ANY_MODEL_PATH,
                 ANY_MODEL_TYPE,
-                wait=False,
-                aborter=None,
             )
+            assert call_args.kwargs["wait"] == False
+            assert call_args.kwargs["aborter"] is None
+            assert "fail_callback" in call_args.kwargs
             mock_sizer.get_model_size.assert_called_once_with(
                 model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
             )

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -14,12 +14,13 @@
 # Standard
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
+import copy
 import os
 import shutil
-import unittest
 
 # Third Party
 import grpc
+import pytest
 
 # Local
 from caikit import get_config
@@ -34,374 +35,380 @@ from tests.fixtures import Fixtures
 get_dynamic_module("caikit.core")
 ANY_MODEL_TYPE = "test-any-model-type"
 ANY_MODEL_PATH = "test-any-model-path"
+MODEL_MANAGER = ModelManager.get_instance()
 
 
-class TestModelManager(unittest.TestCase):
-    """This test suite tests the modelmanager class"""
+@pytest.fixture(autouse=True)
+def tear_down():
+    yield
+    MODEL_MANAGER.unload_all_models()
 
-    def setUp(self):
-        """This method runs before each test begins to run"""
-        self.model_manager = ModelManager.get_instance()
 
-    def tearDown(self):
-        """This method runs after each test executes"""
-        self.model_manager.unload_all_models()
+# ****************************** Integration Tests ****************************** #
+# These tests do not patch in mocks, the manager will use real instances of its dependencies
 
-    # ****************************** Integration Tests ****************************** #
-    # These tests do not patch in mocks, the manager will use real instances of its dependencies
 
-    def test_load_model_ok_response(self):
-        model_id = "happy_load_test"
-        model_size = self.model_manager.load_model(
-            model_id=model_id,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
+def test_load_model_ok_response():
+    model_id = "happy_load_test"
+    model_size = MODEL_MANAGER.load_model(
+        model_id=model_id,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert model_size > 0
+
+
+def test_load_local_models():
+    with TemporaryDirectory() as tempdir:
+        shutil.copytree(Fixtures.get_good_model_path(), os.path.join(tempdir, "model1"))
+        shutil.copy(
+            Fixtures.get_good_model_archive_path(),
+            os.path.join(tempdir, "model2.zip"),
         )
-        self.assertGreater(model_size, 0)
 
-    def test_load_local_models(self):
-        with TemporaryDirectory() as tempdir:
-            shutil.copytree(
-                Fixtures.get_good_model_path(), os.path.join(tempdir, "model1")
-            )
-            shutil.copy(
-                Fixtures.get_good_model_archive_path(),
-                os.path.join(tempdir, "model2.zip"),
-            )
+        MODEL_MANAGER.load_local_models(tempdir)
+        assert len(MODEL_MANAGER.loaded_models) == 2
+        assert "model1" in MODEL_MANAGER.loaded_models.keys()
+        assert "model2.zip" in MODEL_MANAGER.loaded_models.keys()
+        assert "model-does-not-exist.zip" not in MODEL_MANAGER.loaded_models.keys()
 
-            self.model_manager.load_local_models(tempdir)
-            self.assertEqual(len(self.model_manager.loaded_models), 2)
-            self.assertIn("model1", self.model_manager.loaded_models.keys())
-            self.assertIn("model2.zip", self.model_manager.loaded_models.keys())
-            self.assertNotIn(
-                "model-does-not-exist.zip", self.model_manager.loaded_models.keys()
-            )
 
-    def test_model_manager_loads_local_models_on_init(self):
-        with TemporaryDirectory() as tempdir:
-            shutil.copytree(
-                Fixtures.get_good_model_path(), os.path.join(tempdir, "model1")
-            )
-            shutil.copy(
-                Fixtures.get_good_model_archive_path(),
-                os.path.join(tempdir, "model2.zip"),
-            )
-            ModelManager._ModelManager__instance = None
-            with temp_config(
-                {"runtime": {"local_models_dir": tempdir}}, merge_strategy="merge"
-            ):
-                self.model_manager = ModelManager()
-
-                self.assertEqual(len(self.model_manager.loaded_models), 2)
-                self.assertIn("model1", self.model_manager.loaded_models.keys())
-                self.assertIn("model2.zip", self.model_manager.loaded_models.keys())
-                self.assertNotIn(
-                    "model-does-not-exist.zip", self.model_manager.loaded_models.keys()
-                )
-
-    def test_model_manager_raises_if_all_local_models_fail_to_load(self):
-        with TemporaryDirectory() as tempdir:
-            shutil.copy(
-                Fixtures.get_bad_model_archive_path(), os.path.join(tempdir, "model1")
-            )
-            shutil.copy(
-                Fixtures.get_invalid_model_archive_path(),
-                os.path.join(tempdir, "model2.zip"),
-            )
-            with self.assertRaises(CaikitRuntimeException) as ctx:
-                self.model_manager.load_local_models(tempdir)
-            self.assertEqual(grpc.StatusCode.INTERNAL, ctx.exception.status_code)
-
-    def test_load_model_error_response(self):
-        """Test load model's model does not exist when the loader throws"""
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_manager.load_model(
-                model_id=random_test_id(),
-                local_model_path=Fixtures().get_invalid_model_archive_path(),
-                model_type="categories_esa",
-            )
-
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
-        self.assertEqual(len(self.model_manager.loaded_models), 0)
-
-    def test_load_model_map_insertion(self):
-        """Test if loaded model is correctly added to map storing model data"""
-        model = random_test_id()
-        self.model_manager.load_model(
-            model_id=model,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
+def test_model_manager_loads_local_models_on_init():
+    with TemporaryDirectory() as tempdir:
+        shutil.copytree(Fixtures.get_good_model_path(), os.path.join(tempdir, "model1"))
+        shutil.copy(
+            Fixtures.get_good_model_archive_path(),
+            os.path.join(tempdir, "model2.zip"),
         )
-        self.assertGreater(self.model_manager.loaded_models[model].size(), 0)
+        ModelManager._ModelManager__instance = None
+        with temp_config(
+            {"runtime": {"local_models_dir": tempdir}}, merge_strategy="merge"
+        ):
+            MODEL_MANAGER = ModelManager()
 
-    def test_load_model_count(self):
-        """Test if multiple loaded models are added to map storing model data"""
-        self.model_manager.load_model(
+            assert len(MODEL_MANAGER.loaded_models) == 2
+            assert "model1" in MODEL_MANAGER.loaded_models.keys()
+            assert "model2.zip" in MODEL_MANAGER.loaded_models.keys()
+            assert "model-does-not-exist.zip" not in MODEL_MANAGER.loaded_models.keys()
+
+
+def test_model_manager_raises_if_all_local_models_fail_to_load():
+    with TemporaryDirectory() as tempdir:
+        shutil.copy(
+            Fixtures.get_bad_model_archive_path(), os.path.join(tempdir, "model1")
+        )
+        shutil.copy(
+            Fixtures.get_invalid_model_archive_path(),
+            os.path.join(tempdir, "model2.zip"),
+        )
+        with pytest.raises(CaikitRuntimeException) as ctx:
+            MODEL_MANAGER.load_local_models(tempdir)
+        assert grpc.StatusCode.INTERNAL == ctx.value.status_code
+
+
+def test_load_model_error_response():
+    """Test load model's model does not exist when the loader throws"""
+    with pytest.raises(CaikitRuntimeException) as context:
+        MODEL_MANAGER.load_model(
             model_id=random_test_id(),
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.model_manager.load_model(
-            model_id=random_test_id(),
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.assertEqual(len(self.model_manager.loaded_models), 2)
-
-    def test_unload_model_ok_response(self):
-        """Test to make sure that given a loaded model ID, the model manager is able to correctly
-        unload a model, giving a nonzero model size back."""
-        model_id = "happy_unload_test"
-        self.model_manager.load_model(
-            model_id=model_id,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        model_size = self.model_manager.unload_model(model_id=model_id)
-        self.assertTrue(model_size >= 0)
-
-    def test_unload_model_count(self):
-        """Test if unloaded models are deleted from loaded models map"""
-        id_1 = "test"
-        id_2 = "test2"
-        # Load models from COS
-        self.model_manager.load_model(
-            model_id=id_1,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.model_manager.load_model(
-            model_id=id_2,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        # Unload one of the models, and make sure it was properly removed
-        self.model_manager.unload_model(model_id=id_2)
-        self.assertEqual(len(self.model_manager.loaded_models), 1)
-        self.assertIn(id_1, self.model_manager.loaded_models.keys())
-
-    def test_unload_all_models_count(self):
-        """Test if unload all models deletes every model from loaded models map"""
-        id_1 = "test"
-        id_2 = "test2"
-        self.model_manager.load_model(
-            model_id=id_1,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.model_manager.load_model(
-            model_id=id_2,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.model_manager.unload_all_models()
-        self.assertEqual(len(self.model_manager.loaded_models), 0)
-
-    def test_unload_model_not_loaded_response(self):
-        """Test unload model for model not loaded does NOT throw an error"""
-        try:
-            self.model_manager.unload_model(model_id=random_test_id())
-        except Exception:
-            self.fail("Unload for a model that does not exist threw an error!")
-
-    # TODO: If this is refactored to pytest, the loaded_model_id fixture can be used
-    def test_retrieve_model_returns_loaded_model(self):
-        """Test that a loaded model can be retrieved"""
-        model_id = random_test_id()
-        Fixtures.load_model(
-            model_id=model_id,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        model = self.model_manager.retrieve_model(model_id)
-        self.assertIsInstance(model, ModuleBase)
-        self.assertEqual(len(self.model_manager.loaded_models), 1)
-
-    def test_retrieve_model_raises_error_for_not_found_model(self):
-        """Test that gRPC NOT_FOUND exception raised when non-existent model retrieved"""
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_manager.retrieve_model("not-found")
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
-
-    def test_model_size_ok_response(self):
-        """Test if loaded model correctly returns model size"""
-        model = random_test_id()
-        self.model_manager.load_model(
-            model_id=model,
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.assertTrue(self.model_manager.get_model_size(model) > 0)
-
-    def test_model_size_error_not_found_response(self):
-        """Test model size's model does not exist error response"""
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_manager.get_model_size("no_exist_model")
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
-
-    def test_model_size_error_none_not_found_response(self):
-        """Test model size's model is None error response"""
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_manager.get_model_size(None)
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
-
-    def test_estimate_model_size_ok_response_on_loaded_model(self):
-        """Test if loaded model correctly returns model size"""
-        self.model_manager.load_model(
-            model_id=random_test_id(),
-            local_model_path=Fixtures.get_good_model_path(),
-            model_type=Fixtures.get_good_model_type(),
-        )
-        self.assertTrue(
-            self.model_manager.estimate_model_size(
-                "test", Fixtures.get_good_model_path(), Fixtures.get_good_model_type()
-            )
-            > 0
+            local_model_path=Fixtures().get_invalid_model_archive_path(),
+            model_type="categories_esa",
         )
 
-    def test_estimate_model_size_ok_response_on_nonloaded_model(self):
-        """Test if a model that's not loaded, correctly returns predicted model size"""
-        self.assertTrue(
-            self.model_manager.estimate_model_size(
-                "test", Fixtures.get_good_model_path(), Fixtures.get_good_model_type()
-            )
-            > 0
-        )
+    assert context.value.status_code == grpc.StatusCode.NOT_FOUND
+    assert len(MODEL_MANAGER.loaded_models) == 0
 
-    def test_estimate_model_size_by_type(self):
-        """Test that a model's size is estimated differently based on its type"""
-        config = get_config().inference_plugin.model_mesh
-        self.assertTrue(Fixtures.get_good_model_type() in config.model_size_multipliers)
 
-        typed_model_size = self.model_manager.estimate_model_size(
+def test_load_model_map_insertion():
+    """Test if loaded model is correctly added to map storing model data"""
+    model = random_test_id()
+    MODEL_MANAGER.load_model(
+        model_id=model,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert MODEL_MANAGER.loaded_models[model].size() > 0
+
+
+def test_load_model_count():
+    """Test if multiple loaded models are added to map storing model data"""
+    MODEL_MANAGER.load_model(
+        model_id=random_test_id(),
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    MODEL_MANAGER.load_model(
+        model_id=random_test_id(),
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert len(MODEL_MANAGER.loaded_models) == 2
+
+
+def test_unload_model_ok_response():
+    """Test to make sure that given a loaded model ID, the model manager is able to correctly
+    unload a model, giving a nonzero model size back."""
+    model_id = "happy_unload_test"
+    MODEL_MANAGER.load_model(
+        model_id=model_id,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    model_size = MODEL_MANAGER.unload_model(model_id=model_id)
+    assert model_size >= 0
+
+
+def test_unload_model_count():
+    """Test if unloaded models are deleted from loaded models map"""
+    id_1 = "test"
+    id_2 = "test2"
+    # Load models from COS
+    MODEL_MANAGER.load_model(
+        model_id=id_1,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    MODEL_MANAGER.load_model(
+        model_id=id_2,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    # Unload one of the models, and make sure it was properly removed
+    MODEL_MANAGER.unload_model(model_id=id_2)
+    assert len(MODEL_MANAGER.loaded_models) == 1
+    assert id_1 in MODEL_MANAGER.loaded_models.keys()
+
+
+def test_unload_all_models_count():
+    """Test if unload all models deletes every model from loaded models map"""
+    id_1 = "test"
+    id_2 = "test2"
+    MODEL_MANAGER.load_model(
+        model_id=id_1,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    MODEL_MANAGER.load_model(
+        model_id=id_2,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    MODEL_MANAGER.unload_all_models()
+    assert len(MODEL_MANAGER.loaded_models) == 0
+
+
+def test_unload_model_not_loaded_response():
+    """Test unload model for model not loaded does NOT throw an error"""
+    MODEL_MANAGER.unload_model(model_id=random_test_id())
+
+
+def test_retrieve_model_returns_loaded_model():
+    """Test that a loaded model can be retrieved"""
+    model_id = random_test_id()
+    MODEL_MANAGER.load_model(
+        model_id,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
+    )
+    model = MODEL_MANAGER.retrieve_model(model_id)
+    assert isinstance(model, ModuleBase)
+    assert len(MODEL_MANAGER.loaded_models) == 1
+
+
+def test_retrieve_model_raises_error_for_not_found_model():
+    """Test that gRPC NOT_FOUND exception raised when non-existent model retrieved"""
+    with pytest.raises(CaikitRuntimeException) as context:
+        MODEL_MANAGER.retrieve_model("not-found")
+    assert context.value.status_code == grpc.StatusCode.NOT_FOUND
+
+
+def test_model_size_ok_response():
+    """Test if loaded model correctly returns model size"""
+    model = random_test_id()
+    MODEL_MANAGER.load_model(
+        model_id=model,
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert MODEL_MANAGER.get_model_size(model) > 0
+
+
+def test_model_size_error_not_found_response():
+    """Test model size's model does not exist error response"""
+    with pytest.raises(CaikitRuntimeException) as context:
+        MODEL_MANAGER.get_model_size("no_exist_model")
+    assert context.value.status_code == grpc.StatusCode.NOT_FOUND
+
+
+def test_model_size_error_none_not_found_response():
+    """Test model size's model is None error response"""
+    with pytest.raises(CaikitRuntimeException) as context:
+        MODEL_MANAGER.get_model_size(None)
+    assert context.value.status_code == grpc.StatusCode.NOT_FOUND
+
+
+def test_estimate_model_size_ok_response_on_loaded_model():
+    """Test if loaded model correctly returns model size"""
+    MODEL_MANAGER.load_model(
+        model_id=random_test_id(),
+        local_model_path=Fixtures.get_good_model_path(),
+        model_type=Fixtures.get_good_model_type(),
+    )
+    assert (
+        MODEL_MANAGER.estimate_model_size(
             "test", Fixtures.get_good_model_path(), Fixtures.get_good_model_type()
         )
-        untyped_model_size = self.model_manager.estimate_model_size(
-            "test", Fixtures.get_good_model_path(), "test-not-a-model-type"
+        > 0
+    )
+
+
+def test_estimate_model_size_ok_response_on_nonloaded_model():
+    """Test if a model that's not loaded, correctly returns predicted model size"""
+    assert (
+        MODEL_MANAGER.estimate_model_size(
+            "test", Fixtures.get_good_model_path(), Fixtures.get_good_model_type()
         )
+        > 0
+    )
 
-        self.assertTrue(typed_model_size > 0)
-        self.assertTrue(untyped_model_size > 0)
 
-        self.assertNotAlmostEqual(typed_model_size, untyped_model_size)
+def test_estimate_model_size_by_type():
+    """Test that a model's size is estimated differently based on its type"""
+    config = get_config().inference_plugin.model_mesh
+    assert Fixtures.get_good_model_type() in config.model_size_multipliers
 
-    def test_estimate_model_size_error_not_found_response(self):
-        """Test if error in predict model size on unknown model path"""
-        with self.assertRaises(CaikitRuntimeException) as context:
-            self.model_manager.estimate_model_size(
-                model_id=random_test_id(),
-                local_model_path="no_exist.zip",
-                model_type="categories_esa",
-            )
-        self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
+    typed_model_size = MODEL_MANAGER.estimate_model_size(
+        "test", Fixtures.get_good_model_path(), Fixtures.get_good_model_type()
+    )
+    untyped_model_size = MODEL_MANAGER.estimate_model_size(
+        "test", Fixtures.get_good_model_path(), "test-not-a-model-type"
+    )
 
-    # ****************************** Unit Tests ****************************** #
-    # These tests patch in mocks for the manager's dependencies, to test its code in isolation
+    assert typed_model_size > 0
+    assert untyped_model_size > 0
+    assert typed_model_size != untyped_model_size
 
-    def test_load_model(self):
-        """Test to make sure that given valid input, the model manager gives a happy response
-        when we tried to load in a model (model size > 0 or 0 if the model size will be computed
-        at a later time)."""
-        mock_loader = MagicMock()
-        mock_sizer = MagicMock()
-        model_id = random_test_id()
-        expected_model_size = 1234
 
-        with patch.object(self.model_manager, "model_loader", mock_loader):
-            with patch.object(self.model_manager, "model_sizer", mock_sizer):
-                mock_loader.load_model.return_value = LoadedModel()
-                mock_sizer.get_model_size.return_value = expected_model_size
+def test_estimate_model_size_error_not_found_response():
+    """Test if error in predict model size on unknown model path"""
+    with pytest.raises(CaikitRuntimeException) as context:
+        MODEL_MANAGER.estimate_model_size(
+            model_id=random_test_id(),
+            local_model_path="no_exist.zip",
+            model_type="categories_esa",
+        )
+    assert context.value.status_code == grpc.StatusCode.NOT_FOUND
 
-                model_size = self.model_manager.load_model(
-                    model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
-                )
-                self.assertEqual(expected_model_size, model_size)
-                mock_loader.load_model.assert_called_once_with(
-                    model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
-                )
-                mock_sizer.get_model_size.assert_called_once_with(
-                    model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
-                )
 
-    def test_load_model_throws_if_the_model_loader_throws(self):
-        """Test load model's model does not exist when the loader throws"""
-        mock_loader = MagicMock()
-        with patch.object(self.model_manager, "model_loader", mock_loader):
-            mock_loader.load_model.side_effect = CaikitRuntimeException(
-                grpc.StatusCode.NOT_FOUND, "test any not found exception"
-            )
+# ****************************** Unit Tests ****************************** #
+# These tests patch in mocks for the manager's dependencies, to test its code in isolation
 
-            with self.assertRaises(CaikitRuntimeException) as context:
-                self.model_manager.load_model(
-                    random_test_id(), ANY_MODEL_PATH, ANY_MODEL_TYPE
-                )
 
-            self.assertEqual(context.exception.status_code, grpc.StatusCode.NOT_FOUND)
-            self.assertEqual(len(self.model_manager.loaded_models), 0)
+def test_load_model():
+    """Test to make sure that given valid input, the model manager gives a happy response
+    when we tried to load in a model (model size > 0 or 0 if the model size will be computed
+    at a later time)."""
+    mock_loader = MagicMock()
+    mock_sizer = MagicMock()
+    model_id = random_test_id()
+    expected_model_size = 1234
 
-    def test_retrieve_model_returns_the_module_from_the_model_loader(self):
-        """Test that a loaded model can be retrieved"""
-        model_id = random_test_id()
-        expected_module = "this is definitely a stub module"
-        mock_sizer = MagicMock()
-        mock_loader = MagicMock()
-
-        with patch.object(self.model_manager, "model_loader", mock_loader):
-            with patch.object(self.model_manager, "model_sizer", mock_sizer):
-                mock_sizer.get_model_size.return_value = 1
-                mock_loader.load_model.return_value = (
-                    LoadedModel.Builder()
-                    .model(expected_module)
-                    .id("foo")
-                    .type("bar")
-                    .build()
-                )
-                self.model_manager.load_model(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)
-
-                model = self.model_manager.retrieve_model(model_id)
-                self.assertEqual(expected_module, model)
-
-    def test_get_model_size_returns_size_from_model_sizer(self):
-        """Test that loading a model stores the size from the ModelSizer"""
-        mock_loader = MagicMock()
-        mock_sizer = MagicMock()
-        expected_model_size = 1234
-        model_id = random_test_id()
-
-        with patch.object(self.model_manager, "model_loader", mock_loader):
-            with patch.object(self.model_manager, "model_sizer", mock_sizer):
-                mock_loader.load_model.return_value = LoadedModel()
-                mock_sizer.get_model_size.return_value = expected_model_size
-
-                self.model_manager.load_model(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)
-
-                model_size = self.model_manager.get_model_size(model_id)
-                self.assertEqual(expected_model_size, model_size)
-
-    def test_estimate_model_size_returns_size_from_model_sizer(self):
-        """Test that estimating a model size uses the ModelSizer"""
-        mock_sizer = MagicMock()
-        expected_model_size = 5678
-        model_id = random_test_id()
-
-        with patch.object(self.model_manager, "model_sizer", mock_sizer):
+    with patch.object(MODEL_MANAGER, "model_loader", mock_loader):
+        with patch.object(MODEL_MANAGER, "model_sizer", mock_sizer):
+            mock_loader.load_model.return_value = LoadedModel()
             mock_sizer.get_model_size.return_value = expected_model_size
-            model_size = self.model_manager.estimate_model_size(
+
+            model_size = MODEL_MANAGER.load_model(
                 model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
             )
-            self.assertEqual(expected_model_size, model_size)
-
-    def test_estimate_model_size_throws_if_model_sizer_throws(self):
-        """Test that estimating a model size uses the ModelSizer"""
-        mock_sizer = MagicMock()
-        model_id = random_test_id()
-
-        with patch.object(self.model_manager, "model_sizer", mock_sizer):
-            mock_sizer.get_model_size.side_effect = CaikitRuntimeException(
-                grpc.StatusCode.UNAVAILABLE, "test-any-exception"
+            assert expected_model_size == model_size
+            mock_loader.load_model.assert_called_once_with(
+                model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
             )
-            with self.assertRaises(CaikitRuntimeException) as context:
-                self.model_manager.estimate_model_size(
-                    model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
-                )
-            self.assertEqual(context.exception.status_code, grpc.StatusCode.UNAVAILABLE)
+            mock_sizer.get_model_size.assert_called_once_with(
+                model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
+            )
+
+
+def test_load_model_throws_if_the_model_loader_throws():
+    """Test load model's model does not exist when the loader throws"""
+    mock_loader = MagicMock()
+    with patch.object(MODEL_MANAGER, "model_loader", mock_loader):
+        mock_loader.load_model.side_effect = CaikitRuntimeException(
+            grpc.StatusCode.NOT_FOUND, "test any not found exception"
+        )
+
+        with pytest.raises(CaikitRuntimeException) as context:
+            MODEL_MANAGER.load_model(random_test_id(), ANY_MODEL_PATH, ANY_MODEL_TYPE)
+
+        assert context.value.status_code == grpc.StatusCode.NOT_FOUND
+        assert len(MODEL_MANAGER.loaded_models) == 0
+
+
+def test_retrieve_model_returns_the_module_from_the_model_loader():
+    """Test that a loaded model can be retrieved"""
+    model_id = random_test_id()
+    expected_module = "this is definitely a stub module"
+    mock_sizer = MagicMock()
+    mock_loader = MagicMock()
+
+    with patch.object(MODEL_MANAGER, "model_loader", mock_loader):
+        with patch.object(MODEL_MANAGER, "model_sizer", mock_sizer):
+            mock_sizer.get_model_size.return_value = 1
+            mock_loader.load_model.return_value = (
+                LoadedModel.Builder()
+                .model(expected_module)
+                .id("foo")
+                .type("bar")
+                .build()
+            )
+            MODEL_MANAGER.load_model(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)
+
+            model = MODEL_MANAGER.retrieve_model(model_id)
+            assert expected_module == model
+
+
+def test_get_model_size_returns_size_from_model_sizer():
+    """Test that loading a model stores the size from the ModelSizer"""
+    mock_loader = MagicMock()
+    mock_sizer = MagicMock()
+    expected_model_size = 1234
+    model_id = random_test_id()
+
+    with patch.object(MODEL_MANAGER, "model_loader", mock_loader):
+        with patch.object(MODEL_MANAGER, "model_sizer", mock_sizer):
+            mock_loader.load_model.return_value = LoadedModel()
+            mock_sizer.get_model_size.return_value = expected_model_size
+
+            MODEL_MANAGER.load_model(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)
+
+            model_size = MODEL_MANAGER.get_model_size(model_id)
+            assert expected_model_size == model_size
+
+
+def test_estimate_model_size_returns_size_from_model_sizer():
+    """Test that estimating a model size uses the ModelSizer"""
+    mock_sizer = MagicMock()
+    expected_model_size = 5678
+    model_id = random_test_id()
+
+    with patch.object(MODEL_MANAGER, "model_sizer", mock_sizer):
+        mock_sizer.get_model_size.return_value = expected_model_size
+        model_size = MODEL_MANAGER.estimate_model_size(
+            model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
+        )
+        assert expected_model_size == model_size
+
+
+def test_estimate_model_size_throws_if_model_sizer_throws():
+    """Test that estimating a model size uses the ModelSizer"""
+    mock_sizer = MagicMock()
+    model_id = random_test_id()
+
+    with patch.object(MODEL_MANAGER, "model_sizer", mock_sizer):
+        mock_sizer.get_model_size.side_effect = CaikitRuntimeException(
+            grpc.StatusCode.UNAVAILABLE, "test-any-exception"
+        )
+        with pytest.raises(CaikitRuntimeException) as context:
+            MODEL_MANAGER.estimate_model_size(model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE)
+        assert context.value.status_code == grpc.StatusCode.UNAVAILABLE

--- a/tests/runtime/servicers/test_model_runtime_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_runtime_servicer_impl.py
@@ -90,7 +90,7 @@ class TestModelRuntimeServicerImpl(unittest.TestCase):
         mock_manager = MagicMock()
         started = Event()
 
-        def never_return(*args):
+        def never_return(*args, **kwargs):
             started.set()
             while True:
                 time.sleep(0.01)

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -828,7 +828,7 @@ def test_canceling_model_loads_causes_exceptions(runtime_grpc_server):
         modelKey="bar",
     )
 
-    def never_return(*args):
+    def never_return(*args, **kwargs):
         request_received.set()
         try:
             while True:

--- a/tests/runtime/work_management/test_abortable_action.py
+++ b/tests/runtime/work_management/test_abortable_action.py
@@ -19,7 +19,7 @@ import unittest
 # Local
 from caikit.runtime.types.aborted_exception import AbortedException
 from caikit.runtime.work_management.abortable_action import AbortableAction
-from caikit.runtime.work_management.call_aborter import CallAborter
+from caikit.runtime.work_management.rpc_aborter import RpcAborter
 from tests.fixtures import Fixtures
 
 
@@ -29,7 +29,7 @@ class TestAbortableAction(unittest.TestCase):
     def setUp(self):
         """This method runs before each test begins to run"""
         self.rpc_context = Fixtures.build_context()
-        self.aborter = CallAborter(self.rpc_context)
+        self.aborter = RpcAborter(self.rpc_context)
 
     def test_it_can_run_a_function(self):
         expected_result = "test-any-result"

--- a/tests/runtime/work_management/test_call_aborter.py
+++ b/tests/runtime/work_management/test_call_aborter.py
@@ -16,11 +16,11 @@ import threading
 import unittest
 
 # Local
-from caikit.runtime.work_management.call_aborter import CallAborter
+from caikit.runtime.work_management.rpc_aborter import RpcAborter
 from tests.fixtures import Fixtures
 
 
-class TestCallAborter(unittest.TestCase):
+class TestRpcAborter(unittest.TestCase):
     """This test suite tests the call aborter utility"""
 
     CHANNEL = None
@@ -29,7 +29,7 @@ class TestCallAborter(unittest.TestCase):
     def test_call_aborter_sets_event(self):
         ctx = Fixtures.build_context("call_aborter_event_party")
         # Create a new Call aborter
-        aborter = CallAborter(ctx)
+        aborter = RpcAborter(ctx)
         # Create a new threading event and add it to the call aborter
         event = threading.Event()
         aborter.add_event(event)
@@ -41,7 +41,7 @@ class TestCallAborter(unittest.TestCase):
     def test_call_aborter_sets_event_added_after_termination(self):
         ctx = Fixtures.build_context("call_aborter_event_party")
         # Create a new call aborter
-        aborter = CallAborter(ctx)
+        aborter = RpcAborter(ctx)
         # Cancel the call before creating the threading event and adding to the aborter
         ctx.cancel()
         event = threading.Event()


### PR DESCRIPTION
## Description

This is a better implementation of https://github.com/caikit/caikit/pull/336

This PR adds a new feature to `caikit.runtime` to use a local directory on disk (which can be mounted) to act as a shared-state cache. This will allow replicas of `caikit.runtime` to host an eventually-consistent set of models that changes dynamically. This is a significantly weaker value proposition than `model-mesh`, but for many model types, especially those that use a `module_backend` to delegate the work to another engine (e.g. `caikit-tgis-backend`), it's fine to require that all models be loaded on all replicas.