### PR TITLE
update saver to take args

### DIFF
--- a/caikit/core/modules/saver.py
+++ b/caikit/core/modules/saver.py
@@ -225,7 +225,7 @@ class ModuleSaver:
         """
         self.config.update(additional_config)
 
-    def save_module(self, module, relative_path):
+    def save_module(self, module, relative_path, **kwargs):
         """Save a CaikitCore module within a workflow artifact and add a reference to the config.
 
         Args:
@@ -233,6 +233,8 @@ class ModuleSaver:
                 part of this workflow
             relative_path (str): The relative path inside of `model_path` where
                 the module will be saved
+            **kwargs:  dict
+                key-value pair of parameters to be passed to module.save
         """
 
         if not issubclass(module.__class__, ModuleBase):
@@ -247,13 +249,13 @@ class ModuleSaver:
 
         rel_path, abs_path = self.add_dir(relative_path)
         # Save this module at the specified location
-        module.save(abs_path)
+        module.save(abs_path, **kwargs)
         self.config.setdefault(ModuleLoader.MODULE_PATHS_KEY, {}).update(
             {relative_path: rel_path}
         )
         return rel_path, abs_path
 
-    def save_module_list(self, modules, config_key):
+    def save_module_list(self, modules, config_key, **kwargs):
         """Save a list of CaikitCore modules within a workflow artifact and add a reference to the
         config.
 
@@ -263,6 +265,9 @@ class ModuleSaver:
                 part of this workflow
             config_key (str): The config key inside of `model_path` where the
                 modules' relative path with be referenced
+            **kwargs:  dict
+                key-value pair of parameters to be passed to module.save
+
 
         Returns:
             list_of_rel_path: list(str)
@@ -293,7 +298,7 @@ class ModuleSaver:
             rel_path, abs_path = self.add_dir(relative_path)
 
             # Save this module at the specified location
-            module.save(abs_path)
+            module.save(abs_path, **kwargs)
 
             # append relative and absolute path to a list that will be returned
             list_of_rel_path.append(rel_path)

--- a/tests/core/modules/test_module.py
+++ b/tests/core/modules/test_module.py
@@ -138,14 +138,14 @@ def test_run_batch_keyword_only(model_path):
 
 
 def test_save_module(model_path):
-    dummy_block = caikit.core.load(model_path)
+    dummy_model = caikit.core.load(model_path)
 
     with tempfile.TemporaryDirectory() as tempdir:
         with ModuleSaver(
-            dummy_block,
+            dummy_model,
             model_path=tempdir,
         ) as module_saver:
-            module_saver.save_module(dummy_block, "dummy")
+            module_saver.save_module(dummy_model, "dummy")
 
             assert os.path.exists(os.path.join(tempdir, "dummy"))
             assert module_saver.config.get("module_paths") is not None
@@ -154,26 +154,26 @@ def test_save_module(model_path):
 
 def test_save_module_kwargs_get_piped_through(model_path):
     """Testing additional keywords passed to save_module are processed by the module"""
-    dummy_block = caikit.core.load(model_path)
+    dummy_model = caikit.core.load(model_path)
 
     with tempfile.TemporaryDirectory() as tempdir:
         with ModuleSaver(
-            dummy_block,
+            dummy_model,
             model_path=tempdir,
         ) as module_saver:
-            module_saver.save_module(dummy_block, "dummy", keyword=True)
-            saved_block = caikit.core.load(os.path.join(tempdir, "dummy"))
-            assert saved_block.metadata["test_keyword"]
+            module_saver.save_module(dummy_model, "dummy", keyword=True)
+            saved_model = caikit.core.load(os.path.join(tempdir, "dummy"))
+            assert saved_model.metadata["test_keyword"]
 
 
 def test_save_module_list(model_path):
-    """Test valid module list save with a list of syntax blocks."""
-    dummy_block = caikit.core.load(model_path)
-    dummy_models_with_rel_path = {"dummy_path": dummy_block}
+    """Test valid module list save with a list of models."""
+    dummy_model = caikit.core.load(model_path)
+    dummy_models_with_rel_path = {"dummy_path": dummy_model}
 
     with tempfile.TemporaryDirectory() as tempdir:
         with ModuleSaver(
-            dummy_block,
+            dummy_model,
             model_path=tempdir,
         ) as module_saver:
             list_of_rel_path, _ = module_saver.save_module_list(
@@ -191,20 +191,20 @@ def test_save_module_list(model_path):
 
 
 def test_save_module_list_kwargs_get_piped_through(model_path):
-    """Check that additional keywords passed to save_module_list are processed by the block"""
-    dummy_block = caikit.core.load(model_path)
-    dummy_models_with_rel_path = {"dummy_path": dummy_block}
+    """Check that additional keywords passed to save_module_list are processed by the module"""
+    dummy_model = caikit.core.load(model_path)
+    dummy_models_with_rel_path = {"dummy_path": dummy_model}
 
     with tempfile.TemporaryDirectory() as tempdir:
         with ModuleSaver(
-            dummy_block,
+            dummy_model,
             model_path=tempdir,
         ) as module_saver:
             module_saver.save_module_list(
                 dummy_models_with_rel_path, "dummy", keyword=True
             )
-            saved_block = caikit.core.load(os.path.join(tempdir, "dummy_path"))
-            assert saved_block.metadata["test_keyword"]
+            saved_model = caikit.core.load(os.path.join(tempdir, "dummy_path"))
+            assert saved_model.metadata["test_keyword"]
 
 
 ## ModuleConfig ################################################################

--- a/tests/core/modules/test_module.py
+++ b/tests/core/modules/test_module.py
@@ -21,7 +21,7 @@ import tempfile
 import aconfig
 
 # Local
-from caikit.core import ModuleConfig, ModuleLoader
+from caikit.core import ModuleConfig, ModuleLoader, ModuleSaver
 from caikit.core.modules.decorator import SUPPORTED_LOAD_BACKENDS_VAR_NAME
 
 # pylint: disable=import-error
@@ -132,6 +132,79 @@ def test_run_batch_keyword_only(model_path):
     dummy_model = caikit.core.load(model_path)
     dummy_model.run(sample_input=SampleInputType(name="Gabe"))
     dummy_model.run_batch(sample_input=[SampleInputType(name="Gabe")])
+
+
+## ModuleSaver ################################################################
+
+
+def test_save_module(model_path):
+    dummy_block = caikit.core.load(model_path)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with ModuleSaver(
+            dummy_block,
+            model_path=tempdir,
+        ) as module_saver:
+            module_saver.save_module(dummy_block, "dummy")
+
+            assert os.path.exists(os.path.join(tempdir, "dummy"))
+            assert module_saver.config.get("module_paths") is not None
+            assert module_saver.config.get("module_paths") == {"dummy": "./dummy"}
+
+
+def test_save_module_kwargs_get_piped_through(model_path):
+    """Testing additional keywords passed to save_module are processed by the module"""
+    dummy_block = caikit.core.load(model_path)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with ModuleSaver(
+            dummy_block,
+            model_path=tempdir,
+        ) as module_saver:
+            module_saver.save_module(dummy_block, "dummy", keyword=True)
+            saved_block = caikit.core.load(os.path.join(tempdir, "dummy"))
+            assert saved_block.metadata["test_keyword"]
+
+
+def test_save_module_list(model_path):
+    """Test valid module list save with a list of syntax blocks."""
+    dummy_block = caikit.core.load(model_path)
+    dummy_models_with_rel_path = {"dummy_path": dummy_block}
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with ModuleSaver(
+            dummy_block,
+            model_path=tempdir,
+        ) as module_saver:
+            list_of_rel_path, _ = module_saver.save_module_list(
+                dummy_models_with_rel_path, "dummy"
+            )
+            # Ensure that we only get one relative path back
+            assert len(list_of_rel_path) == 1
+            # And that if we split our path components up, get 2 parts...
+            saved_subpath = os.path.split(list_of_rel_path[0])
+            assert len(saved_subpath) == 2
+            # ...Where the first resolves to the relative path [no hierarchy expected here]
+            assert not saved_subpath[0].strip(".")
+            # ...And the second is the dummy_path we specified
+            assert saved_subpath[1] == "dummy_path"
+
+
+def test_save_module_list_kwargs_get_piped_through(model_path):
+    """Check that additional keywords passed to save_module_list are processed by the block"""
+    dummy_block = caikit.core.load(model_path)
+    dummy_models_with_rel_path = {"dummy_path": dummy_block}
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with ModuleSaver(
+            dummy_block,
+            model_path=tempdir,
+        ) as module_saver:
+            module_saver.save_module_list(
+                dummy_models_with_rel_path, "dummy", keyword=True
+            )
+            saved_block = caikit.core.load(os.path.join(tempdir, "dummy_path"))
+            assert saved_block.metadata["test_keyword"]
 
 
 ## ModuleConfig ################################################################

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -89,7 +89,7 @@ class SampleModule(caikit.core.ModuleBase):
         for sample_input in sample_inputs:
             yield self.run(sample_input)
 
-    def save(self, model_path):
+    def save(self, model_path, **kwargs):
         module_saver = ModuleSaver(
             self,
             model_path=model_path,
@@ -101,6 +101,8 @@ class SampleModule(caikit.core.ModuleBase):
                     "learning_rate": self.learning_rate,
                 },
             }
+            if "keyword" in kwargs:
+                config_options["test_keyword"] = True
 
             module_saver.update_config(config_options)
 


### PR DESCRIPTION


**What this PR does / why we need it**:
Both watson_nlp and caikit_nlp pass args to save in certain modules. 

**Special notes for your reviewer**:
Blocking other efforts, kindly prioritize
 
**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
