### PR TITLE
♻️ refactor init for http (see #389 instead)

### DIFF
--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -20,6 +20,7 @@ import sys
 # Local
 from ..core.data_model import render_dataobject_protos
 from .service_factory import ServicePackageFactory
+from caikit.config.config import get_config
 import caikit
 
 
@@ -78,5 +79,7 @@ if __name__ == "__main__":
     # Set up logging so users can set LOG_LEVEL etc
     caikit.core.toolkit.logging.configure()
 
-    dump_grpc_services(out_dir)
-    dump_http_services(out_dir)
+    if get_config().runtime.grpc.enabled:
+        dump_grpc_services(out_dir)
+    if get_config().runtime.http.enabled:
+        dump_http_services(out_dir)

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -55,7 +55,14 @@ def dump_http_services(output_dir: str):
         RuntimeHTTPServer,
     )
 
-    server = RuntimeHTTPServer()
+    inf_svc = ServicePackageFactory.get_service_package(
+        ServicePackageFactory.ServiceType.INFERENCE,
+    )
+    train_svc = ServicePackageFactory.get_service_package(
+        ServicePackageFactory.ServiceType.TRAINING,
+    )
+
+    server = RuntimeHTTPServer(inference_service=inf_svc, training_service=train_svc)
     with TestClient(server.app) as client:
         response = client.get("/openapi.json")
         response.raise_for_status()

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -66,7 +66,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
     def __init__(
         self,
         inference_service: ServicePackage,
-        training_service: Optional[ServicePackage],
+        training_service: Optional[ServicePackage] = None,
         tls_config_override: Optional[aconfig.Config] = None,
         handle_terminations: bool = False,
     ):

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -557,15 +557,29 @@ class RuntimeHTTPServer(RuntimeServerBase):
 
 
 def main():
+
     caikit.core.toolkit.logging.configure()
+    log.debug("Starting up caikit.runtime.http_server")
 
     # This code will live in caikt/runtime/__main__.py eventually
-    inference_service = ServicePackageFactory().get_service_package(
+    # pylint: disable=duplicate-code
+
+    # We should always be able to stand up an inference service
+    inference_service: ServicePackage = ServicePackageFactory.get_service_package(
         ServicePackageFactory.ServiceType.INFERENCE,
     )
-    training_service = ServicePackageFactory().get_service_package(
-        ServicePackageFactory.ServiceType.TRAINING,
-    )
+
+    # But maybe not always a training service
+    try:
+        training_service: Optional[
+            ServicePackage
+        ] = ServicePackageFactory.get_service_package(
+            ServicePackageFactory.ServiceType.TRAINING,
+        )
+    except CaikitRuntimeException as e:
+        log.warning("Cannot stand up training service, disabling training: %s", e)
+        training_service = None
+
     server = RuntimeHTTPServer(
         inference_service=inference_service, training_service=training_service
     )

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -182,7 +182,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
         self._uvicorn_server_thread = None
 
     def __del__(self):
-        if get_config().runtime.metering.enabled:
+        if get_config() and get_config().runtime.metering.enabled:
             self.global_predict_servicer.stop_metering()
 
     def start(self, blocking: bool = True):

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -110,7 +110,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
         self,
         inference_service: ServicePackage,
         #  # pylint: disable=unused-argument
-        training_service: Optional[ServicePackage],
+        training_service: Optional[ServicePackage] = None,
         tls_config_override: Optional[aconfig.Config] = None,
     ):
         super().__init__(get_config().runtime.http.port, tls_config_override)
@@ -180,6 +180,10 @@ class RuntimeHTTPServer(RuntimeServerBase):
 
         # Placeholder for thread when running without blocking
         self._uvicorn_server_thread = None
+
+    def __del__(self):
+        if get_config().runtime.metering.enabled:
+            self.global_predict_servicer.stop_metering()
 
     def start(self, blocking: bool = True):
         """Boot the http server. Can be non-blocking, or block until shutdown

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -95,8 +95,10 @@ class GlobalPredictServicer:
         inference_service: ServicePackage,
         use_abortable_threads: bool = get_config().runtime.use_abortable_threads,
     ):
+        self._started_metering = False
         self._model_manager = ModelManager.get_instance()
         if get_config().runtime.metering.enabled:
+            self._started_metering = True
             self.rpc_meter = RPCMeter()
             log.info(
                 "<RUN76773775I>",
@@ -267,9 +269,10 @@ class GlobalPredictServicer:
             return response
 
     def stop_metering(self):
-        if get_config().runtime.metering.enabled:
+        if get_config().runtime.metering.enabled and self._started_metering:
             self.rpc_meter.flush_metrics()
             self.rpc_meter.end_writer_thread()
+            self._started_metering = False
 
     ## Implementation Details ##################################################
 

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -58,6 +58,15 @@ def session_scoped_open_port():
     return _open_port()
 
 
+@pytest.fixture(scope="session")
+def http_session_scoped_open_port():
+    """Get an open port on localhost
+    Returns:
+        int: Available port
+    """
+    return _open_port()
+
+
 def _open_port():
     # TODO: This has obvious problems where the port returned for use by a test is not immediately
     # put into use, so parallel tests could attempt to use the same port.
@@ -177,10 +186,10 @@ def runtime_http_test_server(open_port, *args, **kwargs):
 
 @pytest.fixture(scope="session")
 def runtime_http_server(
-    session_scoped_open_port, sample_inference_service, sample_train_service
+    http_session_scoped_open_port, sample_inference_service, sample_train_service
 ) -> http_server.RuntimeHTTPServer:
     with runtime_http_test_server(
-        session_scoped_open_port,
+        http_session_scoped_open_port,
         inference_service=sample_inference_service,
         training_service=sample_train_service,
     ) as server:

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -34,7 +34,7 @@ from caikit.core import DataObjectBase, dataobject
 from caikit.interfaces.nlp.data_model import GeneratedTextStreamResult, GeneratedToken
 from caikit.runtime import http_server
 from tests.conftest import temp_config
-from tests.runtime.conftest import ModuleSubproc
+from tests.runtime.conftest import ModuleSubproc, runtime_http_test_server
 
 ## Helpers #####################################################################
 
@@ -123,24 +123,24 @@ def generate_tls_configs(
 ## Insecure and TLS Tests #######################################################################
 
 
-def test_insecure_server(open_port):
+def test_insecure_server(runtime_http_server, open_port):
     with generate_tls_configs(open_port):
-        insecure_http_server = http_server.RuntimeHTTPServer()
         # start a non-blocking http server
-        with insecure_http_server:
-            resp = requests.get(f"http://localhost:{insecure_http_server.port}/docs")
-            resp.raise_for_status()
+        resp = requests.get(f"http://localhost:{runtime_http_server.port}/docs")
+        resp.raise_for_status()
 
 
-def test_basic_tls_server(open_port):
+def test_basic_tls_server(sample_inference_service, sample_train_service, open_port):
     with generate_tls_configs(
         open_port, tls=True, mtls=False, http_config_overrides={}
     ) as config_overrides:
-        http_server_with_tls = http_server.RuntimeHTTPServer(
-            tls_config_override=config_overrides["runtime"]["tls"]
-        )
-        # start a non-blocking http server with basic tls
-        with http_server_with_tls:
+        with runtime_http_test_server(
+            open_port,
+            inference_service=sample_inference_service,
+            training_service=sample_train_service,
+            tls_config_override=config_overrides["runtime"]["tls"],
+        ) as http_server_with_tls:
+            # start a non-blocking http server with basic tls
             resp = requests.get(
                 f"https://localhost:{http_server_with_tls.port}/docs",
                 verify=config_overrides["use_in_test"]["ca_cert"],
@@ -148,15 +148,19 @@ def test_basic_tls_server(open_port):
             resp.raise_for_status()
 
 
-def test_basic_tls_server_with_wrong_cert(open_port):
+def test_basic_tls_server_with_wrong_cert(
+    sample_inference_service, sample_train_service, open_port
+):
     with generate_tls_configs(
         open_port, tls=True, mtls=False, http_config_overrides={}
     ) as config_overrides:
-        http_server_with_tls = http_server.RuntimeHTTPServer(
-            tls_config_override=config_overrides["runtime"]["tls"]
-        )
-        # start a non-blocking http server with basic tls
-        with http_server_with_tls:
+        with runtime_http_test_server(
+            open_port,
+            inference_service=sample_inference_service,
+            training_service=sample_train_service,
+            tls_config_override=config_overrides["runtime"]["tls"],
+        ) as http_server_with_tls:
+            # start a non-blocking http server with basic tls
             with pytest.raises(requests.exceptions.SSLError):
                 requests.get(
                     f"https://localhost:{http_server_with_tls.port}/docs",
@@ -164,15 +168,17 @@ def test_basic_tls_server_with_wrong_cert(open_port):
                 )
 
 
-def test_mutual_tls_server(open_port):
+def test_mutual_tls_server(sample_inference_service, sample_train_service, open_port):
     with generate_tls_configs(
         open_port, tls=True, mtls=True, http_config_overrides={}
     ) as config_overrides:
-        http_server_with_mtls = http_server.RuntimeHTTPServer(
-            tls_config_override=config_overrides["runtime"]["tls"]
-        )
-        # start a non-blocking http server with mutual tls
-        with http_server_with_mtls:
+        with runtime_http_test_server(
+            open_port,
+            inference_service=sample_inference_service,
+            training_service=sample_train_service,
+            tls_config_override=config_overrides["runtime"]["tls"],
+        ) as http_server_with_mtls:
+            # start a non-blocking http server with mutual tls
             resp = requests.get(
                 f"https://localhost:{http_server_with_mtls.port}/docs",
                 verify=config_overrides["use_in_test"]["ca_cert"],
@@ -184,15 +190,19 @@ def test_mutual_tls_server(open_port):
             resp.raise_for_status()
 
 
-def test_mutual_tls_server_with_wrong_cert(open_port):
+def test_mutual_tls_server_with_wrong_cert(
+    sample_inference_service, sample_train_service, open_port
+):
     with generate_tls_configs(
         open_port, tls=True, mtls=True, http_config_overrides={}
     ) as config_overrides:
-        http_server_with_mtls = http_server.RuntimeHTTPServer(
-            tls_config_override=config_overrides["runtime"]["tls"]
-        )
-        # start a non-blocking http server with mutual tls
-        with http_server_with_mtls:
+        with runtime_http_test_server(
+            open_port,
+            inference_service=sample_inference_service,
+            training_service=sample_train_service,
+            tls_config_override=config_overrides["runtime"]["tls"],
+        ) as http_server_with_mtls:
+            # start a non-blocking http server with mutual tls
             with pytest.raises(requests.exceptions.SSLError):
                 requests.get(
                     f"https://localhost:{http_server_with_mtls.port}/docs",
@@ -204,18 +214,16 @@ def test_mutual_tls_server_with_wrong_cert(open_port):
                 )
 
 
-def test_docs():
+def test_docs(runtime_http_server):
     """Simple check that pinging /docs returns 200"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         response = client.get("/docs")
         assert response.status_code == 200
 
 
-def test_inference_sample_task(sample_task_model_id):
+def test_inference_sample_task(sample_task_model_id, runtime_http_server):
     """Simple check that we can ping a model"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         json_input = {"inputs": {"name": "world"}}
         response = client.post(
             f"/api/v1/{sample_task_model_id}/task/sample",
@@ -226,10 +234,11 @@ def test_inference_sample_task(sample_task_model_id):
         assert json_response["greeting"] == "Hello world"
 
 
-def test_inference_sample_task_optional_field(sample_task_model_id):
+def test_inference_sample_task_optional_field(
+    sample_task_model_id, runtime_http_server
+):
     """Simple check for optional fields"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         json_input = {
             "inputs": {"name": "world"},
             "parameters": {"throw": True},
@@ -243,10 +252,9 @@ def test_inference_sample_task_optional_field(sample_task_model_id):
         assert response.status_code == 500
 
 
-def test_inference_other_task(other_task_model_id):
+def test_inference_other_task(other_task_model_id, runtime_http_server):
     """Simple check that we can ping a model"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         json_input = {"inputs": {"name": "world"}}
         response = client.post(
             f"/api/v1/{other_task_model_id}/task/other",
@@ -257,10 +265,9 @@ def test_inference_other_task(other_task_model_id):
         assert json_response["farewell"] == "goodbye: world 42 times"
 
 
-def test_inference_streaming_sample_module(sample_task_model_id):
+def test_inference_streaming_sample_module(sample_task_model_id, runtime_http_server):
     """Simple check for testing a happy path unary-stream case"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         json_input = {"inputs": {"name": "world"}}
         stream = client.post(
             f"/api/v1/{sample_task_model_id}/task/server-streaming-sample",
@@ -276,10 +283,9 @@ def test_inference_streaming_sample_module(sample_task_model_id):
         )
 
 
-def test_model_not_found():
+def test_model_not_found(runtime_http_server):
     """Simple check that we can ping a model"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         response = client.post(
             f"/api/v1/this_is_not_a_model/task/sample",
             json={"inputs": {"name": "world"}},
@@ -287,10 +293,11 @@ def test_model_not_found():
         assert response.status_code == 404
 
 
-def test_inference_sample_task_throws_incorrect_input(sample_task_model_id):
+def test_inference_sample_task_throws_incorrect_input(
+    sample_task_model_id, runtime_http_server
+):
     """error check for a request with incorrect input"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         json_input = {"blah": {"sample_input": {"name": "world"}}}
         response = client.post(
             f"/api/v1/{sample_task_model_id}/task/sample",
@@ -299,10 +306,9 @@ def test_inference_sample_task_throws_incorrect_input(sample_task_model_id):
         assert response.status_code == 400
 
 
-def test_health_check_ok():
+def test_health_check_ok(runtime_http_server):
     """Make sure the health check returns OK"""
-    server = http_server.RuntimeHTTPServer()
-    with TestClient(server.app) as client:
+    with TestClient(runtime_http_server.app) as client:
         response = client.get(http_server.HEALTH_ENDPOINT)
         assert response.status_code == 200
         assert response.text == "OK"
@@ -324,7 +330,7 @@ def test_pydantic_wrapping_with_enums():
     assert token.text == "foo"
 
 
-def test_pydantic_wrapping_with_lists():
+def test_pydantic_wrapping_with_lists(runtime_http_server):
     """Check that pydantic wrapping works on data models with lists"""
 
     @dataobject(package="http")
@@ -338,7 +344,7 @@ def test_pydantic_wrapping_with_lists():
     foo = FooTest(bars=[BarTest(1)])
     assert foo.bars[0].baz == 1
 
-    http_server.RuntimeHTTPServer._dataobject_to_pydantic(FooTest)
+    runtime_http_server._dataobject_to_pydantic(FooTest)
 
     foo = FooTest(bars=[BarTest(1)])
     assert foo.bars[0].baz == 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR refactors the `init` function of the `http_server` to align with `grpc_server`. The idea is to eventually have a common `caikt/runtime/__main__.py` which can start both servers with similar arguments.


Alternate implementation here:  https://github.com/caikit/caikit/pull/389

**Special notes for your reviewer**:

Also fixes https://github.com/caikit/caikit/issues/380

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
