### PR TITLE
Server shutdown with sync

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -92,9 +92,6 @@ runtime:
         client:
             cert: ""
 
-    # Service exposure options
-    unix_socket_path: /tmp/mmesh/grpc.sock
-
     # Configuration for the grpc server
     grpc:
         enabled: true

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -92,6 +92,9 @@ runtime:
         client:
             cert: ""
 
+    # Service exposure options
+    unix_socket_path: /tmp/mmesh/grpc.sock
+
     # Configuration for the grpc server
     grpc:
         enabled: true
@@ -104,9 +107,6 @@ runtime:
         server_shutdown_grace_period_seconds: 45
         # Listen on a unix socket (model mesh feature)
         unix_socket_path: /tmp/mmesh/grpc.sock
-    # Service exposure options
-    port: 8085
-    unix_socket_path: /tmp/mmesh/grpc.sock
 
     # Configuration for the http server
     http:

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -246,6 +246,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
             grace_period_seconds (Union[float, int]): Grace period for service shutdown.
                 Defaults to application config
         """
+        log.debug("Shutting down grpc server")
         if grace_period_seconds is None:
             grace_period_seconds = (
                 self.config.runtime.grpc.server_shutdown_grace_period_seconds
@@ -254,6 +255,8 @@ class RuntimeGRPCServer(RuntimeServerBase):
         # Ensure we flush out any remaining billing metrics and stop metering
         if self.config.runtime.metering.enabled:
             self._global_predict_servicer.stop_metering()
+        # Shut down the model manager's model polling if enabled
+        self._shut_down_model_manager()
 
     def render_protos(self, proto_out_dir: str) -> None:
         """Renders all the necessary protos for this service into a directory

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -81,7 +81,6 @@ class RuntimeGRPCServer(RuntimeServerBase):
         if handle_terminations:
             signal.signal(signal.SIGINT, self.interrupt)
             signal.signal(signal.SIGTERM, self.interrupt)
-        self.port = self.config.runtime.port
 
         # Initialize basic server
         # py_grpc_prometheus.server_metrics.

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -299,10 +299,16 @@ class RuntimeGRPCServer(RuntimeServerBase):
 def main(blocking: bool = True):
     # Configure using the log level and formatter type specified in config.
     caikit.core.toolkit.logging.configure()
+    log.debug("Starting up caikit.runtime.grpc_server")
 
     # Start serving Prometheus metrics
     caikit_config = get_config()
-    start_http_server(caikit_config.runtime.metrics.port)
+    if caikit_config.runtime.metrics.enabled:
+        log.info(
+            "Serving prometheus metrics on port %s", caikit_config.runtime.metrics.port
+        )
+        with alog.ContextTimer(log.info, "Booted metrics server in "):
+            start_http_server(caikit_config.runtime.metrics.port)
 
     # Enable signal handling
     handle_terminations = True

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -92,6 +92,9 @@ GRPC_CODE_TO_HTTP = {
 REQUIRED_INPUTS_KEY = "inputs"
 OPTIONAL_INPUTS_KEY = "parameters"
 
+# Endpoint to use for health checks
+HEALTH_ENDPOINT = "/health"
+
 ## RuntimeHTTPServer ###########################################################
 
 
@@ -121,6 +124,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
         # self.global_train_servicer = GlobalTrainServicer(train_service)
 
         self.package_name = inference_service.descriptor.full_name.rsplit(".", 1)[0]
+
+        # Add the health endpoint
+        self.app.get(HEALTH_ENDPOINT)(self._health_check)
 
         # Bind all routes to the server
         self._bind_routes(inference_service)
@@ -534,6 +540,10 @@ class RuntimeHTTPServer(RuntimeServerBase):
         )
         PYDANTIC_REGISTRY[dm_class] = pydantic_model
         return pydantic_model
+
+    @staticmethod
+    def _health_check():
+        log.debug4("Server healthy")
 
 
 ## Main ########################################################################

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -141,9 +141,13 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
 
     def shut_down(self):
         """Shut down cache purging"""
+        log.info("Shutting down runtime ModelManager")
+        self._enable_lazy_load_poll = False
         timer = getattr(self, "_lazy_sync_timer", None)
         if timer is not None:
-            timer.cancel()
+            with alog.ContextTimer(log.debug, "Done shutting down poll in "):
+                timer.cancel()
+                timer.join()
 
     ## Model Management ##
 
@@ -247,8 +251,15 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
                     self._lazy_load_poll_period_seconds,
                 )
             if self._lazy_sync_timer is not None and self._lazy_sync_timer.is_alive():
-                log.debug2("Canceling live timer")
+                log.debug3("Canceling live timer")
                 self._lazy_sync_timer.cancel()
+            log.debug3(
+                "Starting next poll timer for %ss", self._lazy_load_poll_period_seconds
+            )
+            log.debug4(
+                "All open threads: %s",
+                [thread.name for thread in threading.enumerate()],
+            )
             self._lazy_sync_timer = threading.Timer(
                 self._lazy_load_poll_period_seconds, self.sync_local_models
             )

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -141,13 +141,11 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
 
     def shut_down(self):
         """Shut down cache purging"""
-        log.info("Shutting down runtime ModelManager")
         self._enable_lazy_load_poll = False
         timer = getattr(self, "_lazy_sync_timer", None)
         if timer is not None:
-            with alog.ContextTimer(log.debug, "Done shutting down poll in "):
-                timer.cancel()
-                timer.join()
+            timer.cancel()
+            timer.join()
 
     ## Model Management ##
 

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -145,7 +145,8 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
         timer = getattr(self, "_lazy_sync_timer", None)
         if timer is not None:
             timer.cancel()
-            timer.join()
+            if timer.is_alive():
+                timer.join()
 
     ## Model Management ##
 

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -24,6 +24,7 @@ import alog
 
 # Local
 from caikit.config import get_config
+from caikit.runtime.model_management.model_manager import ModelManager
 
 log = alog.use_channel("SERVR-BASE")
 
@@ -45,6 +46,7 @@ class RuntimeServerBase(abc.ABC):
         self.tls_config = (
             tls_config_override if tls_config_override else self.config.runtime.tls
         )
+        log.debug4("Full caikit config: %s", get_config())
 
     @classmethod
     def _find_port(cls, start=8888, end=None, host="127.0.0.1"):
@@ -74,6 +76,10 @@ class RuntimeServerBase(abc.ABC):
 
                 # port is open
                 return start
+
+    def _shut_down_model_manager(self):
+        """Shared utility for shutting down the model manager"""
+        ModelManager.get_instance().shut_down()
 
     @abc.abstractmethod
     def start(self, blocking: bool = True):

--- a/tests/fixtures/config/config.yml
+++ b/tests/fixtures/config/config.yml
@@ -1,5 +1,7 @@
 # Config for tests
 runtime:
+    metrics:
+        enabled: false
     metering:
         # Switch on metering by default
         enabled: true

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -122,7 +122,7 @@ def runtime_grpc_test_server(open_port, *args, **kwargs):
                 "runtime": {
                     "metering": {"log_dir": temp_log_dir},
                     "training": {"output_dir": temp_save_dir},
-                    "port": open_port,
+                    "grpc": {"port": open_port},
                 }
             },
             "merge",

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -277,7 +277,7 @@ class ModuleSubproc:
         self._cmd = shlex.split(cmd)
 
         # Set up the environment
-        self._env = copy.copy(os.environ)
+        self._env = copy.deepcopy(os.environ)
         self._env.update(env_vars)
         self._env["PYTHONPATH"] = ":".join(sys.path)
 

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -3,12 +3,17 @@ This sets up global test configs when pytest starts
 """
 
 # Standard
-from concurrent.futures import Future
 from contextlib import contextmanager
+from types import ModuleType
 from typing import Type, Union
+import copy
 import os
+import shlex
 import socket
+import subprocess
+import sys
 import tempfile
+import threading
 import time
 
 # Third Party
@@ -258,6 +263,49 @@ def register_trained_model(
     if isinstance(servicer, RuntimeGRPCServer):
         servicer = servicer._global_predict_servicer
     servicer._model_manager.loaded_models[model_id] = loaded_model
+
+
+class ModuleSubproc:
+    def __init__(
+        self, module_to_run: str, *args, kill_timeout: float = 10.0, **env_vars
+    ):
+        """Run the given python as a subprocess and kill it after the given timeout"""
+        # Set up the command
+        cmd = f"{sys.executable} -m {module_to_run}"
+        for arg in args:
+            cmd += f" {arg}"
+        self._cmd = shlex.split(cmd)
+
+        # Set up the environment
+        self._env = copy.copy(os.environ)
+        self._env.update(env_vars)
+        self._env["PYTHONPATH"] = ":".join(sys.path)
+
+        # Start the process
+        self.proc = None
+        self._killed = False
+
+        # Start the timer that will kill the process
+        self._kill_timer = threading.Timer(kill_timeout, self._kill_proc)
+
+    @property
+    def killed(self):
+        return self._killed
+
+    def _kill_proc(self):
+        self._killed = True
+        if self.proc is not None:
+            self.proc.kill()
+
+    def __enter__(self):
+        self.proc = subprocess.Popen(self._cmd, env=self._env)
+        self._kill_timer.start()
+        return self.proc
+
+    def __exit__(self, *_):
+        self.proc.wait()
+        self._kill_timer.cancel()
+        self._kill_timer.join()
 
 
 # IMPLEMENTATION DETAILS ############################################################

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -4,9 +4,7 @@ This sets up global test configs when pytest starts
 
 # Standard
 from contextlib import contextmanager
-from types import ModuleType
 from typing import Type, Union
-import copy
 import os
 import shlex
 import socket
@@ -277,8 +275,7 @@ class ModuleSubproc:
         self._cmd = shlex.split(cmd)
 
         # Set up the environment
-        self._env = copy.deepcopy(os.environ)
-        self._env.update(env_vars)
+        self._env = {**os.environ, **env_vars}
         self._env["PYTHONPATH"] = ":".join(sys.path)
 
         # Start the process

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -1069,6 +1069,7 @@ def test_grpc_sever_shutdown_with_model_poll(open_port):
             RUNTIME_LOCAL_MODELS_DIR=workdir,
             RUNTIME_LAZY_LOAD_LOCAL_MODELS="true",
             RUNTIME_LAZY_LOAD_POLL_PERIOD_SECONDS="0.1",
+            RUNTIME_METRICS_ENABLED="false",
         )
         with server_proc as proc:
 


### PR DESCRIPTION
## Description

Closes #364

This PR updates the shutdown logic in `grpc_server` and `http_server` to correctly shut down the runtime Model Manager's poll timer for lazy model loading. While I was working on this, I discovered several other bugs that needed fixing:

1. Runtime was using `runtime.port` instead of `runtime.grpc.port`
2. The prometheus metrics were _always_ booting up in the `grpc_server`'s `main()`, regardless of `runtime.metrics.enabled`