### PR TITLE
:sparkles: Update text gen interfaces with TGIS compatibility

### DIFF
--- a/caikit/interfaces/nlp/data_model/text_generation.py
+++ b/caikit/interfaces/nlp/data_model/text_generation.py
@@ -15,7 +15,7 @@
 
 # Standard
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 # Third Party
 import numpy as np
@@ -40,6 +40,8 @@ class FinishReason(Enum):
     CANCELLED = 3
     TIME_LIMIT = 4
     STOP_SEQUENCE = 5
+    TOKEN_LIMIT = 6
+    ERROR = 7
 
 
 @dataobject(package=NLP_PACKAGE)
@@ -67,6 +69,6 @@ class TokenStreamDetails(DataObjectBase):
 
 @dataobject(package=NLP_PACKAGE)
 class GeneratedTextStreamResult(DataObjectBase):
-    token: Annotated[GeneratedToken, FieldNumber(1)]
-    generated_text: Annotated[Optional[str], FieldNumber(2)]
+    generated_text: Annotated[str, FieldNumber(1)]
+    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(2)]
     details: Annotated[Optional[TokenStreamDetails], FieldNumber(3)]


### PR DESCRIPTION
Originally the text generation interfaces in caikit were developed here in alignment with [Huggingface TGI](https://github.com/huggingface/text-generation-inference/blob/main/docs/openapi.json) but the [TGIS streaming interfaces](https://github.com/IBM/text-generation-inference/blob/main/proto/generation.proto) predate and slightly differ from TGI, with the main focus on text.

[`caikit-nlp`](https://github.com/caikit/caikit-nlp) using [caikit-tgis-backend](https://github.com/caikit/caikit-tgis-backend) has text generation module implementations that require TGIS compatibility. The stream result here has been edited for TGIS compatibility but still keeping most TGI fields, where the original TGI `token` could be one of the TGIS-compatible `tokens`.

NOTE: The current interfaces already have more "FinishReason" enums than TGI, more in line with TGIS but missing two. This PR adds the remaining two TGIS enums so there is no gap.