### PR TITLE
🐛 Fix derived DM to pydantic conversion bug

### DIFF
--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -634,14 +634,10 @@ class RuntimeHTTPServer(RuntimeServerBase):
         """Make a pydantic model based on the given proto message by using the data
         model class annotations to mirror as a pydantic model
         """
-        # Use dicts for jsondict values
-        # this is needed for pydantic to have a handle on JsonDicts while
+        # define a local namespace for type hints to get type information from.
+        # This is needed for pydantic to have a handle on JsonDict and JsonDictValue while
         # creating its base model
-        # pylint: disable=unused-variable
-        JsonDict = dict
-        JsonDictValue = dict
-        # define a local namespace for type hints to get type information from
-        localns = {"JsonDict": JsonDict, "JsonDictValue": JsonDictValue}
+        localns = {"JsonDict": dict, "JsonDictValue": dict}
 
         if dm_class in PYDANTIC_TO_DM_MAPPING:
             return PYDANTIC_TO_DM_MAPPING[dm_class]

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -635,15 +635,15 @@ class RuntimeHTTPServer(RuntimeServerBase):
             return PYDANTIC_TO_DM_MAPPING[dm_class]
 
         annotations = {
-            field_name: cls._get_pydantic_type(field_type)
-            for field_name, field_type in dm_class.__annotations__.items()
+            field.name: cls._get_pydantic_type(field.type)
+            for _, field in dm_class.__dataclass_fields__.items()
         }
         pydantic_model = type(pydantic.BaseModel)(
             dm_class.get_proto_class().DESCRIPTOR.full_name,
             (pydantic.BaseModel,),
             {
                 "__annotations__": annotations,
-                **{name: None for name in dm_class.__annotations__},
+                **{name: None for name in dm_class.__dataclass_fields__},
             },
         )
         PYDANTIC_TO_DM_MAPPING[dm_class] = pydantic_model

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -350,7 +350,7 @@ def test_health_check_ok(runtime_http_server):
         assert response.text == "OK"
 
 
-def test_pydantic_wrapping_with_enums(runtime_http_server):
+def test_pydantic_wrapping_with_enums():
     """Check that the pydantic wrapping works on our data models when they have enums"""
     # The NLP GeneratedTextStreamResult data model contains enums
 
@@ -359,14 +359,14 @@ def test_pydantic_wrapping_with_enums(runtime_http_server):
     assert token.text == "foo"
 
     # Wrap the containing data model in pydantic
-    runtime_http_server._dataobject_to_pydantic(GeneratedTextStreamResult)
+    http_server.RuntimeHTTPServer._dataobject_to_pydantic(GeneratedTextStreamResult)
 
     # Check that our data model is _still_ fine and dandy
     token = GeneratedToken(text="foo")
     assert token.text == "foo"
 
 
-def test_pydantic_wrapping_with_inheritance(runtime_http_server):
+def test_pydantic_wrapping_with_inheritance():
     """Check that the pydantic wrapping works on our data models when they involve inheritance"""
 
     @dataobject
@@ -385,7 +385,7 @@ def test_pydantic_wrapping_with_inheritance(runtime_http_server):
     assert derived.foo == 2
 
     # Wrap the containing data model in pydantic
-    pydantic_datamodel = runtime_http_server._dataobject_to_pydantic(Derived)
+    pydantic_datamodel = http_server.RuntimeHTTPServer._dataobject_to_pydantic(Derived)
 
     # Check that our data model is _still_ fine and dandy
     new_derived = pydantic_datamodel(bar="one", foo=2)
@@ -393,7 +393,7 @@ def test_pydantic_wrapping_with_inheritance(runtime_http_server):
     assert new_derived.foo == 2
 
 
-def test_pydantic_wrapping_with_lists(runtime_http_server):
+def test_pydantic_wrapping_with_lists():
     """Check that pydantic wrapping works on data models with lists"""
 
     @dataobject(package="http")
@@ -407,7 +407,7 @@ def test_pydantic_wrapping_with_lists(runtime_http_server):
     foo = FooTest(bars=[BarTest(1)])
     assert foo.bars[0].baz == 1
 
-    runtime_http_server._dataobject_to_pydantic(FooTest)
+    http_server.RuntimeHTTPServer._dataobject_to_pydantic(FooTest)
 
     foo = FooTest(bars=[BarTest(1)])
     assert foo.bars[0].baz == 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes an issue when converting dataobject to pydantic models when there is inheritance involved.

fix #419 

**Special notes for your reviewer**:

> FYI - this has a consequence in all cases where we have derived DM objects. Instantiating any derived DM object will require that we satisfy ALL fields within the base DM object as well. (applies to `S3Path`)

#### Useful links:
- https://docs.python.org/3/library/typing.html#typing.get_type_hints
- https://peps.python.org/pep-0526/#runtime-effects-of-type-annotations
    
     > The recommended way of getting annotations at runtime is by using typing.get_type_hints function; as with all dunder attributes, any undocumented use of __annotations__ is subject to breakage without warning:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
