### PR TITLE
ModelManagementFactoryImports

### DIFF
--- a/caikit/core/model_management/factories.py
+++ b/caikit/core/model_management/factories.py
@@ -14,25 +14,89 @@
 """
 Global factories for model management
 """
+# Standard
+from typing import Optional
+import importlib
+
+# First Party
+import alog
 
 # Local
-from ..toolkit.factory import Factory
+from ..toolkit.errors import error_handler
+from ..toolkit.factory import Factory, FactoryConstructible
 from .local_model_finder import LocalModelFinder
 from .local_model_initializer import LocalModelInitializer
 from .local_model_trainer import LocalModelTrainer
 
+log = alog.use_channel("MMFCTRY")
+error = error_handler.get(log)
+
+
+class ImportableFactory(Factory):
+    """An ImportableFactory extends the base Factory to allow the construction
+    to specify an "import_class" field that will be used to import and register
+    the implementation class before attempting to initialize it.
+    """
+
+    IMPORT_CLASS_KEY = "import_class"
+
+    def construct(
+        self,
+        instance_config: dict,
+        instance_name: Optional[str] = None,
+    ):
+        # Look for an import_class and import and register it if found
+        import_class_val = instance_config.get(self.__class__.IMPORT_CLASS_KEY)
+        if import_class_val:
+            error.type_check(
+                "<COR85108801E>",
+                str,
+                **{self.__class__.IMPORT_CLASS_KEY: import_class_val},
+            )
+            module_name, class_name = import_class_val.rsplit(".", 1)
+            try:
+                imported_module = importlib.import_module(module_name)
+            except ImportError:
+                error(
+                    "<COR46837141E>",
+                    ValueError(
+                        "Invalid {}: Module cannot be imported [{}]".format(
+                            self.__class__.IMPORT_CLASS_KEY,
+                            module_name,
+                        )
+                    ),
+                )
+            try:
+                imported_class = getattr(imported_module, class_name)
+            except AttributeError:
+                error(
+                    "<COR46837142E>",
+                    ValueError(
+                        "Invalid {}: No such class [{}] on module [{}]".format(
+                            self.__class__.IMPORT_CLASS_KEY,
+                            class_name,
+                            module_name,
+                        )
+                    ),
+                )
+            error.subclass_check("<COR52306423E>", imported_class, FactoryConstructible)
+
+            self.register(imported_class)
+        return super().construct(instance_config, instance_name)
+
+
 # Model trainer factory. A trainer is responsible for performing the train
 # operation against a configured framework connection.
-model_trainer_factory = Factory("ModelTrainer")
+model_trainer_factory = ImportableFactory("ModelTrainer")
 model_trainer_factory.register(LocalModelTrainer)
 
 # Model finder factory. A finder is responsible for locating a well defined
 # configuration for a model based on a unique path or id.
-model_finder_factory = Factory("ModelFinder")
+model_finder_factory = ImportableFactory("ModelFinder")
 model_finder_factory.register(LocalModelFinder)
 
 # Model initializer factory. An initializer is responsible for taking a model
 # configuration and preparing the model to be run in a configured runtime
 # location.
-model_initializer_factory = Factory("ModelInitializer")
+model_initializer_factory = ImportableFactory("ModelInitializer")
 model_initializer_factory.register(LocalModelInitializer)

--- a/tests/core/model_management/test_factories.py
+++ b/tests/core/model_management/test_factories.py
@@ -1,0 +1,65 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ImportableFactory"""
+
+# Third Party
+import pytest
+
+# Local
+from caikit.core.model_management.factories import ImportableFactory
+from caikit.core.model_management.local_model_finder import LocalModelFinder
+
+
+def test_importable_factory_auto_register():
+    """Test that a constructible gets auto-registered with a factory if given
+    the import_class key
+    """
+    fact = ImportableFactory("TestFact")
+    assert not fact._registered_types
+    inst = fact.construct(
+        {
+            ImportableFactory.IMPORT_CLASS_KEY: "{}.{}".format(
+                LocalModelFinder.__module__,
+                LocalModelFinder.__name__,
+            ),
+            ImportableFactory.TYPE_KEY: LocalModelFinder.name,
+        }
+    )
+    assert inst
+    assert fact._registered_types
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (f"not.valid.{LocalModelFinder.__name__}", ValueError),
+        (f"{LocalModelFinder.__module__}.FooBar", ValueError),
+        (f"{LocalModelFinder.__module__}.alog", TypeError),
+        (12345, TypeError),
+    ],
+)
+def test_importable_factory_error_cases(params):
+    """Make sure that all forms of bad value result in a ValueError or TypeError
+    is raised
+    """
+    import_class_val, exc_type = params
+    fact = ImportableFactory("TestFact")
+    assert not fact._registered_types
+    with pytest.raises(exc_type):
+        fact.construct(
+            {
+                ImportableFactory.IMPORT_CLASS_KEY: import_class_val,
+                ImportableFactory.TYPE_KEY: LocalModelFinder.name,
+            }
+        )


### PR DESCRIPTION
## Description

Make model management factories support import plugins. In each factory blob, there's now an additional "import_class" field that can be added to force an import of an external library with a predefined class in it that should be registered and constructed.

Closes: https://github.com/caikit/caikit/issues/347