### PR TITLE
:recycle: Only find open ports on tests

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -119,9 +119,6 @@ runtime:
         enabled: true
         port: 8086
 
-    # Use arbitrary available ports if the specified ones aren't free
-    find_available_ports: false
-
     # Whether or not to abort work on client cancellation
     use_abortable_threads: true
 

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -16,7 +16,6 @@
 # Standard
 from typing import Optional
 import abc
-import socket
 
 # First Party
 import aconfig
@@ -34,48 +33,11 @@ class RuntimeServerBase(abc.ABC):
 
     def __init__(self, base_port: int, tls_config_override: Optional[aconfig.Config]):
         self.config = get_config()
-        self.port = (
-            self._find_port(base_port)
-            if self.config.runtime.find_available_ports
-            else base_port
-        )
-        if self.port != base_port:
-            log.warning(
-                "Port %d was in use, had to find another! %d", base_port, self.port
-            )
+        self.port = base_port
         self.tls_config = (
             tls_config_override if tls_config_override else self.config.runtime.tls
         )
         log.debug4("Full caikit config: %s", get_config())
-
-    @classmethod
-    def _find_port(cls, start=8888, end=None, host="127.0.0.1"):
-        """Function to find an available port in a given range
-        Args:
-            start: int
-                Starting number for port search (inclusive)
-                Default: 8888
-            end: Optional[int]
-                End number for port search (exclusive)
-                Default: start + 1000
-            host: str
-                Host name or ip address to search on
-                Default: localhost
-        Returns:
-            int
-                Available port
-        """
-        end = start + 1000 if end is None else end
-        if start < end:
-            with socket.socket() as soc:
-                # soc.connect_ex returns 0 if connection is successful and thus
-                # indicating port is available
-                if soc.connect_ex((host, start)) == 0:
-                    # port is in use, thus connection to it is successful
-                    return cls._find_port(start + 1, end, host)
-
-                # port is open
-                return start
 
     def _shut_down_model_manager(self):
         """Shared utility for shutting down the model manager"""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

`find_available_ports` cleanup (round 2) for #343 in line with the changes made in PR #302 

As described, the base runtime server should not have a private method to find open ports. This should only be done for unit tests, where an `open_port` fixture exists.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
