### PR TITLE
:recycle: Move training info out of interfaces

### DIFF
--- a/caikit/core/data_model/__init__.py
+++ b/caikit/core/data_model/__init__.py
@@ -29,4 +29,4 @@ from .enums import *
 from .producer import PACKAGE_COMMON, ProducerId
 from .streams import data_stream
 from .streams.data_stream import *
-from .training_status import TrainingInfo, TrainingStatus
+from .training_status import TrainingStatus

--- a/caikit/core/data_model/training_status.py
+++ b/caikit/core/data_model/training_status.py
@@ -17,10 +17,6 @@ Common data model enum used for reporting training status
 
 # Standard
 from enum import Enum
-from typing import List
-
-# First Party
-from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
 
 # Local
 from .dataobject import DataObjectBase, dataobject
@@ -42,12 +38,3 @@ class TrainingStatus(Enum):
             self.__class__.CANCELED,
             self.__class__.ERRORED,
         ]
-
-
-@dataobject(PACKAGE_COMMON)
-class TrainingInfo(DataObjectBase):
-    errors: Annotated[List[str], FieldNumber(1)]
-    # TODO: Add elements to conveying other useful information
-    # regarding training status, such as iterations progressed
-    # evaluation so far, etc.
-    status: Annotated[TrainingStatus, FieldNumber(2)]

--- a/caikit/core/data_model/training_status.py
+++ b/caikit/core/data_model/training_status.py
@@ -19,7 +19,7 @@ Common data model enum used for reporting training status
 from enum import Enum
 
 # Local
-from .dataobject import DataObjectBase, dataobject
+from .dataobject import dataobject
 from .package import PACKAGE_COMMON
 
 

--- a/caikit/core/model_management/__init__.py
+++ b/caikit/core/model_management/__init__.py
@@ -27,4 +27,4 @@ from .factories import (
 )
 from .model_finder_base import ModelFinderBase
 from .model_initializer_base import ModelInitializerBase
-from .model_trainer_base import ModelTrainerBase
+from .model_trainer_base import ModelTrainerBase, TrainingInfo

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -29,12 +29,12 @@ import aconfig
 import alog
 
 # Local
-from ..data_model import TrainingInfo, TrainingStatus
+from ..data_model import TrainingStatus
 from ..modules import ModuleBase
 from ..toolkit.destroyable_process import DestroyableProcess
 from ..toolkit.destroyable_thread import DestroyableThread
 from ..toolkit.errors import error_handler
-from .model_trainer_base import ModelTrainerBase
+from .model_trainer_base import ModelTrainerBase, TrainingInfo
 import caikit
 
 log = alog.use_channel("LOC-TRNR")
@@ -145,7 +145,7 @@ class LocalModelTrainer(ModelTrainerBase):
             # The worker threw outside of a cancellation process
             if self._worker.threw:
                 return TrainingInfo(
-                    status=TrainingStatus.ERRORED, errors=[str(self._worker.error)]
+                    status=TrainingStatus.ERRORED, errors=[self._worker.error]
                 )
 
             # The worker completed its work without being canceled or raising

--- a/caikit/core/model_management/model_trainer_base.py
+++ b/caikit/core/model_management/model_trainer_base.py
@@ -26,7 +26,7 @@ model_management:
 """
 
 # Standard
-from typing import Optional, Type
+from typing import List, Optional, Type
 import abc
 import dataclasses
 import os
@@ -41,7 +41,7 @@ from ..toolkit.reversible_hasher import ReversibleHasher
 @dataclasses.dataclass
 class TrainingInfo:
     status: TrainingStatus
-    errors: Optional[Exception] = None
+    errors: Optional[List[Exception]] = None
 
 
 class ModelTrainerBase(FactoryConstructible):

--- a/caikit/core/model_management/model_trainer_base.py
+++ b/caikit/core/model_management/model_trainer_base.py
@@ -28,13 +28,20 @@ model_management:
 # Standard
 from typing import Optional, Type
 import abc
+import dataclasses
 import os
 
 # Local
-from ..data_model import TrainingInfo
+from ..data_model import TrainingStatus
 from ..modules import ModuleBase
 from ..toolkit.factory import FactoryConstructible
 from ..toolkit.reversible_hasher import ReversibleHasher
+
+
+@dataclasses.dataclass
+class TrainingInfo:
+    status: TrainingStatus
+    errors: Optional[Exception] = None
 
 
 class ModelTrainerBase(FactoryConstructible):

--- a/caikit/interfaces/runtime/data_model/__init__.py
+++ b/caikit/interfaces/runtime/data_model/__init__.py
@@ -17,7 +17,7 @@ from . import training_management
 from .training_management import (
     ModelPointer,
     TrainingInfoRequest,
-    TrainingInfoResponse,
     TrainingJob,
     TrainingStatus,
+    TrainingStatusResponse,
 )

--- a/caikit/interfaces/runtime/data_model/training_management.py
+++ b/caikit/interfaces/runtime/data_model/training_management.py
@@ -50,9 +50,9 @@ class ModelPointer(DataObjectBase):
 
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
 @dataobject(RUNTIME_PACKAGE)
-class TrainingInfoResponse(DataObjectBase):
+class TrainingStatusResponse(DataObjectBase):
     training_id: Annotated[str, FieldNumber(1)]
-    status: Annotated[TrainingStatus, FieldNumber(2)]
+    state: Annotated[TrainingStatus, FieldNumber(2)]
     submission_timestamp: Annotated[datetime, FieldNumber(3)]
     completion_timestamp: Annotated[datetime, FieldNumber(4)]
     reasons: Annotated[List[str], FieldNumber(5)]

--- a/caikit/interfaces/runtime/data_model/training_management.py
+++ b/caikit/interfaces/runtime/data_model/training_management.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Standard
+from datetime import datetime
+from typing import List
+
 # First Party
+from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
 import alog
 
 # Local
@@ -46,8 +51,8 @@ class ModelPointer(DataObjectBase):
 @work_in_progress(action=Action.WARNING, category=WipCategory.BETA)
 @dataobject(RUNTIME_PACKAGE)
 class TrainingInfoResponse(DataObjectBase):
-    training_id: str
-    status: TrainingStatus
-    submission_timestamp: str
-    completion_timestamp: str
-    error_code: str
+    training_id: Annotated[str, FieldNumber(1)]
+    status: Annotated[TrainingStatus, FieldNumber(2)]
+    submission_timestamp: Annotated[datetime, FieldNumber(3)]
+    completion_timestamp: Annotated[datetime, FieldNumber(4)]
+    reasons: Annotated[List[str], FieldNumber(5)]

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -33,7 +33,7 @@ from caikit import get_config
 from caikit.core import ModuleBase
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,
-    TrainingInfoResponse,
+    TrainingStatusResponse,
 )
 from caikit.runtime import service_generation
 from caikit.runtime.service_generation.rpcs import CaikitRPCBase, snake_to_upper_camel
@@ -49,7 +49,7 @@ TRAINING_MANAGEMENT_SERVICE_SPEC = {
             {
                 "name": "GetTrainingStatus",
                 "input_type": TrainingInfoRequest.get_proto_class().DESCRIPTOR.full_name,
-                "output_type": TrainingInfoResponse.get_proto_class().DESCRIPTOR.full_name,
+                "output_type": TrainingStatusResponse.get_proto_class().DESCRIPTOR.full_name,
             }
         ]
     }

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -262,7 +262,7 @@ class GlobalTrainServicer:
                     )
                     if isinstance(model_future, LocalModelTrainer.LocalModelFuture):
                         raise model_future._worker.error
-                    raise RuntimeError(training_info.errors[0])
+                    raise training_info.errors[0]
 
         # return TrainingJob object
         return TrainingJob(

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -29,7 +29,6 @@ import alog
 from caikit import get_config
 from caikit.core import MODEL_MANAGER, ModuleBase
 from caikit.core.data_model import DataBase
-from caikit.core.model_management.local_model_trainer import LocalModelTrainer
 from caikit.interfaces.runtime.data_model import TrainingJob
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.service_factory import ServicePackage
@@ -258,10 +257,8 @@ class GlobalTrainServicer:
                         "Training %s failed with error: %s. "
                         "Re-raising exception for synchronous response",
                         model_future.id,
-                        training_info.errors[0],
+                        str(training_info.errors[0]),
                     )
-                    if isinstance(model_future, LocalModelTrainer.LocalModelFuture):
-                        raise model_future._worker.error
                     raise training_info.errors[0]
 
         # return TrainingJob object

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -48,6 +48,7 @@ class TrainingManagementServicerImpl:
             return TrainingInfoResponse(
                 training_id=training_info.training_id,
                 status=model_future.get_info().status,
+                reasons=[str(error) for error in model_future.get_info().errors],
             ).to_proto()
         except ValueError as err:
             raise CaikitRuntimeException(

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -45,10 +45,14 @@ class TrainingManagementServicerImpl:
                 training_id=training_info.training_id
             )
 
+            reasons = []
+            if model_future.get_info().errors:
+                reasons = [str(error) for error in model_future.get_info().errors]
+
             return TrainingInfoResponse(
                 training_id=training_info.training_id,
                 status=model_future.get_info().status,
-                reasons=[str(error) for error in model_future.get_info().errors],
+                reasons=reasons,
             ).to_proto()
         except ValueError as err:
             raise CaikitRuntimeException(

--- a/caikit/runtime/servicers/training_management_servicer.py
+++ b/caikit/runtime/servicers/training_management_servicer.py
@@ -25,7 +25,7 @@ import alog
 from caikit.core import MODEL_MANAGER
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,
-    TrainingInfoResponse,
+    TrainingStatusResponse,
 )
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
@@ -49,9 +49,9 @@ class TrainingManagementServicerImpl:
             if model_future.get_info().errors:
                 reasons = [str(error) for error in model_future.get_info().errors]
 
-            return TrainingInfoResponse(
+            return TrainingStatusResponse(
                 training_id=training_info.training_id,
-                status=model_future.get_info().status,
+                state=model_future.get_info().status,
                 reasons=reasons,
             ).to_proto()
         except ValueError as err:

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -21,10 +21,11 @@ import pytest
 
 # Local
 from caikit.core import MODEL_MANAGER
-from caikit.core.data_model import TrainingInfo, TrainingStatus
+from caikit.core.data_model import TrainingStatus
 from caikit.core.model_management import (
     ModelInitializerBase,
     ModelTrainerBase,
+    TrainingInfo,
     model_initializer_factory,
     model_trainer_factory,
 )

--- a/tests/core/model_management/test_local_model_trainer.py
+++ b/tests/core/model_management/test_local_model_trainer.py
@@ -220,4 +220,6 @@ def test_get_into_return_error(trainer_type_cfg):
     assert model_future.get_info().status == TrainingStatus.ERRORED
     assert model_future.get_info().status.is_terminal
     assert isinstance(model_future.get_info().errors, list)
-    assert model_future.get_info().errors[0] == "Batch size of 999 is not allowed!"
+    assert model_future.get_info().errors[0] == ValueError(
+        "Batch size of 999 is not allowed!"
+    )

--- a/tests/core/model_management/test_local_model_trainer.py
+++ b/tests/core/model_management/test_local_model_trainer.py
@@ -220,6 +220,5 @@ def test_get_into_return_error(trainer_type_cfg):
     assert model_future.get_info().status == TrainingStatus.ERRORED
     assert model_future.get_info().status.is_terminal
     assert isinstance(model_future.get_info().errors, list)
-    assert model_future.get_info().errors[0] == ValueError(
-        "Batch size of 999 is not allowed!"
-    )
+    assert isinstance(model_future.get_info().errors[0], ValueError)
+    assert str(model_future.get_info().errors[0]) == "Batch size of 999 is not allowed!"

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -338,7 +338,7 @@ def test_global_train_Edge_Case_Widget_should_raise_when_error_surfaces_from_mod
     future_info = MODEL_MANAGER.get_model_future(
         training_response.training_id
     ).get_info()
-    assert f"Batch size of 999 is not allowed!" in future_info.errors[0]
+    assert f"Batch size of 999 is not allowed!" in str(future_info.errors[0])
 
 
 def test_global_train_returns_exit_code_with_oom(
@@ -366,7 +366,7 @@ def test_global_train_returns_exit_code_with_oom(
         future_info = MODEL_MANAGER.get_model_future(
             training_response.training_id
         ).get_info()
-        assert f"Training process died with OOM error!" in future_info.errors[0]
+        assert f"Training process died with OOM error!" in str(future_info.errors[0])
 
 
 #####################################################################

--- a/tests/runtime/servicers/test_training_management_servicer.py
+++ b/tests/runtime/servicers/test_training_management_servicer.py
@@ -64,7 +64,7 @@ def test_training_runs(training_management_servicer, training_pool):
     # send a request, check it's running
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status == TrainingStatus.RUNNING.value
+    assert response.state == TrainingStatus.RUNNING.value
 
     event.set()
     model_future.wait()
@@ -72,7 +72,7 @@ def test_training_runs(training_management_servicer, training_pool):
     # Ensure it's now done
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
-    assert response.status == TrainingStatus.COMPLETED.value
+    assert response.state == TrainingStatus.COMPLETED.value
 
 
 def test_training_complete_status(training_management_servicer, training_pool):
@@ -90,8 +90,8 @@ def test_training_complete_status(training_management_servicer, training_pool):
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
 
-    assert re.match("<class '.*TrainingInfoResponse'>", str(type(response)))
-    assert response.status == TrainingStatus.COMPLETED.value
+    assert re.match("<class '.*TrainingStatusResponse'>", str(type(response)))
+    assert response.state == TrainingStatus.COMPLETED.value
 
 
 def test_training_status_incorrect_id(training_management_servicer):
@@ -119,4 +119,4 @@ def test_training_fails(training_management_servicer, training_pool):
     request = TrainingInfoRequest(training_id=model_future.id).to_proto()
     response = training_management_servicer.GetTrainingStatus(request, context=None)
 
-    assert response.status == TrainingStatus.ERRORED.value
+    assert response.state == TrainingStatus.ERRORED.value

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -45,9 +45,9 @@ from caikit.core import MODEL_MANAGER
 from caikit.core.data_model.base import DataBase
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,
-    TrainingInfoResponse,
     TrainingJob,
     TrainingStatus,
+    TrainingStatusResponse,
 )
 from caikit.runtime.grpc_server import RuntimeGRPCServer
 from caikit.runtime.model_management.model_manager import ModelManager
@@ -101,14 +101,14 @@ def is_good_train_response(
         training_info_request = TrainingInfoRequest(
             training_id=actual_response.training_id
         )
-        training_management_response: TrainingInfoResponse = (
-            TrainingInfoResponse.from_proto(
+        training_management_response: TrainingStatusResponse = (
+            TrainingStatusResponse.from_proto(
                 training_management_stub.GetTrainingStatus(
                     training_info_request.to_proto()
                 )
             )
         )
-        status = training_management_response.status
+        status = training_management_response.state
         assert status != TrainingStatus.ERRORED.value
         i += 1
         assert i < 100, "Waited too long for training to complete"
@@ -173,10 +173,10 @@ def test_model_train(runtime_grpc_server):
     )
 
     # MT training is sync, so it should be COMPLETE immediately
-    response: TrainingInfoResponse = TrainingInfoResponse.from_proto(
+    response: TrainingStatusResponse = TrainingStatusResponse.from_proto(
         training_management_stub.GetTrainingStatus(training_info_request)
     )
-    assert response.status == TrainingStatus.COMPLETED.value
+    assert response.state == TrainingStatus.COMPLETED.value
 
     # Make sure we wait for training to finish
     result = MODEL_MANAGER.get_model_future(response.training_id).load()

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -45,12 +45,12 @@ import sample_lib
 def test_servicer_util_validate_caikit_library_class_exists_returns_caikit_class():
     """Test that validate_caikit_library_class_exists returns a caikit class object"""
     validated_class = validate_caikit_library_class_exists(
-        get_data_model(), "TrainingInfoResponse"
+        get_data_model(), "TrainingStatusResponse"
     )
 
     assert issubclass(
         validated_class,
-        caikit.interfaces.runtime.data_model.training_management.TrainingInfoResponse,
+        caikit.interfaces.runtime.data_model.training_management.TrainingStatusResponse,
     )
 
     """


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
1.  Move `TrainingInfo` down to `caikit.core` as part of the ModelTrainer / ModelFuture api
2. Make trainers return exception instead of returning error strings

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
