### PR TITLE
:goal_net: add more compatibility for toolkit.error_handler

### DIFF
--- a/caikit/core/toolkit/error_handler.py
+++ b/caikit/core/toolkit/error_handler.py
@@ -1,0 +1,32 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""This file exists for backwards compatibility.
+It imports from the caikit.core.exceptions package where things moved"""
+
+# Standard
+import warnings as _warnings
+
+# Local
+from caikit.core.exceptions.error_handler import *
+
+# 🌶️🌶️🌶️ Warn if this package is ever imported
+# Allow DeprecationWarnings through if anything tries to import from `toolkit.errors`
+_warnings.filterwarnings("default", category=DeprecationWarning)
+# And actually warn them
+_warnings.warn(
+    "The caikit.toolkit.error_handler package has moved to caikit.core.exceptions",
+    DeprecationWarning,
+)

--- a/caikit/core/toolkit/error_handler.py
+++ b/caikit/core/toolkit/error_handler.py
@@ -20,7 +20,7 @@ It imports from the caikit.core.exceptions package where things moved"""
 import warnings as _warnings
 
 # Local
-from caikit.core.exceptions.error_handler import *
+from caikit.core.exceptions.error_handler import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 # 🌶️🌶️🌶️ Warn if this package is ever imported
 # Allow DeprecationWarnings through if anything tries to import from `toolkit.errors`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Whoops, adds back the ability to
```
from caikit.core.toolkit import error_handler
```

with warnings

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
