### PR TITLE
Proactive mm init 355

### DIFF
--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -75,6 +75,19 @@ class ModelManager:
         self._initializers = {}
         self.__singleton_lock = Lock()
 
+    def initialize_components(self):
+        """Proactively initialize all configured trainer/finder/initializer
+        component instances. This is a separate call to enable explicit config.
+        """
+        # Initialize all configured components
+        mm_config = get_config().model_management
+        for trainer in mm_config.trainers:
+            self._get_trainer(trainer)
+        for finder in mm_config.finders:
+            self._get_finder(finder)
+        for initializer in mm_config.initializers:
+            self._get_initializer(initializer)
+
     ## Public ##################################################################
 
     def train(

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -24,6 +24,7 @@ import alog
 
 # Local
 from caikit.config import get_config
+from caikit.core import MODEL_MANAGER
 
 log = alog.use_channel("SERVR-BASE")
 
@@ -45,6 +46,10 @@ class RuntimeServerBase(abc.ABC):
         self.tls_config = (
             tls_config_override if tls_config_override else self.config.runtime.tls
         )
+
+        # Make sure all core model management components have been proactively
+        # initialized in the main thread before the server boots
+        MODEL_MANAGER.initialize_components()
 
     @classmethod
     def _find_port(cls, start=8888, end=None, host="127.0.0.1"):

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -24,7 +24,6 @@ import alog
 
 # Local
 from caikit.config import get_config
-from caikit.core import MODEL_MANAGER
 
 log = alog.use_channel("SERVR-BASE")
 
@@ -46,10 +45,6 @@ class RuntimeServerBase(abc.ABC):
         self.tls_config = (
             tls_config_override if tls_config_override else self.config.runtime.tls
         )
-
-        # Make sure all core model management components have been proactively
-        # initialized in the main thread before the server boots
-        MODEL_MANAGER.initialize_components()
 
     @classmethod
     def _find_port(cls, start=8888, end=None, host="127.0.0.1"):

--- a/caikit/runtime/utils/import_util.py
+++ b/caikit/runtime/utils/import_util.py
@@ -30,6 +30,7 @@ import alog
 
 # Local
 from caikit import get_config
+from caikit.core import MODEL_MANAGER
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import caikit.core
 
@@ -86,8 +87,7 @@ def get_data_model(config: aconfig.Config = None) -> UnifiedDataModel:
     Returns:
         (module): Handle to the module after dynamic wild import
     """
-    if not config:
-        config = get_config()
+    config = config or get_config()
     lib_names = clean_lib_names(config.runtime.library)
 
     # Add all caikit.interfaces.X modules
@@ -118,6 +118,14 @@ def get_data_model(config: aconfig.Config = None) -> UnifiedDataModel:
     # Get data model from lib_names
     for lib_name in base_lib_names:
         cdm = _get_cdm_from_lib(lib_name, cdm)
+
+    # Ensure that all model management components have been initialized
+    # TODO: This function has a _ton_ of side effects! We need to split it up
+    #   and isolate these side effects in appropriately named functions.
+    #   Specifically, this function is not only responsible for creating the
+    #   data model, but it performs the dynamic import of the domain library and
+    #   initializes the model management components.
+    MODEL_MANAGER.initialize_components()
 
     return cdm
 

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -569,6 +569,37 @@ def test_load_loader_finder_by_value(reset_globals):
         assert isinstance(model, SampleModule)
 
 
+def test_initialize_all_components(reset_globals):
+    """Make sure that calling initialize_components will proactively create all
+    component instances from config
+    """
+    with temp_config(
+        {
+            "model_management": {
+                "trainers": {
+                    "default": {"type": "LOCAL"},
+                    "foobar": {"type": "LOCAL"},
+                },
+                "finders": {
+                    "default": {"type": "LOCAL"},
+                    "foobar": {"type": "LOCAL"},
+                },
+                "initializers": {
+                    "default": {"type": "LOCAL"},
+                    "foobar": {"type": "LOCAL"},
+                },
+            }
+        }
+    ):
+        assert not MODEL_MANAGER._trainers
+        assert not MODEL_MANAGER._finders
+        assert not MODEL_MANAGER._initializers
+        MODEL_MANAGER.initialize_components()
+        assert set(MODEL_MANAGER._trainers.keys()) == {"default", "foobar"}
+        assert set(MODEL_MANAGER._finders.keys()) == {"default", "foobar"}
+        assert set(MODEL_MANAGER._initializers.keys()) == {"default", "foobar"}
+
+
 def test_train_by_module_class(reset_globals):
     """Make sure training can be accessed through the central train function
     with the class directly

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -64,6 +64,7 @@ from sample_lib.data_model import (
     SampleTrainingType,
 )
 from tests.conftest import random_test_id
+from tests.core.helpers import *
 from tests.fixtures import Fixtures
 from tests.runtime.conftest import register_trained_model, runtime_grpc_test_server
 import caikit.interfaces.common
@@ -181,6 +182,25 @@ def test_model_train(runtime_grpc_server):
     # Fields with defaults have expected values
     assert result.batch_size == 64
     assert result.learning_rate == 0.0015
+
+
+def test_components_preinitialized(
+    reset_globals, open_port, sample_inference_service, sample_train_service
+):
+    """Test that all model management components get pre-initialized when the
+    server is instantiated
+    """
+    assert not MODEL_MANAGER._trainers
+    assert not MODEL_MANAGER._finders
+    assert not MODEL_MANAGER._initializers
+    with runtime_grpc_test_server(
+        open_port,
+        inference_service=sample_inference_service,
+        training_service=sample_train_service,
+    ):
+        assert MODEL_MANAGER._trainers
+        assert MODEL_MANAGER._finders
+        assert MODEL_MANAGER._initializers
 
 
 def test_predict_sample_module_ok_response(


### PR DESCRIPTION
## Description

Closes #355 

This PR moves the initialization of `caikit.core.MODEL_MANAGER` components to happen proactively when a server (`grpc` or `http`) is initialized. This means that each component instance will be instantiated in the parent thread of the server rather than in a worker thread.