### PR TITLE
Non disk lazy loading

### DIFF
--- a/caikit/core/model_management/local_model_initializer.py
+++ b/caikit/core/model_management/local_model_initializer.py
@@ -28,7 +28,8 @@ model_management:
                       config: {}
 """
 # Standard
-from typing import Callable, Optional
+from typing import Callable, List, Optional
+import copy
 import inspect
 
 # First Party
@@ -198,6 +199,11 @@ class LocalModelInitializer(ModelInitializerBase):
 
         # Return the loaded model if it was able to load
         return loaded_model
+
+    @property
+    def backends(self) -> List[BackendBase]:
+        """Return an immutable view of the priority sequence of backends"""
+        return copy.copy(self._backends)
 
     ## Implementation Details ##################################################
 

--- a/caikit/core/model_management/local_model_initializer.py
+++ b/caikit/core/model_management/local_model_initializer.py
@@ -177,8 +177,10 @@ class LocalModelInitializer(ModelInitializerBase):
                     module_backend_impl.__name__,
                 )
                 extra_kwargs = {}
-                if self._supports_load_backend_kwarg(module_backend_impl.load):
+                if self._supports_arg(module_backend_impl.load, "load_backend"):
                     extra_kwargs["load_backend"] = load_backend
+                if self._supports_arg(module_backend_impl.load, "model_config"):
+                    extra_kwargs["model_config"] = model_config
                 loaded_model = module_backend_impl.load(
                     model_path,
                     **extra_kwargs,
@@ -200,12 +202,12 @@ class LocalModelInitializer(ModelInitializerBase):
     ## Implementation Details ##################################################
 
     @staticmethod
-    def _supports_load_backend_kwarg(load_fn: Callable) -> bool:
+    def _supports_arg(load_fn: Callable, arg_name: str) -> bool:
         """A load function supports the load_backend kwarg IFF it has an arg
         explicitly named load_backend or it has a ** kwarg capture
         """
         sig = inspect.signature(load_fn)
-        return "load_backend" in sig.parameters
+        return arg_name in sig.parameters
 
     def _get_supported_load_backends(self, backend_impl: ModuleBase):
         """Function to get a list of supported load backends

--- a/caikit/core/model_management/local_model_initializer.py
+++ b/caikit/core/model_management/local_model_initializer.py
@@ -191,7 +191,7 @@ class LocalModelInitializer(ModelInitializerBase):
                 except TypeError as err:
                     log.warning(
                         "<COR98539580W>",
-                        "DEPRECATION: Loading %s failed with ModuleConfig. Using model_path for compatibility. %s",
+                        "DEPRECATION: Loading %s failed with ModuleConfig. Using model_path. %s",
                         module_backend_impl.MODULE_ID,
                         err,
                     )

--- a/caikit/core/modules/config.py
+++ b/caikit/core/modules/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Standard
+from typing import Union
 import os
 
 # First Party
@@ -82,20 +83,23 @@ class ModuleConfig(aconfig.Config):
         )
 
     @classmethod
-    def load(cls, model_path):
+    def load(cls, model_path: Union[str, "ModuleConfig"]) -> "ModuleConfig":
         """Load a new module configuration from a directory on disk.
 
         Args:
-            model_path (str): Path to model directory. At the top level of
-                directory is `config.yml` which holds info about the model. Note
-                that the model_path here is assumed to be operating system
-                correct as a consequence of the way this method is invoked by
-                the model manager.
+            model_path (Union[str, ModuleConfig]): Path to model directory. At
+                the top level of directory is `config.yml` which holds info
+                about the model. Note that the model_path here is assumed to be
+                operating system correct as a consequence of the way this method
+                is invoked by the model manager.
 
         Returns:
-            BlockConfig: Instantiated BlockConfig for model given model_path.
+            model_config (ModuleConfig): Instantiated ModuleConfig for model
+                given model_path.
         """
-        error.type_check("<COR71170339E>", str, model_path=model_path)
+        error.type_check("<COR71170339E>", str, cls, model_path=model_path)
+        if isinstance(model_path, cls):
+            return model_path
 
         # Validate config.yml
         config_path = os.path.join(model_path, "config.yml")

--- a/caikit/core/modules/loader.py
+++ b/caikit/core/modules/loader.py
@@ -17,6 +17,7 @@ Contains recursive functions for loading modules saved inside modules.
 """
 
 # Standard
+from typing import Union
 import os
 
 # First Party
@@ -34,16 +35,15 @@ error = error_handler.get(log)
 class ModuleLoader:
     MODULE_PATHS_KEY = "module_paths"
 
-    def __init__(self, model_path):
+    def __init__(self, model_path: Union[str, ModuleConfig]):
         """Construct a new module loader.
 
         Args:
-            model_path (str): The path to the directory where the model is to be
-                loaded from.
+            model_path (Union[str, ModuleConfig]): The path to the directory
+                where the model is to be loaded from, or a preloaded config.
         """
-        self.model_path = os.path.normpath(model_path)
-        error.dir_check("<COR43014802E>", model_path)
         self.config = ModuleConfig.load(model_path)
+        self.model_path = self.config.model_path
 
     def load_arg(self, arg):
         """Extract arg value from the loaded model's config"""

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -24,7 +24,7 @@ import alog
 
 # Local
 from caikit.config import get_config
-from caikit.core import MODEL_MANAGER
+from caikit.core import MODEL_MANAGER, ModuleBase
 from caikit.runtime.model_management.batcher import Batcher
 from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
@@ -32,7 +32,6 @@ from caikit.runtime.work_management.abortable_action import (
     AbortableAction,
     ActionAborter,
 )
-import caikit.core
 
 log = alog.use_channel("MODEL-LOADER")
 
@@ -110,7 +109,7 @@ class ModelLoader:
 
             # Load using the caikit.core
             with CAIKIT_CORE_LOAD_DURATION_SUMMARY.labels(model_type=model_type).time():
-                model = caikit.core.load(model_path)
+                model = MODEL_MANAGER.load(model_path)
 
             # If this model needs batching, configure a Batcher to wrap it
             model = self._wrap_in_batcher_if_configured(
@@ -157,10 +156,10 @@ class ModelLoader:
 
     def _wrap_in_batcher_if_configured(
         self,
-        caikit_core_model: caikit.core.ModuleBase,
+        caikit_core_model: ModuleBase,
         model_type: str,
         model_id: str,
-    ) -> Union[Batcher, caikit.core.ModuleBase]:
+    ) -> Union[Batcher, ModuleBase]:
         """Perform Batcher wrapping on the given module if configured, otherwise
         return the model as is
         """

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -14,6 +14,7 @@
 
 # Standard
 from typing import Optional, Type
+import os
 import uuid
 
 # Third Party
@@ -23,9 +24,11 @@ import pytest
 from caikit.core import MODEL_MANAGER
 from caikit.core.data_model import TrainingStatus
 from caikit.core.model_management import (
+    ModelFinderBase,
     ModelInitializerBase,
     ModelTrainerBase,
     TrainingInfo,
+    model_finder_factory,
     model_initializer_factory,
     model_trainer_factory,
 )
@@ -38,6 +41,7 @@ from caikit.core.registries import (
     module_backend_types,
     module_registry,
 )
+from sample_lib.modules import SampleModule
 
 
 # Add mock backend
@@ -61,8 +65,30 @@ class MockBackend(BackendBase):
 
 backend_types.register_backend_type(MockBackend)
 
+# Add a new model finder that tests can use
+class TestFinder(ModelFinderBase):
+    name = "TestFinder"
+    __test__ = False
 
-# Add a new shared load backend that tests can use
+    def __init__(self, config, instance_name):
+        # Fill in expected fields for SampleModule
+        config.setdefault("module_id", SampleModule.MODULE_ID)
+        config.setdefault("train", {}).setdefault("batch_size", 1)
+        config.setdefault("train", {}).setdefault("learning_rate", 0.1)
+        self._config = config
+        self._local_finder = model_finder_factory.construct({"type": "LOCAL"})
+        self._instance_name = instance_name
+
+    def find_model(self, model_path, *args, **kwargs):
+        if os.path.exists(model_path):
+            return self._local_finder.find_model(model_path, *args, **kwargs)
+        return ModuleConfig(self._config)
+
+
+model_finder_factory.register(TestFinder)
+
+
+# Add a new model initializer that tests can use
 class TestInitializer(ModelInitializerBase):
     name = "TestInitializer"
     __test__ = False

--- a/tests/core/modules/test_module.py
+++ b/tests/core/modules/test_module.py
@@ -350,7 +350,7 @@ def test_class_attributes(reset_globals):
         # Normally non-local backend modules are loaded through caikit.load, so
         # we need to make sure the local loader has been properly configured to
         # enable local instance instantiation.
-        assert MODEL_MANAGER._get_initializer("default")
+        assert MODEL_MANAGER.get_initializer("default")
 
         # Make sure an instance can fetch via get_backend()
         inst = DummyBar()

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -600,6 +600,22 @@ def test_initialize_all_components(reset_globals):
         assert set(MODEL_MANAGER._initializers.keys()) == {"default", "foobar"}
 
 
+def test_find_without_on_disk_model(good_model_path, reset_globals):
+    """Make sure that ephemeral models can be found without existing on disk"""
+
+    with temp_config(
+        {
+            "model_management": {
+                "finders": {"default": {"type": TestFinder.name}},
+                "initializers": {"default": {"type": "LOCAL"}},
+            }
+        }
+    ):
+        model = caikit.core.load("some_pretend_model")
+        assert model
+        assert not os.path.exists("some_pretend_model")
+
+
 def test_train_by_module_class(reset_globals):
     """Make sure training can be accessed through the central train function
     with the class directly

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -489,8 +489,8 @@ def test_load_with_two_shared_initializers_of_the_same_type(
             }
         }
     ):
-        model_one_loader = MODEL_MANAGER._get_initializer("model-one")
-        model_two_loader = MODEL_MANAGER._get_initializer("model-two")
+        model_one_loader = MODEL_MANAGER.get_initializer("model-one")
+        model_two_loader = MODEL_MANAGER.get_initializer("model-two")
 
         # plain model load should use first loader
         model = caikit.core.load(good_model_path, initializer="model-one")

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -32,9 +32,11 @@ class SampleModule(caikit.core.ModuleBase):
         self.stream_size = stream_size
 
     @classmethod
-    def load(cls, model_path, **kwargs):
-        loader = ModuleLoader(model_path)
-        config = loader.config
+    def load(cls, model_path, model_config=None, **kwargs):
+        config = model_config
+        if not config:
+            loader = ModuleLoader(model_path)
+            config = loader.config
         return cls(config["train"]["batch_size"], config["train"]["learning_rate"])
 
     @SampleTask.taskmethod()

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -32,11 +32,9 @@ class SampleModule(caikit.core.ModuleBase):
         self.stream_size = stream_size
 
     @classmethod
-    def load(cls, model_path, model_config=None, **kwargs):
-        config = model_config
-        if not config:
-            loader = ModuleLoader(model_path)
-            config = loader.config
+    def load(cls, model_path, **kwargs):
+        loader = ModuleLoader(model_path)
+        config = loader.config
         return cls(config["train"]["batch_size"], config["train"]["learning_rate"])
 
     @SampleTask.taskmethod()


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #394 

This PR makes it possible to write a `ModelFinder` that finds models in non-disk locations. This could be fetching a model from a remote repository or a config-only model that does not need any load-time artifacts (e.g. remote proxy to TGIS)