### PR TITLE
fix: change in function args order to _extract_pred_set

### DIFF
--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -677,7 +677,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
             NotImplementedError("This is not available in this module."),
         )
 
-    def _extract_pred_set(self, dataset, *args, preprocess_func=None, **kwargs):
+    def _extract_pred_set(self, dataset, preprocess_func=None, *args, **kwargs):
         """Method for extracting pred set from dataset. Implemented in subclass.
 
         Args:

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -677,7 +677,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
             NotImplementedError("This is not available in this module."),
         )
 
-    def _extract_pred_set(self, dataset, preprocess_func=None, *args, **kwargs):
+    def _extract_pred_set(self, dataset, preprocess_func=None, **kwargs):
         """Method for extracting pred set from dataset. Implemented in subclass.
 
         Args:
@@ -687,7 +687,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
                 steps that need to be taken to run the model on the input text.
                 This helper function ultimately leads to the input to this
                 module and may involve executing other modules.
-            *args, **kwargs (dict): Optional keyword arguments for prediction set extraction.
+            **kwargs (dict): Optional keyword arguments for prediction set extraction.
         Returns:
             list: List of labels in the format of the module_type that is being
                 called.


### PR DESCRIPTION
**What this PR does / why we need it**:
The proposed change is **original watson_core order** of function args and also what is specified in docstrings. changing order in caikit can cause weird behavior in downstreams unless we all change order of arguments, which is a huge change for nLP and unnecessary
 
**Special notes for your reviewer**:
blocking NLP rebase. There were no unit tests for these functions from the start, will be a larger effort to add for all these functions in module base. 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
