### PR TITLE
🐛  No canceled after completed

### DIFF
--- a/caikit/core/toolkit/destroyable_thread.py
+++ b/caikit/core/toolkit/destroyable_thread.py
@@ -87,7 +87,7 @@ class DestroyableThread(threading.Thread, Destroyable):
 
     @property
     def canceled(self) -> bool:
-        return self.destroyed and self.__started
+        return self.destroyed and self.__started and not self.__ran
 
     @property
     def ran(self) -> bool:

--- a/tests/core/model_management/test_local_model_trainer.py
+++ b/tests/core/model_management/test_local_model_trainer.py
@@ -20,7 +20,6 @@ import multiprocessing
 import os
 import tempfile
 import threading
-import time
 
 # Third Party
 import pytest

--- a/tests/core/toolkit/test_destroyable_process.py
+++ b/tests/core/toolkit/test_destroyable_process.py
@@ -54,6 +54,15 @@ def test_processes_can_return_results():
     assert not proc.threw
 
 
+def test_process_not_canceled_after_success():
+    proc = DestroyableProcess(lambda: None)
+    proc.start()
+    proc.join()
+    assert not proc.canceled
+    proc.destroy()
+    assert not proc.canceled
+
+
 def test_processes_can_be_set_to_not_return_results():
     expected = "test-any-result"
     proc = DestroyableProcess(lambda: expected, return_result=False)

--- a/tests/core/toolkit/test_destroyable_thread.py
+++ b/tests/core/toolkit/test_destroyable_thread.py
@@ -113,6 +113,15 @@ def test_threads_can_return_results():
     assert expected == thread.get_or_throw()
 
 
+def test_threads_not_canceled_after_success():
+    thread = DestroyableThread(lambda: None)
+    thread.start()
+    thread.join()
+    assert not thread.canceled
+    thread.destroy()
+    assert not thread.canceled
+
+
 def test_threads_can_throw():
     expected = ValueError("test-any-error")
 


### PR DESCRIPTION
Supports #332 

This PR fixes the bug where a training run in a `DestroyableThread` can move from `COMPLETED` -> `CANCELED`