### PR TITLE
Use spawn for train subprocess 384

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -38,6 +38,7 @@ model_management:
                 # Format: XdXhXmXs
                 retention_duration: 1d
                 use_subprocess: false
+                subprocess_start_method: spawn
     finders:
         default:
             type: LOCAL

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -18,7 +18,7 @@ The LocalModelTrainer uses a local thread to launch and manage each training job
 # Standard
 from concurrent.futures.thread import _threads_queues
 from datetime import datetime, timedelta
-from typing import Optional, Type, Union
+from typing import Any, Dict, Iterable, Optional, Type, Union
 import os
 import re
 import threading
@@ -67,14 +67,14 @@ class LocalModelTrainer(ModelTrainerBase):
             self,
             trainer_name: str,
             module_class: Type[ModuleBase],
-            *args,
             save_path: Optional[Union[str, S3Path]],
             save_with_id: bool,
             model_name: Optional[str],
             external_training_id: Optional[str],
             use_subprocess: bool,
             subprocess_start_method: str,
-            **kwargs,
+            args: Iterable[Any],
+            kwargs: Dict[str, Any],
         ):
             super().__init__(
                 trainer_name=trainer_name,
@@ -290,14 +290,14 @@ class LocalModelTrainer(ModelTrainerBase):
         model_future = self.LocalModelFuture(
             self._instance_name,
             module_class,
-            *args,
             save_path=save_path,
             save_with_id=save_with_id,
             external_training_id=external_training_id,
             use_subprocess=self._use_subprocess,
             subprocess_start_method=self._subprocess_start_method,
             model_name=model_name,
-            **kwargs,
+            args=args,
+            kwargs=kwargs,
         )
 
         # Lock the global futures dict and add it to the dict

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -72,6 +72,7 @@ class LocalModelTrainer(ModelTrainerBase):
             model_name: Optional[str],
             external_training_id: Optional[str],
             use_subprocess: bool,
+            subprocess_start_method: str,
             **kwargs,
         ):
             super().__init__(
@@ -101,6 +102,7 @@ class LocalModelTrainer(ModelTrainerBase):
             if self._use_subprocess:
                 log.debug2("Running training %s as a SUBPROCESS", self.id)
                 self._worker = DestroyableProcess(
+                    start_method=subprocess_start_method,
                     target=self._train_and_save,
                     return_result=True,
                     args=args,
@@ -225,6 +227,7 @@ class LocalModelTrainer(ModelTrainerBase):
         """Initialize with a shared dict of all trainings"""
         self._instance_name = instance_name
         self._use_subprocess = config.get("use_subprocess", False)
+        self._subprocess_start_method = config.get("subprocess_start_method", "spawn")
         self._retention_duration = config.get("retention_duration")
         if self._retention_duration is not None:
             try:
@@ -277,6 +280,7 @@ class LocalModelTrainer(ModelTrainerBase):
             save_with_id=save_with_id,
             external_training_id=external_training_id,
             use_subprocess=self._use_subprocess,
+            subprocess_start_method=self._subprocess_start_method,
             model_name=model_name,
             **kwargs,
         )

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -106,7 +106,7 @@ class LocalModelTrainer(ModelTrainerBase):
                 self._worker = DestroyableProcess(
                     start_method=self._subprocess_start_method,
                     target=self._train_and_save,
-                    return_result=True,
+                    return_result=False,
                     args=args,
                     kwargs={
                         **kwargs,

--- a/caikit/core/toolkit/destroyable_process.py
+++ b/caikit/core/toolkit/destroyable_process.py
@@ -35,13 +35,11 @@ from .destroyable import Destroyable
 
 log = alog.use_channel("DESTROY-PROC")
 
-FORK_CTX = multiprocessing.get_context("fork")
-
 OOM_EXIT_CODE = 137
 
 
 class DestroyableProcess(
-    FORK_CTX.Process, Destroyable
+    multiprocessing.Process, Destroyable
 ):  # pylint: disable=too-many-instance-attributes
     __doc__ = __doc__
 
@@ -56,8 +54,8 @@ class DestroyableProcess(
         **_kwargs,
     ):
         """Initialize with an event to use to signal completion"""
-        self._parent_conn, self._child_conn = FORK_CTX.Pipe()
-        self._completion_event = completion_event or FORK_CTX.Event()
+        self._parent_conn, self._child_conn = multiprocessing.Pipe()
+        self._completion_event = completion_event or multiprocessing.Event()
         self._destroy_grace_period = destroy_grace_period
         self._return_result = return_result
 

--- a/caikit/core/toolkit/destroyable_process.py
+++ b/caikit/core/toolkit/destroyable_process.py
@@ -32,16 +32,26 @@ import alog
 
 # Local
 from .destroyable import Destroyable
+from .errors import error_handler
 
 log = alog.use_channel("DESTROY-PROC")
+error = error_handler.get(log)
+
 
 OOM_EXIT_CODE = 137
 
+FORK_CTX = multiprocessing.get_context("fork")
+SPAWN_CTX = multiprocessing.get_context("spawn")
+FORKSERVER_CTX = multiprocessing.get_context("forkserver")
 
-class DestroyableProcess(
-    multiprocessing.Process, Destroyable
+
+class _DestroyableProcess(
+    multiprocessing.process.BaseProcess,
+    Destroyable,
 ):  # pylint: disable=too-many-instance-attributes
-    __doc__ = __doc__
+    """The _DestroyableProcess base class implements a context-agnostic process
+    class that manages the subprocess and allows it to be destroyed
+    """
 
     def __init__(
         self,
@@ -54,8 +64,8 @@ class DestroyableProcess(
         **_kwargs,
     ):
         """Initialize with an event to use to signal completion"""
-        self._parent_conn, self._child_conn = multiprocessing.Pipe()
-        self._completion_event = completion_event or multiprocessing.Event()
+        self._parent_conn, self._child_conn = self.__class__._MP_CTX.Pipe()
+        self._completion_event = completion_event or self.__class__._MP_CTX.Event()
         self._destroy_grace_period = destroy_grace_period
         self._return_result = return_result
 
@@ -110,9 +120,9 @@ class DestroyableProcess(
             )
 
         # Update the result and throw if it's an error
-        error = self.error
-        if error is not None:
-            raise error
+        err = self.error
+        if err is not None:
+            raise err
         return self.__result
 
     def destroy(self):
@@ -201,3 +211,37 @@ class DestroyableProcess(
         if self._return_result:
             self._child_conn.send(result)
         self._completion_event.set()
+
+
+class _ForkDestroyableProcess(FORK_CTX.Process, _DestroyableProcess):
+    _MP_CTX = FORK_CTX
+
+
+class _SpawnDestroyableProcess(SPAWN_CTX.Process, _DestroyableProcess):
+    _MP_CTX = SPAWN_CTX
+
+
+class _ForkserverDestroyableProcess(FORKSERVER_CTX.Process, _DestroyableProcess):
+    _MP_CTX = FORKSERVER_CTX
+
+
+_PROCESS_TYPES = {
+    "fork": _ForkDestroyableProcess,
+    "forkserver": _ForkserverDestroyableProcess,
+    "spawn": _SpawnDestroyableProcess,
+}
+
+
+def DestroyableProcess(start_method: str, *args, **kwargs):
+    """Class wrapper that returns the appropriate process type based on the
+    requested start method.
+
+    NOTE: Naming intentionally looks like a class!
+    """
+    error.value_check(
+        "<COR16699811E>",
+        start_method in _PROCESS_TYPES,
+        "Unsupported start_method: {}",
+        start_method,
+    )
+    return _PROCESS_TYPES[start_method](*args, **kwargs)

--- a/caikit/core/toolkit/destroyable_process.py
+++ b/caikit/core/toolkit/destroyable_process.py
@@ -60,7 +60,7 @@ class _DestroyableProcess(
         args: Optional[Tuple] = None,
         kwargs: Optional[dict] = None,
         destroy_grace_period: float = 10,
-        return_result: bool = True,
+        return_result: bool = False,
         **_kwargs,
     ):
         """Initialize with an event to use to signal completion"""

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -78,6 +78,9 @@ class DataStreamSourceBase(DataStream):
         """
         new_inst = self.__class__.from_binary_buffer(pickle_bytes)
         setattr(self, new_inst.which_oneof("data_stream"), new_inst.data_stream)
+        self.generator_func = self._generator
+        self.generator_args = tuple()
+        self.generator_kwargs = {}
 
     # pylint: disable=too-many-return-statements
     def to_data_stream(self) -> DataStream:

--- a/caikit/runtime/utils/servicer_util.py
+++ b/caikit/runtime/utils/servicer_util.py
@@ -269,7 +269,7 @@ def validate_data_model(
         validate_caikit_library_class_method_exists(caikit_Library_class, "to_proto")
 
 
-class ServicePackageStreamWrapper(DataStream):
+class ServicePackageStreamWrapper(DataStreamSourceBase):
     """This class wraps up a DataStreamSourceBase derived class so that it can
     be safely pickled to a subprocess using "spawn".
 
@@ -289,7 +289,7 @@ class ServicePackageStreamWrapper(DataStream):
         NOTE: We _intentionally_ don't initialize the base class here and
             instead we forward
         """
-        super().__init__(stream._generator)
+        super().__init__()
         self._stream = stream
         update_wrapper(self, stream)
 

--- a/caikit/runtime/utils/servicer_util.py
+++ b/caikit/runtime/utils/servicer_util.py
@@ -15,7 +15,7 @@
 """
 # Standard
 from functools import update_wrapper
-from typing import Any, Dict, Iterable, Iterator, Tuple
+from typing import Any, Dict, Iterable, Iterator, Optional, Tuple
 import multiprocessing
 import sys
 import traceback
@@ -345,6 +345,64 @@ class ServicePackageStreamWrapper(DataStream):
         return getattr(self._stream, name)
 
 
+class SpawnProcessModelWrapper(ModuleBase):
+    """This class wraps up a model to make it safe to pass to a spawned
+    subprocess. It will not be efficient, but it will be safe!
+    """
+
+    def __init__(self, model_id: str, model: ModuleBase):
+        super().__init__()
+        self._model_id = model_id
+        self._model = model
+
+    def __getattr__(self, name):
+        """Forward attributes that are not found on the base class to the model
+
+        NOTE: This does _not_ forward base class attributes since those are
+            resolved before __getattr__ is called.
+        """
+        return getattr(self._model, name)
+
+    def save(self, *args, **kwargs):
+        """Directly forward save to the model so that it is not called by the
+        base class
+        """
+        return self._model.save(*args, **kwargs)
+
+    def run(self, *args, **kwargs):
+        """Directly forward run to the model so that it is not called by the
+        base class
+        """
+        return self._model.run(*args, **kwargs)
+
+    def __getstate__(self) -> Tuple[str, Optional[bytes]]:
+        """When pickling, only send the serialized model body for non-fork. This
+        is not a general-purpose pickle solution for models, but makes them safe
+        for training jobs that need to move models between processes.
+        """
+        start_method = multiprocessing.get_start_method()
+        body = None
+        if start_method != "fork":
+            body = self._model.as_bytes()
+        return self._model_id, body
+
+    def __setstate__(self, pickled: Tuple[str, Optional[bytes]]):
+        """When unpickling, deserialize the body if the model is not already
+        loaded in the model manager. This must be used in conjunction with the
+        above __getstate__ across a process boundary and should not be used as a
+        general-purpose deserialization for models.
+        """
+        model_id, body = pickled
+        model_manager = ModelManager.get_instance()
+        try:
+            retrieved_model = model_manager.retrieve_model(model_id)
+        except CaikitRuntimeException:
+            assert body is not None, "Cannot unpickle non-loaded model without a body"
+            retrieved_model = caikit.core.load(body)
+        self._model = retrieved_model
+        self._model_id = model_id
+
+
 def build_caikit_library_request_dict(
     request: ProtoMessageType,
     module_signature: CaikitMethodSignature,
@@ -407,7 +465,9 @@ def build_caikit_library_request_dict(
                 log.debug2("field %s value is a ModelPointer obj", field_name)
                 model_manager = ModelManager.get_instance()
                 model_retrieved = model_manager.retrieve_model(field_value.model_id)
-                kwargs_dict[field_name] = model_retrieved
+                updated_kwargs[field_name] = SpawnProcessModelWrapper(
+                    field_value.model_id, model_retrieved
+                )
 
             # 3.2 Data streams
             elif isinstance(field_value, DataStreamSourceBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,9 @@ def test_environment():
     test_config_path = os.path.join(FIXTURES_DIR, "config", "config.yml")
     caikit.configure(test_config_path)
     with tempfile.TemporaryDirectory() as workdir:
+        # 🌶️ All tests need to clean up after themselves! The metering and
+        # training output directories are the one thing easily creates leftover
+        # files, so we explicitly update config here to point them at a temp dir
         with temp_config(
             {
                 "runtime": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,12 +49,26 @@ def test_environment():
     """The most important fixture: This runs caikit configuration with the base test config overrides"""
     test_config_path = os.path.join(FIXTURES_DIR, "config", "config.yml")
     caikit.configure(test_config_path)
-    # import the mock backend that is specified in the config
-    # This is required to run any test that loads a model
-    # Local
-    from tests.core.helpers import MockBackend
+    with tempfile.TemporaryDirectory() as workdir:
+        with temp_config(
+            {
+                "runtime": {
+                    "metering": {
+                        "log_dir": os.path.join(workdir, "metering_logs"),
+                    },
+                    "training": {
+                        "output_dir": os.path.join(workdir, "training_output"),
+                    },
+                }
+            },
+            "merge",
+        ):
+            # import the mock backend that is specified in the config
+            # This is required to run any test that loads a model
+            # Local
+            from tests.core.helpers import MockBackend
 
-    yield
+            yield
     # No cleanup required...?
 
 

--- a/tests/core/model_management/test_local_model_trainer.py
+++ b/tests/core/model_management/test_local_model_trainer.py
@@ -28,9 +28,9 @@ import pytest
 import aconfig
 
 # Local
+from caikit.config import get_config
 from caikit.core.data_model import DataStream, TrainingStatus
 from caikit.core.model_management.local_model_trainer import LocalModelTrainer
-from caikit.core.toolkit.destroyable_process import OOM_EXIT_CODE
 from sample_lib.modules import SampleModule
 
 ## Helpers #####################################################################
@@ -53,7 +53,12 @@ def save_path():
 
 
 def get_event(cfg: dict):
-    return cfg.get("use_subprocess") and multiprocessing.Event() or threading.Event()
+    if cfg.get("use_subprocess"):
+        start_method = (
+            get_config().model_management.trainers.default.config.subprocess_start_method
+        )
+        return multiprocessing.get_context(start_method).Event()
+    return threading.Event()
 
 
 ## Tests #######################################################################

--- a/tests/core/toolkit/test_destroyable_process.py
+++ b/tests/core/toolkit/test_destroyable_process.py
@@ -133,7 +133,7 @@ def test_processes_will_not_execute_if_destroyed_before_starting(process_type):
 
 
 def test_event_is_set_on_completion(process_type):
-    event = multiprocessing.Event()
+    event = multiprocessing.get_context(process_type).Event()
     proc = DestroyableProcess(process_type, succeeder, completion_event=event)
     assert not event.is_set()
     proc.start()
@@ -146,7 +146,7 @@ def test_event_is_set_on_completion(process_type):
 
 
 def test_event_is_set_on_exception(process_type):
-    event = multiprocessing.Event()
+    event = multiprocessing.get_context(process_type).Event()
     proc = DestroyableProcess(process_type, thrower, completion_event=event)
     assert not event.is_set()
     proc.start()

--- a/tests/core/toolkit/test_destroyable_process.py
+++ b/tests/core/toolkit/test_destroyable_process.py
@@ -73,7 +73,7 @@ def test_processes_can_be_interrupted(process_type):
 
 
 def test_processes_can_return_results(process_type):
-    proc = DestroyableProcess(process_type, succeeder)
+    proc = DestroyableProcess(process_type, succeeder, return_result=True)
     proc.start()
     proc.join()
     assert EXPECTED_SUCCESS == proc.get_or_throw()

--- a/tests/core/toolkit/test_error_handler.py
+++ b/tests/core/toolkit/test_error_handler.py
@@ -351,6 +351,9 @@ class TestErrorHandler(TestCaseBase):
         with pytest.raises(TypeError):
             self.error.subclass_check("<III>", 1, int, allow_none=True)
 
+    @pytest.mark.skipif(
+        os.environ.get("LOG_FORMATTER") == "pretty", reason="Pretty formatter"
+    )
     def test_value_check_raises(self):
         """Verify that `value_check` raises a `ValueError`."""
         bad_value = 1.1
@@ -365,6 +368,9 @@ class TestErrorHandler(TestCaseBase):
             "exception raised: ValueError('value check failed: invalid range `1.1`')",
         )
 
+    @pytest.mark.skipif(
+        os.environ.get("LOG_FORMATTER") == "pretty", reason="Pretty formatter"
+    )
     def test_value_check_no_args_raises(self):
         """Verify that `value_check` raises a `ValueError` if no args are given with empty msg."""
         bad_value = 1.1
@@ -377,6 +383,9 @@ class TestErrorHandler(TestCaseBase):
             "exception raised: ValueError('value check failed: ')",
         )
 
+    @pytest.mark.skipif(
+        os.environ.get("LOG_FORMATTER") == "pretty", reason="Pretty formatter"
+    )
     def test_value_check_empty_msg_raises(self):
         """Verify that `value_check` raises a `ValueError` if msg is empty."""
         bad_value = 1.1
@@ -389,6 +398,9 @@ class TestErrorHandler(TestCaseBase):
             "exception raised: ValueError('value check failed: 1.1')",
         )
 
+    @pytest.mark.skipif(
+        os.environ.get("LOG_FORMATTER") == "pretty", reason="Pretty formatter"
+    )
     def test_value_check_empty_args_raises(self):
         """Verify that `value_check` raises a `ValueError` if only msg is provided."""
         bad_value = 1.1

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -25,6 +25,7 @@ import grpc
 import pytest
 
 # Local
+from caikit.config import get_config
 from caikit.core import MODEL_MANAGER
 from caikit.interfaces.common.data_model.stream_sources import S3Path
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
@@ -423,9 +424,11 @@ def test_global_train_aborts_long_running_trains(
         oom_exit=False,
     )
 
-    # sample_train_servicer.use_subprocess = True
     if sample_train_servicer.use_subprocess:
-        test_event = multiprocessing.Event()
+        start_method = (
+            get_config().model_management.trainers.default.config.subprocess_start_method
+        )
+        test_event = multiprocessing.get_context(start_method).Event()
     else:
         test_event = threading.Event()
 

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -21,6 +21,7 @@ import pytest
 
 # Local
 from caikit.runtime.protobufs import model_runtime_pb2
+from caikit.runtime.service_generation.data_stream_source import DataStreamSourceBase
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import get_data_model
 from caikit.runtime.utils.servicer_util import (
@@ -306,6 +307,7 @@ def test_global_train_build_caikit_library_request_dict_strips_empty_list_from_r
     expected_arguments = {"training_data", "union_list"}
 
     assert expected_arguments == set(caikit.core_request.keys())
+    assert isinstance(caikit.core_request["training_data"], DataStreamSourceBase)
 
 
 def test_global_train_build_caikit_library_request_dict_works_for_repeated_fields(


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #384 

This PR makes it safe to use "spawn" when performing training jobs.

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
