### PR TITLE
Module load api cleanup 417

### DIFF
--- a/caikit/core/model_management/local_model_initializer.py
+++ b/caikit/core/model_management/local_model_initializer.py
@@ -188,7 +188,7 @@ class LocalModelInitializer(ModelInitializerBase):
                         **extra_kwargs,
                         **kwargs,
                     )
-                except TypeError as err:
+                except Exception as err:  # pylint: disable=broad-exception-caught
                     log.warning(
                         "<COR98539580W>",
                         "DEPRECATION: Loading %s failed with ModuleConfig. Using model_path. %s",

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -203,7 +203,7 @@ class ModelManager:
 
     def load(
         self,
-        module_path: str,
+        module_path: Union[str, BytesIO, bytes],
         *,
         load_singleton: bool = False,
         finder: Union[str, ModelFinderBase] = "default",

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -270,7 +270,7 @@ class ModelManager:
                 module_path, load_singleton, finder, initializer, **kwargs
             )
         try:
-            return self._load_from_dir(
+            return self._do_load(
                 module_path, load_singleton, finder, initializer, **kwargs
             )
         except FileNotFoundError:
@@ -422,9 +422,7 @@ class ModelManager:
 
     ## Implementation Details ##################################################
 
-    def _load_from_dir(
-        self, module_path, load_singleton, finder, initializer, **kwargs
-    ):
+    def _do_load(self, module_path, load_singleton, finder, initializer, **kwargs):
         """Load a model from a directory.
 
         Args:
@@ -519,7 +517,7 @@ class ModelManager:
             # to files directly, or it may unpack to a (single) directory containing the files.
             # We expect the former, but fall back to the second if we can't find the config.
             try:
-                model = self._load_from_dir(
+                model = self._do_load(
                     extract_path, load_singleton, finder, initializer, **kwargs
                 )
             # NOTE: Error handling is a little gross here, the main reason being that we
@@ -549,7 +547,7 @@ class ModelManager:
                 # Otherwise, try again. If we fail again stop, because the zip creation should only
                 # create one potential extra layer of nesting around the model directory.
                 try:
-                    model = self._load_from_dir(
+                    model = self._do_load(
                         nested_dirs[0], load_singleton, finder, initializer, **kwargs
                     )
                 except FileNotFoundError:

--- a/caikit/core/model_manager.py
+++ b/caikit/core/model_manager.py
@@ -251,7 +251,9 @@ class ModelManager:
         load_path = get_config().load_path
         if load_path is not None and isinstance(module_path, str):
             if not os.path.exists(module_path):
-                module_path = os.path.join(load_path, module_path)
+                full_module_path = os.path.join(load_path, module_path)
+                if os.path.exists(full_module_path):
+                    module_path = full_module_path
 
         # Ensure that we have a loadable directory.
         error.type_check("<COR98255419E>", str, BytesIO, bytes, module_path=module_path)

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -40,6 +40,7 @@ from ..data_model import DataBase, DataStream
 from ..exceptions import error_handler
 from ..exceptions.validation_error import DataValidationError
 from ..toolkit import fileio
+from .config import ModuleConfig
 from .loader import ModuleLoader
 from .meta import _ModuleBaseMeta
 from caikit import core
@@ -120,14 +121,19 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
     @classmethod
     @alog.logged_function(log.debug)
-    def load(cls, model_path, *args, **kwargs):
+    def load(
+        cls,
+        model_path: Union[str, ModuleConfig],
+        *args,
+        **kwargs,
+    ) -> "ModuleBase":
         """Load a new instance of workflow from a given model_path
 
         Args:
-            model_path (str): Path to workflow
+            model_path (Union[str, ModuleConfig]): Path to saved model or
+                in-memory ModuleConfig
         Returns:
-            caikit.core.workflows.base.WorkflowBase: A new instance of any given
-                implementation of WorkflowBase
+            model (ModuleBase): A new instance of this module class
         """
         return cls._load(ModuleLoader(model_path), *args, **kwargs)
 
@@ -177,7 +183,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
     ###################
 
     @alog.logged_function(log.debug)
-    def save(self, model_path, *args, **kwargs):
+    def save(self, model_path: str, *args, **kwargs):
         """Save a model.
 
         Args:
@@ -189,7 +195,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         )
 
     @alog.logged_function(log.debug)
-    def as_file_like_object(self, *args, **kwargs):
+    def as_file_like_object(self, *args, **kwargs) -> BytesIO:
         """Produces a file-like object corresponding to a zip archive affiliated with a given
         model. This method wraps is functionally similar to .save() - it saves a model into
         a temporary directory and produces a zip archive, then loads the result as a io.BytesIO
@@ -205,7 +211,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         return BytesIO(self.as_bytes(*args, **kwargs))
 
     @alog.logged_function(log.debug)
-    def as_bytes(self, *args, **kwargs):
+    def as_bytes(self, *args, **kwargs) -> bytes:
         """Produces a bytes object corresponding to a zip archive affiliated with a given
         model. This method wraps is functionally similar to .save() - it saves a model into
         a temporary directory and produces a zip archive, then loads the result as a bytes

--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -142,7 +142,7 @@ class ModelLoader:
                 % (model_path, repr(ex)),
                 "model_id": model_id,
             }
-            log.error(log_dict)
+            log.error(log_dict, exc_info=True)
             raise CaikitRuntimeException(
                 StatusCode.INTERNAL,
                 f"Model {model_id} failed to load. Nested error: {ex}",

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -80,7 +80,6 @@ class TestFinder(ModelFinderBase):
         self._config = config
         self._local_finder = model_finder_factory.construct({"type": "LOCAL"})
         self._instance_name = instance_name
-        self._fallback_to_local = config.get("fallback_to_local", True)
 
     def find_model(self, model_path, *args, **kwargs):
         if self._raise_on_find:
@@ -88,9 +87,7 @@ class TestFinder(ModelFinderBase):
         if self._fail_to_find:
             return None
         if os.path.exists(model_path):
-            if self._fallback_to_local:
-                return self._local_finder.find_model(model_path, *args, **kwargs)
-            return None
+            return self._local_finder.find_model(model_path, *args, **kwargs)
         return ModuleConfig(self._config)
 
 

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -80,6 +80,7 @@ class TestFinder(ModelFinderBase):
         self._config = config
         self._local_finder = model_finder_factory.construct({"type": "LOCAL"})
         self._instance_name = instance_name
+        self._fallback_to_local = config.get("fallback_to_local", True)
 
     def find_model(self, model_path, *args, **kwargs):
         if self._raise_on_find:
@@ -87,7 +88,9 @@ class TestFinder(ModelFinderBase):
         if self._fail_to_find:
             return None
         if os.path.exists(model_path):
-            return self._local_finder.find_model(model_path, *args, **kwargs)
+            if self._fallback_to_local:
+                return self._local_finder.find_model(model_path, *args, **kwargs)
+            return None
         return ModuleConfig(self._config)
 
 

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -627,14 +627,7 @@ def test_find_without_on_disk_model_and_load_path(good_model_path, reset_globals
             {
                 "load_path": workdir,
                 "model_management": {
-                    "finders": {
-                        "default": {
-                            "type": TestFinder.name,
-                            "config": {
-                                "fallback_to_local": False,
-                            },
-                        },
-                    },
+                    "finders": {"default": {"type": TestFinder.name}},
                     "initializers": {"default": {"type": "LOCAL"}},
                 },
             }

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -18,11 +18,13 @@ and download and load them.
 from contextlib import contextmanager
 import os
 import tempfile
+import uuid
 
 # Local
 from caikit.core import LocalBackend
 from caikit.core.data_model import DataStream, TrainingStatus
 from caikit.core.model_management import ModelFinderBase, model_finder_factory
+from caikit.core.modules import ModuleBase, ModuleSaver, module
 
 # Unit Test Infrastructure
 from sample_lib.modules.sample_task import SampleModule
@@ -640,6 +642,34 @@ def test_find_without_on_disk_model_and_load_path(good_model_path, reset_globals
             model = caikit.core.load("some_pretend_model")
             assert model
             assert not os.path.exists("some_pretend_model")
+
+
+def test_load_requires_path_str(reset_globals):
+    """Make sure that modules whose load function requires a path string
+    explicitly can be loaded
+    """
+    mod_id = str(uuid.uuid4())
+
+    class CustomException(Exception):
+        """Never been seen before!"""
+
+    @module(id=mod_id, name="Needs a path", version="1.2.3")
+    class NeedsAPath(ModuleBase):
+        def save(self, model_path: str):
+            with ModuleSaver(self, model_path=model_path) as module_saver:
+                module_saver.update_config({"foo": "bar"})
+
+        @classmethod
+        def load(cls, model_path: str, *_, **__):
+            if not isinstance(model_path, str) or not os.path.exists(model_path):
+                raise CustomException("Yikes!")
+            return cls()
+
+    with tempfile.TemporaryDirectory() as workdir:
+        model_path = os.path.join(workdir, "test_model")
+        NeedsAPath().save(model_path)
+        loaded = caikit.load(model_path)
+        assert loaded
 
 
 def test_train_by_module_class(reset_globals):

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -600,7 +600,7 @@ def test_initialize_all_components(reset_globals):
         assert set(MODEL_MANAGER._initializers.keys()) == {"default", "foobar"}
 
 
-def test_find_without_on_disk_model(good_model_path, reset_globals):
+def test_find_without_on_disk_model_no_load_path(good_model_path, reset_globals):
     """Make sure that ephemeral models can be found without existing on disk"""
 
     with temp_config(
@@ -614,6 +614,32 @@ def test_find_without_on_disk_model(good_model_path, reset_globals):
         model = caikit.core.load("some_pretend_model")
         assert model
         assert not os.path.exists("some_pretend_model")
+
+
+def test_find_without_on_disk_model_and_load_path(good_model_path, reset_globals):
+    """Make sure that ephemeral models can be found without existing on disk
+    when a shared load_path is configured
+    """
+    with tempfile.TemporaryDirectory() as workdir:
+        with temp_config(
+            {
+                "load_path": workdir,
+                "model_management": {
+                    "finders": {
+                        "default": {
+                            "type": TestFinder.name,
+                            "config": {
+                                "fallback_to_local": False,
+                            },
+                        },
+                    },
+                    "initializers": {"default": {"type": "LOCAL"}},
+                },
+            }
+        ):
+            model = caikit.core.load("some_pretend_model")
+            assert model
+            assert not os.path.exists("some_pretend_model")
 
 
 def test_train_by_module_class(reset_globals):


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #417 

This PR fixes the overly-strict assumptions made about how `load` functions have been implemented in the wild, thus fixing backwards compatibility for recent changes to pass `ModuleConfig` as the first argument to `load`. It does so explicitly to fix backwards compatibility, so did not attempt to make anything more strict w.r.t. setting expectations about how `load` should be implemented in the future

**If applicable**:
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
