### PR TITLE
Add output_path to train apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 .coverage
 .coverage.*
+durations/*
 coverage*.xml
 dist
 htmlcov

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -18,7 +18,7 @@ The LocalModelTrainer uses a local thread to launch and manage each training job
 # Standard
 from concurrent.futures.thread import _threads_queues
 from datetime import datetime, timedelta
-from typing import Optional, Type
+from typing import Optional, Type, Union
 import os
 import re
 import threading
@@ -29,6 +29,7 @@ import aconfig
 import alog
 
 # Local
+from ...interfaces.common.data_model.stream_sources import S3Path
 from ..data_model import TrainingStatus
 from ..modules import ModuleBase
 from ..toolkit.destroyable_process import DestroyableProcess
@@ -66,7 +67,7 @@ class LocalModelTrainer(ModelTrainerBase):
             trainer_name: str,
             module_class: Type[ModuleBase],
             *args,
-            save_path: Optional[str],
+            save_path: Optional[Union[str, S3Path]],
             save_with_id: bool,
             external_training_id: Optional[str],
             use_subprocess: bool,

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -29,6 +29,7 @@ import zipfile
 import alog
 
 # Local
+from ..interfaces.common.data_model.stream_sources import S3Path
 from .model_management import (
     ModelFinderBase,
     ModelInitializerBase,
@@ -95,7 +96,7 @@ class ModelManager:
         module: Union[Type[ModuleBase], str],
         *args,
         trainer: Union[str, ModelTrainerBase] = "default",
-        save_path: Optional[str] = None,
+        save_path: Optional[Union[str, S3Path]] = None,
         save_with_id: bool = False,
         wait: bool = False,
         **kwargs,
@@ -119,8 +120,9 @@ class ModelManager:
             trainer (Union[str, ModelTrainerBase]): The trainer to use. If given
                 as a string, this is a key in the global config at
                 model_management.trainers.
-            save_path (Optional[str]): Path on disk where the model should be
-                saved (may be relative to a remote trainer's filesystem)
+            save_path (Optional[Union[str, S3Path]]): Path where the model should be
+                saved (may be relative to a remote trainer's filesystem, or link to S3
+                storage)
             save_with_id (bool): Inject the training ID into the save path for
                 the output model
             wait (bool): Wait for training to complete before returning
@@ -144,7 +146,7 @@ class ModelManager:
         error.subclass_check("<COR05418775E>", module, ModuleBase)
 
         # Get the trainer to use
-        trainer = self._get_trainer(trainer)
+        trainer: ModelTrainerBase = self._get_trainer(trainer)
 
         # Start the training
         with alog.ContextTimer(log.debug, "Started training in: "):

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -38,6 +38,7 @@ from caikit.core.data_model.base import DataBase
 from caikit.core.data_model.dataobject import make_dataobject
 from caikit.core.signature_parsing import CaikitMethodSignature, CustomSignature
 from caikit.interfaces.runtime.data_model import ModelPointer, TrainingJob
+from ...interfaces.common.data_model.stream_sources import S3Path
 
 log = alog.use_channel("RPC-SERIALIZERS")
 
@@ -169,7 +170,10 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         # Change return type for async training interface
         return_type = TrainingJob
 
-        new_params = {"model_name": str}
+        # Start with extra metaparameters
+        # - model_name: user-provided custom ID for the model to train
+        # - output_path: pointer to some storage where the model will be saved
+        new_params = {"model_name": str, "output_path": S3Path}
         for name, typ in signature.parameters.items():
             if type_helpers.has_data_stream(typ):
                 # Assume this is training data

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -30,6 +30,7 @@ from py_to_proto.dataclass_to_proto import (  # NOTE: Imported from here for com
 import alog
 
 # Local
+from ...interfaces.common.data_model.stream_sources import S3Path
 from . import protoable, type_helpers
 from .compatibility_checker import ApiFieldNames
 from .data_stream_source import make_data_stream_source
@@ -38,7 +39,6 @@ from caikit.core.data_model.base import DataBase
 from caikit.core.data_model.dataobject import make_dataobject
 from caikit.core.signature_parsing import CaikitMethodSignature, CustomSignature
 from caikit.interfaces.runtime.data_model import ModelPointer, TrainingJob
-from ...interfaces.common.data_model.stream_sources import S3Path
 
 log = alog.use_channel("RPC-SERIALIZERS")
 

--- a/caikit/runtime/servicers/model_train_servicer.py
+++ b/caikit/runtime/servicers/model_train_servicer.py
@@ -144,7 +144,7 @@ class ModelTrainServicerImpl(process_pb2_grpc.ProcessServicer):
             )
             raise CaikitRuntimeException(
                 grpc.StatusCode.INVALID_ARGUMENT,
-                f"Exception raised during inference. This may be a problem with your input: {e}",
+                f"Exception raised during training. This may be a problem with your input: {e}",
             ) from e
 
         except Exception as e:

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -18,9 +18,15 @@ then
     exit 1
 fi
 
-if < deps.txt grep -q ".*caikit_interfaces.*\->.*caikit_core.*"
+if < deps.txt grep -q ".*caikit_interfaces.*\->.*caikit_core.module*"
 then
-    echo "Fail: The core is importing the interfaces!"
+    echo "Fail: The core module definitions are importing the interfaces!"
+    exit 1
+fi
+
+if < deps.txt grep -q ".*caikit_interfaces.*\->.*caikit_core.data_model.*"
+then
+    echo "Fail: The core data model is importing the interfaces!"
     exit 1
 fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml {posargs:tests -m "not examples"}
+commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not examples"}
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
**What this PR does / why we need it**:

For #369 

This PR adds `output_path: S3Path` to all train apis

This PR _does not_ nest the rest of the training parameters. That turned out to be a bit of a bear so we're following up in a separate PR.

**Special notes for your reviewer**:

We went with just an `S3Path` for now and not also a `str` because we already have pretty good on-disk-path support via the `runtime.training.output_dir` configuration. That allows a deployment-wide base path to be set and then the `model_name` parameter provides the directory separation within that base path on a per-training-request basis. We think some more design thought is needed if we want to start overriding disk paths directly from the training API.

This change updates the base trainer implementation to fail if an S3 path is passed to the logic that builds disk paths- we expect trainers that support S3 paths to do their own path handling.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
