### PR TITLE
🥅 add better REST error handling

### DIFF
--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -28,7 +28,7 @@ import threading
 import time
 
 # Third Party
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import ResponseValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -119,10 +119,11 @@ class RuntimeHTTPServer(RuntimeServerBase):
 
         self.app = FastAPI()
 
+        # Response validation
         @self.app.exception_handler(ResponseValidationError)
         async def validation_exception_handler(_, exc: ResponseValidationError):
             return JSONResponse(
-                status_code=500,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
             )
 

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -7,6 +7,7 @@ import typing
 
 # Local
 from caikit.core import DataObjectBase, TaskBase, dataobject, task
+from caikit.core.data_model import ProducerId
 
 
 @dataobject(package="caikit_data_model.sample_lib")
@@ -29,6 +30,7 @@ class OtherOutputType(DataObjectBase):
     """A simple return type for the `other_task` task"""
 
     farewell: str
+    producer_id: ProducerId
 
 
 @dataobject(package="caikit_data_model.sample_lib")

--- a/tests/fixtures/sample_lib/modules/other_task/other_implementation.py
+++ b/tests/fixtures/sample_lib/modules/other_task/other_implementation.py
@@ -7,6 +7,7 @@ from typing import Union
 # Local
 from ...data_model.sample import OtherOutputType, OtherTask, SampleInputType
 from caikit.core.data_model import DataStream
+from caikit.core.data_model.producer import ProducerId
 from caikit.core.modules import ModuleLoader, ModuleSaver
 import caikit.core
 
@@ -21,9 +22,11 @@ class OtherModule(caikit.core.ModuleBase):
         self.learning_rate = learning_rate
 
     def run(
-        self, sample_input: Union[SampleInputType, str]
+        self, sample_input: Union[SampleInputType, str], include_producer_id=True
     ) -> Union[OtherOutputType, str]:
-        return OtherOutputType(f"goodbye: {sample_input.name} {self.batch_size} times")
+        farewell = f"goodbye: {sample_input.name} {self.batch_size} times"
+        producer_id = ProducerId("other_mod", "1.1.1") if include_producer_id else None
+        return OtherOutputType(farewell, producer_id)
 
     @classmethod
     def load(cls, model_path, **kwargs):

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -27,6 +27,7 @@ import pytest
 # Local
 from caikit.config import get_config
 from caikit.core import MODEL_MANAGER
+from caikit.core.data_model.producer import ProducerId
 from caikit.interfaces.common.data_model.stream_sources import S3Path
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
@@ -194,6 +195,7 @@ def test_global_train_other_task(
         inference_response
         == OtherOutputType(
             farewell=f"goodbye: Gabe {batch_size} times",
+            producer_id=ProducerId("other_mod", "1.1.1"),
         ).to_proto()
     )
 

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -43,6 +43,7 @@ import alog
 from caikit import get_config
 from caikit.core import MODEL_MANAGER
 from caikit.core.data_model.base import DataBase
+from caikit.core.data_model.producer import ProducerId
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,
     TrainingJob,
@@ -471,7 +472,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]
     )
     expected_trained_inference_response = OtherOutputType(
-        farewell="goodbye: Gabe 100 times"
+        farewell="goodbye: Gabe 100 times", producer_id=ProducerId("other_mod", "1.1.1")
     ).to_proto()
     assert trained_inference_response == expected_trained_inference_response
 
@@ -480,7 +481,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
         predict_request, metadata=[("mm-model-id", other_task_model_id)]
     )
     expected_original_inference_response = OtherOutputType(
-        farewell="goodbye: Gabe 42 times"
+        farewell="goodbye: Gabe 42 times", producer_id=ProducerId("other_mod", "1.1.1")
     ).to_proto()
     assert original_inference_response == expected_original_inference_response
 

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -296,9 +296,9 @@ def test_inference_other_task(other_task_model_id, runtime_http_server):
             f"/api/v1/{other_task_model_id}/task/other",
             json=json_input,
         )
-        assert response.status_code == 200
+        assert response.status_code == 500
         json_response = json.loads(response.content.decode(response.default_encoding))
-        assert json_response["farewell"] == "goodbye: world 42 times"
+        assert json_response["detail"][0]["loc"] == ["response", "producer_id"]
 
 
 def test_inference_streaming_sample_module(sample_task_model_id, runtime_http_server):

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -314,7 +314,7 @@ def test_inference_other_task_request_throws_missing_field(
         assert response.status_code == 400
         json_response = json.loads(response.content.decode(response.default_encoding))
         assert (
-            "This may be a problem with your input: run() missing 1 required positional argument"
+            "missing 1 required positional argument: 'sample_input'"
             in json_response["details"]
         )
 

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -296,6 +296,24 @@ def test_inference_other_task(other_task_model_id, runtime_http_server):
             f"/api/v1/{other_task_model_id}/task/other",
             json=json_input,
         )
+        assert response.status_code == 200
+        json_response = json.loads(response.content.decode(response.default_encoding))
+        assert json_response["farewell"] == "goodbye: world 42 times"
+
+
+def test_inference_other_task_throws_missing_producer_id(
+    other_task_model_id, runtime_http_server
+):
+    """Test to check we throw an error if required fields are missing"""
+    with TestClient(runtime_http_server.app) as client:
+        json_input = {
+            "inputs": {"name": "world"},
+            "parameters": {"include_producer_id": False},
+        }
+        response = client.post(
+            f"/api/v1/{other_task_model_id}/task/other",
+            json=json_input,
+        )
         assert response.status_code == 500
         json_response = json.loads(response.content.decode(response.default_encoding))
         assert json_response["detail"][0]["loc"] == ["response", "producer_id"]


### PR DESCRIPTION
fix https://github.com/caikit/caikit/issues/346

## Changes

- This PR implements `ResponseValidationError` which validates the handler's `response` and enables better error message from the response validation.

    - To test this, this PR also adds `ProducerId` as a required field in `OtherOutputType` and adds a poison pill within `other_implementation` so that we can test error conditions if a required field is not present. 

- This PR also adds other `http` tests to test for incorrect/missing fields in `request` messages.
## Useful links

- Uses [requestvalidationerror](https://fastapi.tiangolo.com/tutorial/handling-errors/#use-the-requestvalidationerror-body) documentation but for `ResponseValidationError`.

