### PR TITLE
Add CancelTraining to training_mangement_servicer

### DIFF
--- a/caikit/core/toolkit/destroyable_thread.py
+++ b/caikit/core/toolkit/destroyable_thread.py
@@ -87,7 +87,9 @@ class DestroyableThread(threading.Thread, Destroyable):
 
     @property
     def canceled(self) -> bool:
-        return self.destroyed and self.__started and not self.__ran
+        return self.destroyed and (
+            (self.__started and (self.threw or not self.ran)) or not self.__started
+        )
 
     @property
     def ran(self) -> bool:

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -50,7 +50,12 @@ TRAINING_MANAGEMENT_SERVICE_SPEC = {
                 "name": "GetTrainingStatus",
                 "input_type": TrainingInfoRequest.get_proto_class().DESCRIPTOR.full_name,
                 "output_type": TrainingStatusResponse.get_proto_class().DESCRIPTOR.full_name,
-            }
+            },
+            {
+                "name": "CancelTraining",
+                "input_type": TrainingInfoRequest.get_proto_class().DESCRIPTOR.full_name,
+                "output_type": TrainingStatusResponse.get_proto_class().DESCRIPTOR.full_name,
+            },
         ]
     }
 }

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -86,3 +86,10 @@ class TrainingManagementServicerImpl:
                     training_info.training_id,
                 ),
             ) from err
+        except Exception as err:
+            raise CaikitRuntimeException(
+                grpc.StatusCode.INTERNAL,
+                "Failed to cancel training id {}".format(
+                    training_info.training_id,
+                ),
+            ) from err

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -75,7 +75,7 @@ class TrainingManagementServicerImpl:
 
             return TrainingInfoResponse(
                 training_id=training_info.training_id,
-                status=model_future.get_status(),
+                status=model_future.get_info().status,
             ).to_proto()
 
         except ValueError as err:

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -73,9 +73,14 @@ class TrainingManagementServicerImpl:
 
             model_future.cancel()
 
-            return TrainingInfoResponse(
+            reasons = []
+            if model_future.get_info().errors:
+                reasons = [str(error) for error in model_future.get_info().errors]
+
+            return TrainingStatusResponse(
                 training_id=training_info.training_id,
-                status=model_future.get_info().status,
+                state=model_future.get_info().status,
+                reasons=reasons,
             ).to_proto()
 
         except ValueError as err:

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -73,6 +73,11 @@ class TrainingManagementServicerImpl:
 
             model_future.cancel()
 
+            return TrainingInfoResponse(
+                training_id=training_info.training_id,
+                status=model_future.get_status(),
+            ).to_proto()
+
         except ValueError as err:
             raise CaikitRuntimeException(
                 grpc.StatusCode.NOT_FOUND,

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -61,3 +61,23 @@ class TrainingManagementServicerImpl:
                     training_info.training_id,
                 ),
             ) from err
+
+    def CancelTraining(self, request, context):  # pylint: disable=unused-argument
+        """Cancel a training future."""
+        training_info = TrainingInfoRequest.from_proto(request)
+
+        try:
+            model_future = MODEL_MANAGER.get_model_future(
+                training_id=training_info.training_id
+            )
+
+            model_future.cancel()
+
+        except ValueError as err:
+            raise CaikitRuntimeException(
+                grpc.StatusCode.NOT_FOUND,
+                "{} not found in the list of currently running training jobs. \
+                    Did not perform cancel.".format(
+                    training_info.training_id,
+                ),
+            ) from err

--- a/tests/core/toolkit/test_destroyable_thread.py
+++ b/tests/core/toolkit/test_destroyable_thread.py
@@ -76,6 +76,7 @@ def test_threads_canceled_when_interrupt_fails():
     #   be true, though, based on reasonable timing.
     thread.join(60)
     assert not thread.is_alive()
+    assert thread.canceled
 
 
 def test_threads_can_catch_the_interrupts():

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -116,6 +116,11 @@ class SampleModule(caikit.core.ModuleBase):
     ) -> "SampleModule":
         """Sample training method that produces a trained model"""
 
+        # If requested, set an event to indicate that the training has started
+        start_event = kwargs.get("start_event")
+        if start_event is not None:
+            start_event.set()
+
         # If needed, wait for an event
         # NOTE: We need to pull this from **kwargs because it's not a valid arg
         #   for train API deduction. It's only needed for testing purposes, so

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -187,7 +187,7 @@ def test_training_raises_when_cancel_on_incorrect_id(training_management_service
     event.set()
     model_future.wait()
 
-    # cancel the training request, check that its status is now canceled
+    # cancel a training with wrong training id
     cancel_request = TrainingInfoRequest(training_id="some_random_id").to_proto()
     with pytest.raises(CaikitRuntimeException) as context:
         training_management_servicer.CancelTraining(cancel_request, context=None)

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -92,15 +92,14 @@ def test_training_cannot_cancel_on_completed_training(training_management_servic
     event.set()
     model_future.wait()
 
-    # cancel the training request, check that its status is still completed because it was completed
+    # cancel the training request, but this won't change its status as it was finished
     training_management_servicer.CancelTraining(request, context=None)
-
     response = training_management_servicer.GetTrainingStatus(request, context=None)
     assert response.status == TrainingStatus.COMPLETED.value
 
 
 def test_training_cancel_on_correct_id(training_management_servicer):
-    # Create a future and set it in the training manager
+    # Create a training future for first model with a wait event
     event_1 = threading.Event()
     model_future_1 = MODEL_MANAGER.train(
         SampleModule,
@@ -108,35 +107,31 @@ def test_training_cancel_on_correct_id(training_management_servicer):
         wait_event=event_1,
     )
 
-    event_2 = threading.Event()
+    def unblock_training_thread():
+        event_1.set()
+        model_future_1.wait()
+
+    request_1 = TrainingInfoRequest(training_id=model_future_1.id).to_proto()
+    response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
+    assert response_1.status == TrainingStatus.RUNNING.value
+
+    # Model 2 has no wait event, should proceed to complete training
     model_future_2 = MODEL_MANAGER.train(
         SampleModule,
         DataStream.from_iterable([1, 2, 3]),
-        wait_event=event_2,
     )
 
-    # send train requests, check they're not errored
+    # Cancel first training
     request_1 = TrainingInfoRequest(training_id=model_future_1.id).to_proto()
-    response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
-    assert response_1.status != TrainingStatus.ERRORED.value
-
-    request_2 = TrainingInfoRequest(training_id=model_future_2.id).to_proto()
-    response_2 = training_management_servicer.GetTrainingStatus(request_2, context=None)
-    assert response_2.status != TrainingStatus.ERRORED.value
-
-    event_1.set()
-    model_future_1.wait()
-
-    event_2.set()
-    model_future_2.wait()
-
-    # cancel the first training request, check that its status is now canceled
-    # and the status of second training request is completed
     training_management_servicer.CancelTraining(request_1, context=None)
 
     response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
     assert response_1.status == TrainingStatus.CANCELED.value
 
+    unblock = threading.Thread(target=unblock_training_thread)
+    unblock.start()
+
+    request_2 = TrainingInfoRequest(training_id=model_future_2.id).to_proto()
     response_2 = training_management_servicer.GetTrainingStatus(request_2, context=None)
     assert response_2.status == TrainingStatus.COMPLETED.value
 

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -128,9 +128,11 @@ def test_training_cancel_on_correct_id(training_management_servicer):
     response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
     assert response_1.status == TrainingStatus.CANCELED.value
 
+    # release the blocked training that is waiting to clean up
     unblock = threading.Thread(target=unblock_training_thread)
     unblock.start()
 
+    # training number 2 should still complete
     request_2 = TrainingInfoRequest(training_id=model_future_2.id).to_proto()
     response_2 = training_management_servicer.GetTrainingStatus(request_2, context=None)
     assert response_2.status == TrainingStatus.COMPLETED.value

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -84,10 +84,10 @@ def test_training_can_cancel(training_management_servicer):
         wait_event=event,
     )
 
-    # send a request, check it's running
+    # send a request, check it's not errored
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status == TrainingStatus.RUNNING.value
+    assert response.status != TrainingStatus.ERRORED.value
 
     event.set()
     model_future.wait()
@@ -115,14 +115,14 @@ def test_training_cancel_on_correct_id(training_management_servicer):
         wait_event=event_2,
     )
 
-    # send train requests, check they're running
+    # send train requests, check they're not errored
     request_1 = TrainingInfoRequest(training_id=model_future_1.id).to_proto()
     response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
-    assert response_1.status == TrainingStatus.RUNNING.value
+    assert response_1.status != TrainingStatus.ERRORED.value
 
     request_2 = TrainingInfoRequest(training_id=model_future_2.id).to_proto()
     response_2 = training_management_servicer.GetTrainingStatus(request_2, context=None)
-    assert response_2.status == TrainingStatus.RUNNING.value
+    assert response_2.status != TrainingStatus.ERRORED.value
 
     event_1.set()
     model_future_1.wait()
@@ -182,10 +182,10 @@ def test_training_raises_when_cancel_on_incorrect_id(training_management_service
         wait_event=event,
     )
 
-    # send a request, check it's running
+    # send a request, check it's not errored
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status == TrainingStatus.RUNNING.value
+    assert response.status != TrainingStatus.ERRORED.value
 
     event.set()
     model_future.wait()

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -87,7 +87,7 @@ def test_training_cannot_cancel_on_completed_training(training_management_servic
     # send a request, check it's not errored
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status != TrainingStatus.ERRORED.value
+    assert response.state != TrainingStatus.ERRORED.value
 
     event.set()
     model_future.wait()
@@ -95,7 +95,7 @@ def test_training_cannot_cancel_on_completed_training(training_management_servic
     # cancel the training request, but this won't change its status as it was finished
     training_management_servicer.CancelTraining(request, context=None)
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status == TrainingStatus.COMPLETED.value
+    assert response.state == TrainingStatus.COMPLETED.value
 
 
 def test_training_cancel_on_correct_id(training_management_servicer):
@@ -113,7 +113,7 @@ def test_training_cancel_on_correct_id(training_management_servicer):
 
     request_1 = TrainingInfoRequest(training_id=model_future_1.id).to_proto()
     response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
-    assert response_1.status == TrainingStatus.RUNNING.value
+    assert response_1.state == TrainingStatus.RUNNING.value
 
     # Model 2 has no wait event, should proceed to complete training
     model_future_2 = MODEL_MANAGER.train(
@@ -126,7 +126,7 @@ def test_training_cancel_on_correct_id(training_management_servicer):
     training_management_servicer.CancelTraining(request_1, context=None)
 
     response_1 = training_management_servicer.GetTrainingStatus(request_1, context=None)
-    assert response_1.status == TrainingStatus.CANCELED.value
+    assert response_1.state == TrainingStatus.CANCELED.value
 
     # release the blocked training that is waiting to clean up
     unblock = threading.Thread(target=unblock_training_thread)
@@ -135,7 +135,7 @@ def test_training_cancel_on_correct_id(training_management_servicer):
     # training number 2 should still complete
     request_2 = TrainingInfoRequest(training_id=model_future_2.id).to_proto()
     response_2 = training_management_servicer.GetTrainingStatus(request_2, context=None)
-    assert response_2.status == TrainingStatus.COMPLETED.value
+    assert response_2.state == TrainingStatus.COMPLETED.value
 
 
 def test_training_complete_status(training_management_servicer, training_pool):
@@ -182,7 +182,7 @@ def test_training_raises_when_cancel_on_incorrect_id(training_management_service
     # send a request, check it's not errored
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status != TrainingStatus.ERRORED.value
+    assert response.state != TrainingStatus.ERRORED.value
 
     event.set()
     model_future.wait()

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -75,7 +75,7 @@ def test_training_runs(training_management_servicer, training_pool):
     assert response.state == TrainingStatus.COMPLETED.value
 
 
-def test_training_can_cancel(training_management_servicer):
+def test_training_cannot_cancel_on_completed_training(training_management_servicer):
     # Create a future and set it in the training manager
     event = threading.Event()
     model_future = MODEL_MANAGER.train(
@@ -92,11 +92,11 @@ def test_training_can_cancel(training_management_servicer):
     event.set()
     model_future.wait()
 
-    # cancel the training request, check that its status is now canceled
+    # cancel the training request, check that its status is still completed because it was completed
     training_management_servicer.CancelTraining(request, context=None)
 
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status == TrainingStatus.CANCELED.value
+    assert response.status == TrainingStatus.COMPLETED.value
 
 
 def test_training_cancel_on_correct_id(training_management_servicer):

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -631,7 +631,7 @@ def test_train_fake_module_ok_response_with_datastream_csv_file(
 def test_train_and_succesfully_cancel_training(
     train_stub, sample_train_service, training_management_stub
 ):
-    # train a model, make sure training is running
+    # train a model, make sure training doesn't have error
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(
         jsondata=stream_type.JsonData(
@@ -657,7 +657,7 @@ def test_train_and_succesfully_cancel_training(
         )
     )
 
-    assert training_management_response.status == TrainingStatus.RUNNING.value
+    assert training_management_response.status != TrainingStatus.ERRORED.value
 
     # cancel the training
     canceled_response = training_management_stub.CancelTraining(
@@ -695,7 +695,7 @@ def test_cancel_does_not_affect_other_models(
         )
     )
 
-    assert training_management_response.status == TrainingStatus.RUNNING.value
+    assert training_management_response.status != TrainingStatus.ERRORED.value
 
     # train another model
     model_name2 = random_test_id()

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -103,7 +103,7 @@ def assert_training_successful(
             training_management_stub.GetTrainingStatus(training_info_request.to_proto())
         )
     )
-    status = training_management_response.status
+    status = training_management_response.state
     assert status == TrainingStatus.COMPLETED.value
 
 
@@ -632,7 +632,7 @@ def test_train_and_successfully_cancel_training(
     model_name = random_test_id()
     # start a training that sleeps for a long time, so I can cancel
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
-        model_name=model_name, training_data=training_data.to_proto(), sleep_time=1
+        model_name=model_name, training_data=training_data.to_proto(), sleep_time=10
     )
     train_response = train_stub.SampleTaskSampleModuleTrain(train_request)
 
@@ -644,13 +644,13 @@ def test_train_and_successfully_cancel_training(
         )
     )
     assert (
-        training_management_response.status == TrainingStatus.RUNNING.value
-    ), "Could not cancel this training within 1s"
+        training_management_response.state == TrainingStatus.RUNNING.value
+    ), "Could not cancel this training within 10s"
     # cancel the training
     canceled_response = training_management_stub.CancelTraining(
         training_info_request.to_proto()
     )
-    assert canceled_response.status == TrainingStatus.CANCELED.value
+    assert canceled_response.state == TrainingStatus.CANCELED.value
 
 
 def test_cancel_does_not_affect_other_models(
@@ -666,7 +666,7 @@ def test_cancel_does_not_affect_other_models(
     model_name = random_test_id()
     # start a training that sleeps for a long time, so I can cancel
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
-        model_name=model_name, training_data=training_data.to_proto(), sleep_time=1
+        model_name=model_name, training_data=training_data.to_proto(), sleep_time=10
     )
     train_response = train_stub.SampleTaskSampleModuleTrain(train_request)
 
@@ -686,18 +686,18 @@ def test_cancel_does_not_affect_other_models(
     # train another model
     model_name2 = random_test_id()
     train_request2 = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
-        model_name=model_name2, training_data=training_data.to_proto(), sleep_time=0.09
+        model_name=model_name2, training_data=training_data.to_proto()
     )
     train_response2 = train_stub.SampleTaskSampleModuleTrain(train_request2)
 
     # cancel the first training
     assert (
-        training_management_response.status == TrainingStatus.RUNNING.value
-    ), "Could not cancel this training within 1s"
+        training_management_response.state == TrainingStatus.RUNNING.value
+    ), "Could not cancel this training within 10s"
     canceled_response = training_management_stub.CancelTraining(
         training_info_request.to_proto()
     )
-    assert canceled_response.status == TrainingStatus.CANCELED.value
+    assert canceled_response.state == TrainingStatus.CANCELED.value
 
     # second training should be COMPLETED
     assert_training_successful(


### PR DESCRIPTION
Issue #332 

This PR adds:
- another rpc to `service_factory.py`, TRAINING_MANAGEMENT_SERVICE_SPEC to include a new rpc for cancelling a training. The rpc accepts a training id as input, and returns the TrainingStatus of that training as output after canceling the model future.
- implements the `CancelTraining` method in `training_management_servicer.py`.
- Tests