### PR TITLE
♻️  split training parameters

### DIFF
--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -77,7 +77,6 @@ from caikit.runtime.service_generation.rpcs import (
 from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
 from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
-import caikit
 
 ## Globals #####################################################################
 

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -602,7 +602,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
             return int
         if np.issubclass_(field_type, np.floating):
             return float
-        if field_type in (int, float, bool, str, bytes, type(None)):
+        if field_type in (int, float, bool, str, bytes, dict, type(None)):
             return field_type
         if isinstance(field_type, type) and issubclass(field_type, enum.Enum):
             return field_type
@@ -632,7 +632,10 @@ class RuntimeHTTPServer(RuntimeServerBase):
             return List[cls._get_pydantic_type(get_args(field_type)[0])]
 
         if get_origin(field_type) is dict:
-            return field_type
+            return Dict[
+                cls._get_pydantic_type(get_args(field_type)[0]),
+                cls._get_pydantic_type(get_args(field_type)[1]),
+            ]
 
         raise TypeError(f"Cannot get pydantic type for type [{field_type}]")
 

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -129,6 +129,15 @@ HEALTH_ENDPOINT = "/health"
 ## RuntimeHTTPServer ###########################################################
 
 
+# Base class for pydantic models
+# We want to set the config to forbid extra attributes
+# while instantiating any pydantic models
+# This is done to make sure any oneofs can be
+# correctly infered by pydantic
+class ParentPydanticBaseModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
 class RuntimeHTTPServer(RuntimeServerBase):
     """An implementation of a FastAPI server that serves caikit runtimes"""
 
@@ -660,9 +669,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 dm_class, localns=localns
             ).items()
         }
-        pydantic_model = type(pydantic.BaseModel)(
+        pydantic_model = type(ParentPydanticBaseModel)(
             dm_class.get_proto_class().DESCRIPTOR.full_name,
-            (pydantic.BaseModel,),
+            (ParentPydanticBaseModel,),
             {
                 "__annotations__": annotations,
                 **{

--- a/caikit/runtime/http_server.py
+++ b/caikit/runtime/http_server.py
@@ -602,9 +602,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
 
     @classmethod
     # pylint: disable=too-many-return-statements
-    def _get_pydantic_type(
-        cls, field_type: type, is_extra_forbid: bool = False
-    ) -> type:
+    def _get_pydantic_type(cls, field_type: type) -> type:
         """Recursive helper to get a valid pydantic type for every field type"""
         # pylint: disable=too-many-return-statements
 
@@ -625,36 +623,34 @@ class RuntimeHTTPServer(RuntimeServerBase):
             and not issubclass(field_type, pydantic.BaseModel)
         ):
             # NB: for data models we're calling the data model conversion fn
-            return cls._dataobject_to_pydantic(field_type, is_extra_forbid)
+            return cls._dataobject_to_pydantic(field_type)
 
         # And then all of these types can be nested in other type annotations
         if get_origin(field_type) is Annotated:
-            return cls._get_pydantic_type(get_args(field_type)[0], is_extra_forbid)
+            return cls._get_pydantic_type(get_args(field_type)[0])
         if get_origin(field_type) is Union:
             return Union[  # type: ignore
                 tuple(
                     (
-                        cls._get_pydantic_type(arg_type, is_extra_forbid)
+                        cls._get_pydantic_type(arg_type)
                         for arg_type in get_args(field_type)
                     )
                 )
             ]
         if get_origin(field_type) is list:
-            return List[
-                cls._get_pydantic_type(get_args(field_type)[0], is_extra_forbid)
-            ]
+            return List[cls._get_pydantic_type(get_args(field_type)[0])]
 
         if get_origin(field_type) is dict:
             return Dict[
-                cls._get_pydantic_type(get_args(field_type)[0], is_extra_forbid),
-                cls._get_pydantic_type(get_args(field_type)[1], is_extra_forbid),
+                cls._get_pydantic_type(get_args(field_type)[0]),
+                cls._get_pydantic_type(get_args(field_type)[1]),
             ]
 
         raise TypeError(f"Cannot get pydantic type for type [{field_type}]")
 
     @classmethod
     def _dataobject_to_pydantic(
-        cls, dm_class: Type[DataBase], is_extra_forbid: bool = False
+        cls, dm_class: Type[DataBase]
     ) -> Type[pydantic.BaseModel]:
         """Make a pydantic model based on the given proto message by using the data
         model class annotations to mirror as a pydantic model
@@ -667,24 +663,15 @@ class RuntimeHTTPServer(RuntimeServerBase):
         if dm_class in PYDANTIC_TO_DM_MAPPING:
             return PYDANTIC_TO_DM_MAPPING[dm_class]
 
-        annotations = {}
-        for field_name, field_type in get_type_hints(dm_class, localns=localns).items():
-            # if a field is a Union, then all sub-fields within it should also be
-            # using the ParentPydanticBaseModel
-            # This is because of the fact that using ParentPydanticBaseModel is the
-            # only way we've figured out to determine the right instance of the
-            # oneof value in pydantic.
-            # see https://github.com/pydantic/pydantic/discussions/7239
-            if get_origin(field_type) is Union:
-                is_extra_forbid = True
-            annotations[field_name] = cls._get_pydantic_type(
-                field_type=field_type, is_extra_forbid=is_extra_forbid
-            )
-        base_class = ParentPydanticBaseModel if is_extra_forbid else pydantic.BaseModel
-
-        pydantic_model = type(base_class)(
+        annotations = {
+            field_name: cls._get_pydantic_type(field_type)
+            for field_name, field_type in get_type_hints(
+                dm_class, localns=localns
+            ).items()
+        }
+        pydantic_model = type(ParentPydanticBaseModel)(
             dm_class.get_proto_class().DESCRIPTOR.full_name,
-            (base_class,),
+            (ParentPydanticBaseModel,),
             {
                 "__annotations__": annotations,
                 **{

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -31,6 +31,7 @@ import alog
 # Local
 from caikit import get_config
 from caikit.core import LocalBackend, ModuleBase, registries
+from caikit.core.data_model.dataobject import _AUTO_GEN_PROTO_CLASSES
 from caikit.interfaces.runtime.data_model import (
     TrainingInfoRequest,
     TrainingStatusResponse,
@@ -150,9 +151,9 @@ class ServicePackageFactory:
             "Package with service message class implementations",
         )
 
-        for dm_class in request_data_models:
-            # We need the message class that data model serializes to
-            setattr(client_module, dm_class.__name__, type(dm_class().to_proto()))
+        for proto_class in _AUTO_GEN_PROTO_CLASSES:
+            # We need all the DM objects in the client_module for ease of use
+            setattr(client_module, proto_class.DESCRIPTOR.name, proto_class)
 
         rpc_jsons = [rpc.create_rpc_json(package_name) for rpc in rpc_list]
         service_json = {"service": {"rpcs": rpc_jsons}}

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -142,9 +142,8 @@ class ServicePackageFactory:
 
         rpc_list = [rpc for rpc in rpc_list if rpc.return_type is not None]
 
-        request_data_models = [
-            rpc.create_request_data_model(package_name) for rpc in rpc_list
-        ]
+        for rpc in rpc_list:
+            rpc.create_request_data_model(package_name)
 
         client_module = ModuleType(
             "ClientMessages",

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -125,7 +125,7 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         # Build the inner request data model
         inner_request_data_model = self._inner_request.create_data_model(package_name)
         # Insert the new type into the outer request
-        for triple_index in range(len(self._req.triples)):
+        for triple_index, _ in enumerate(self._req.triples):
             if self._req.triples[triple_index][1] == "parameters":
                 triple = self._req.triples[triple_index]
                 self._req.triples[triple_index] = (

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -63,33 +63,7 @@ class CaikitRPCBase(abc.ABC):
 
     def create_request_data_model(self, package_name: str) -> Type[DataBase]:
         """Dynamically create data model for this RPC's request message"""
-        properties = {
-            # triple e.g. ('caikit.interfaces.common.ProducerPriority', 'producer_id', 1)
-            # This does not take care of nested descriptors
-            triple[1]: Annotated[triple[0], FieldNumber(triple[2])]
-            for triple in self.request.triples
-            if triple[1] not in self.request.default_map
-        }
-        optional_properties = {
-            triple[1]: Annotated[Optional[triple[0]], FieldNumber(triple[2])]
-            for triple in self.request.triples
-            if triple[1] in self.request.default_map
-        }
-        attrs = copy.copy(self.request.default_map)
-
-        if not properties and not optional_properties:
-            log.warning(
-                "No arguments found for request %s. Cannot generate rpc",
-                self.request.name,
-            )
-            return None
-
-        return make_dataobject(
-            package=package_name,
-            name=self.request.name,
-            attrs=attrs,
-            annotations={**properties, **optional_properties},
-        )
+        return self.request.create_data_model(package_name)
 
     def create_rpc_json(self, package_name: str) -> Dict:
         """Return json snippet for the service definition of this RPC"""
@@ -128,10 +102,40 @@ class ModuleClassTrainRPC(CaikitRPCBase):
 
         # Store the input and output protobuf message types for this RPC
         self.return_type = self._method.return_type
-        self._req = _RequestMessage(
-            ModuleClassTrainRPC.module_class_to_req_name(self.clz),
+
+        # Inner / outer requests
+        # The actual training parameters from the method signature are nested under `parameters`
+        self._inner_request = _RequestMessage(
+            ModuleClassTrainRPC.module_class_to_inner_request_name(self.clz),
             self._method.parameters,
             self._method.default_parameters,
+        )
+
+        params = {"model_name": str, "output_path": S3Path, "parameters": "PLACEHOLDER"}
+
+        self._req = _RequestMessage(
+            ModuleClassTrainRPC.module_class_to_req_name(self.clz),
+            params,
+            {},
+        )
+
+    def create_request_data_model(self, package_name: str):
+        """Partial override of CaikitRPCBase.create_request_data_model to take care of the inner
+        request data model"""
+        # Build the inner request data model
+        inner_request_data_model = self._inner_request.create_data_model(package_name)
+        # Insert the new type into the outer request
+        for triple_index in range(len(self._req.triples)):
+            if self._req.triples[triple_index][1] == "parameters":
+                triple = self._req.triples[triple_index]
+                self._req.triples[triple_index] = (
+                    inner_request_data_model,
+                    triple[1],
+                    triple[2],
+                )
+        # Call the base class' method
+        return CaikitRPCBase.create_request_data_model(
+            self=self, package_name=package_name
         )
 
     @property
@@ -165,16 +169,25 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         return f"{ModuleClassTrainRPC.module_class_to_rpc_name(module_class)}Request"
 
     @staticmethod
+    def module_class_to_inner_request_name(module_class: Type[ModuleBase]) -> str:
+        """Helper function to convert from a module to the name of the inner message
+        containing all the training parameters
+
+        Example: self.clz._module__ = sample_lib.modules.sample_task.sample_implementation
+
+        return: SampleTaskSampleModuleTrainParameters
+        """
+        return f"{ModuleClassTrainRPC.module_class_to_rpc_name(module_class)}Parameters"
+
+    @staticmethod
     def _mutate_method_signature_for_training(
         signature: CaikitMethodSignature,
     ) -> Optional[CaikitMethodSignature]:
         # Change return type for async training interface
         return_type = TrainingJob
 
-        # Start with extra metaparameters
-        # - model_name: user-provided custom ID for the model to train
-        # - output_path: pointer to some storage where the model will be saved
-        new_params = {"model_name": str, "output_path": S3Path}
+        # Loop through params and edit as needed
+        new_params = {}
         for name, typ in signature.parameters.items():
             if type_helpers.has_data_stream(typ):
                 # Assume this is training data
@@ -387,3 +400,33 @@ class _RequestMessage:
             self.triples.append((typ, item_name, num))
 
         self.triples.sort(key=lambda x: x[2])
+
+    def create_data_model(self, package_name: str) -> Type[DataBase]:
+        """Dynamically create a data model for this request message"""
+        properties = {
+            # triple e.g. ('caikit.interfaces.common.ProducerPriority', 'producer_id', 1)
+            # This does not take care of nested descriptors
+            triple[1]: Annotated[triple[0], FieldNumber(triple[2])]
+            for triple in self.triples
+            if triple[1] not in self.default_map
+        }
+        optional_properties = {
+            triple[1]: Annotated[Optional[triple[0]], FieldNumber(triple[2])]
+            for triple in self.triples
+            if triple[1] in self.default_map
+        }
+        attrs = copy.copy(self.default_map)
+
+        if not properties and not optional_properties:
+            log.warning(
+                "No arguments found for request %s. Cannot generate rpc",
+                self.name,
+            )
+            return None
+
+        return make_dataobject(
+            package=package_name,
+            name=self.name,
+            attrs=attrs,
+            annotations={**properties, **optional_properties},
+        )

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -213,7 +213,9 @@ class GlobalTrainServicer:
                 "save_path": model_path,
                 "save_with_id": self.save_with_id,
                 "model_name": request_data_model.model_name,
-                **build_caikit_library_request_dict(request, module.TRAIN_SIGNATURE),
+                **build_caikit_library_request_dict(
+                    request.parameters, module.TRAIN_SIGNATURE
+                ),
             }
         )
 

--- a/caikit/runtime/servicers/model_train_servicer.py
+++ b/caikit/runtime/servicers/model_train_servicer.py
@@ -95,7 +95,7 @@ class ModelTrainServicerImpl(process_pb2_grpc.ProcessServicer):
             )
             # update any file references relative to the training input dir
             self._update_file_references(
-                train_message_request, request.training_input_dir
+                train_message_request.parameters, request.training_input_dir
             )
 
             # make the train call

--- a/tests/runtime/service_generation/test_rpcs.py
+++ b/tests/runtime/service_generation/test_rpcs.py
@@ -263,13 +263,9 @@ def test_module_train_rpc():
     assert hasattr(data_model, "output_path")
     assert hasattr(data_model, "parameters")
 
-    training_message = data_model.from_json({
-        "model_name": "any_model_name",
-        "parameters": {
-            "int_val": 1,
-            "str_val": "foo"
-        }
-    })
+    training_message = data_model.from_json(
+        {"model_name": "any_model_name", "parameters": {"int_val": 1, "str_val": "foo"}}
+    )
 
     assert training_message.parameters.int_val == 1
     assert training_message.parameters.str_val == "foo"

--- a/tests/runtime/service_generation/test_rpcs.py
+++ b/tests/runtime/service_generation/test_rpcs.py
@@ -257,3 +257,19 @@ def test_module_train_rpc():
     assert data_model is not None
 
     assert rpc.name == "TestTaskTestModuleTrain"
+
+    # Training RPCs nest the actual training params from the `.train` signature
+    assert hasattr(data_model, "model_name")
+    assert hasattr(data_model, "output_path")
+    assert hasattr(data_model, "parameters")
+
+    training_message = data_model.from_json({
+        "model_name": "any_model_name",
+        "parameters": {
+            "int_val": 1,
+            "str_val": "foo"
+        }
+    })
+
+    assert training_message.parameters.int_val == 1
+    assert training_message.parameters.str_val == "foo"

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -98,8 +98,10 @@ def test_global_train_sample_task(
     model_name = random_test_id()
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=model_name,
-        batch_size=42,
-        training_data=training_data,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            batch_size=42,
+            training_data=training_data,
+        ),
     )
 
     training_response = sample_train_servicer.Train(
@@ -159,9 +161,11 @@ def test_global_train_other_task(
     training_data = stream_type(jsondata=stream_type.JsonData(data=[1])).to_proto()
     train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
         model_name="Other module Training",
-        training_data=training_data,
-        sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
-        batch_size=batch_size,
+        parameters=sample_train_service.messages.OtherTaskOtherModuleTrainParameters(
+            training_data=training_data,
+            sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
+            batch_size=batch_size,
+        ),
     )
 
     training_response = sample_train_servicer.Train(
@@ -212,11 +216,11 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_no
         model_id=sample_task_model_id
     ).to_proto()
 
-    training_request = (
-        sample_train_service.messages.SampleTaskCompositeModuleTrainRequest(
-            model_name="AnotherWidget_Training",
+    training_request = sample_train_service.messages.SampleTaskCompositeModuleTrainRequest(
+        model_name="AnotherWidget_Training",
+        parameters=sample_train_service.messages.SampleTaskCompositeModuleTrainParameters(
             sample_block=sample_model,
-        )
+        ),
     )
 
     training_response = sample_train_servicer.Train(
@@ -268,8 +272,10 @@ def test_run_train_job_works_with_wait(
     ).to_proto()
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=random_test_id(),
-        batch_size=42,
-        training_data=training_data,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            batch_size=42,
+            training_data=training_data,
+        ),
     )
     servicer = GlobalTrainServicer(training_service=sample_train_service)
     with TemporaryDirectory() as tmp_dir:
@@ -317,7 +323,9 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_but_not_loaded_s
     ).to_proto()
     request = sample_train_service.messages.SampleTaskCompositeModuleTrainRequest(
         model_name="AnotherWidget_Training",
-        sample_block=sample_model,
+        parameters=sample_train_service.messages.SampleTaskCompositeModuleTrainParameters(
+            sample_block=sample_model,
+        ),
     )
 
     with pytest.raises(CaikitRuntimeException) as context:
@@ -337,8 +345,10 @@ def test_global_train_Edge_Case_Widget_should_raise_when_error_surfaces_from_mod
 
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=random_test_id(),
-        batch_size=999,
-        training_data=training_data,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            batch_size=999,
+            training_data=training_data,
+        ),
     )
 
     training_response = sample_train_servicer.Train(
@@ -362,9 +372,11 @@ def test_global_train_returns_exit_code_with_oom(
     ).to_proto()
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=random_test_id(),
-        batch_size=42,
-        training_data=training_data,
-        oom_exit=True,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            batch_size=42,
+            training_data=training_data,
+            oom_exit=True,
+        ),
     )
 
     # Enable sub-processing for test
@@ -391,9 +403,11 @@ def test_local_trainer_rejects_s3_output_paths(
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=random_test_id(),
         output_path=S3Path(path="foo").to_proto(),
-        batch_size=42,
-        training_data=training_data,
-        oom_exit=True,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            batch_size=42,
+            training_data=training_data,
+            oom_exit=True,
+        ),
     )
 
     with pytest.raises(
@@ -420,9 +434,11 @@ def test_global_train_aborts_long_running_trains(
 
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=training_id,
-        batch_size=42,
-        training_data=training_data,
-        oom_exit=False,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            batch_size=42,
+            training_data=training_data,
+            oom_exit=False,
+        ),
     )
 
     if sample_train_servicer.use_subprocess:
@@ -468,7 +484,6 @@ def test_global_train_aborts_long_running_trains(
         f"{SampleModule.__module__}.{SampleModule.train.__qualname__}",
         never_respond,
     ):
-
         train_thread.start()
         # NB: assert is here to make sure we called the patched train
         assert test_event.wait(test_event_timeout)

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -91,7 +91,7 @@ def test_model_train_no_train_module_raises(sample_model_train_servicer, output_
         trainingID=training_id,
         customTrainingID=str(uuid.uuid4()),
         request_dict={
-            "training_params": '{"model_name": "abc", "training_data": [1]}',
+            "training_params": '{"model_name": "abc", "parameters": {"training_data": [1]}}',
         },
         training_input_dir="training_input_dir",
         training_output_dir=os.path.join(output_dir, training_id),
@@ -110,7 +110,7 @@ def test_model_train_incorrect_train_params_raises(
         customTrainingID=str(uuid.uuid4()),
         request_dict={
             "train_module": "00110203-0405-0607-0809-0a0b02dd0e0f",
-            "training_params": '{"model_name": "abc", "training_data": "blah"}',
+            "training_params": '{"model_name": "abc", "parameters": {"training_data": "blah"}}',
         },
         training_input_dir="training_input_dir",
         training_output_dir=os.path.join(output_dir, training_id),
@@ -150,7 +150,7 @@ def test_model_train_incorrect_train_request_raises(
         customTrainingID=str(uuid.uuid4()),
         request_dict={
             "train_module": "00110203-0405-0607-0809-0a0b02dd0e0f",
-            "training_params": '{"model_name": "abc", "training_data": [1]}',
+            "training_params": '{"model_name": "abc", "parameters": {"training_data": [1]}}',
         },
         training_input_dir="training_input_dir",
         training_output_dir=os.path.join(output_dir, training_id),
@@ -173,7 +173,7 @@ def test_model_train_validation_error_raises(sample_model_train_servicer, output
         customTrainingID=str(uuid.uuid4()),
         request_dict={
             "train_module": "00110203-0405-0607-0809-0a0b02dd0e0f",
-            "training_params": '{"model_name": "abc", "training_data": [1], "batch_size": 999}',
+            "training_params": '{"model_name": "abc", "parameters": {"training_data": [1], "batch_size": 999}}',
         },
         training_input_dir="training_input_dir",
         training_output_dir=os.path.join(output_dir, training_id),
@@ -197,13 +197,15 @@ def test_model_train_sample_widget(sample_model_train_servicer, output_dir):
             "training_params": json.dumps(
                 {
                     "model_name": "abc",
-                    "training_data": {
-                        "jsondata": {
-                            "data": [
-                                sample_lib.data_model.SampleTrainingType(
-                                    number=1
-                                ).to_dict()
-                            ]
+                    "parameters": {
+                        "training_data": {
+                            "jsondata": {
+                                "data": [
+                                    sample_lib.data_model.SampleTrainingType(
+                                        number=1
+                                    ).to_dict()
+                                ]
+                            },
                         },
                     },
                 }
@@ -253,9 +255,11 @@ def test_files_from_training_input_dir_are_used(
             "training_params": json.dumps(
                 {
                     "model_name": "abc",
-                    "training_data": {
-                        "file": {
-                            "filename": input_file_name  # This is relative to training_input_dir
+                    "parameters": {
+                        "training_data": {
+                            "file": {
+                                "filename": input_file_name  # This is relative to training_input_dir
+                            },
                         },
                     },
                 }

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -306,7 +306,7 @@ def test_build_dm_object_datastream_file(runtime_http_server):
         datastream_dm_class
     )
 
-    # build our DM Datastream JsonData object using a pydantic object
+    # build our DM Datastream File object using a pydantic object
     datastream_dm_obj = runtime_http_server._build_dm_object(
         datastream_pydantic_model(data_stream={"filename": "hello"})
     )
@@ -315,21 +315,6 @@ def test_build_dm_object_datastream_file(runtime_http_server):
     assert isinstance(datastream_dm_obj, DataBase)
     assert isinstance(datastream_dm_obj.data_stream, File)
     assert datastream_dm_obj.to_json() == '{"file": {"filename": "hello"}}'
-
-    # file_datastream_dm_class = DataBase.get_class_for_name("File")
-    # file_datastream_pydantic_model = http_server.PYDANTIC_TO_DM_MAPPING.get(
-    #     file_datastream_dm_class
-    # )
-    # file_pydantic_obj = file_datastream_pydantic_model.model_validate_json(
-    #     '{"filename" : "hello"}'
-    # )
-    # f = datastream_pydantic_model(data_stream=file_pydantic_obj)
-    # f.model_dump_json()
-    # # '{"data_stream":{"filename":"hello"}}'
-    # # datastream_pydantic_model.model_validate_json('{"data_stream":{"filename":"hello"}}')
-    # assert f == datastream_pydantic_model.model_validate_json(f.model_dump_json())
-    # why this no work???
-    # caikit_data_model.runtime.DataStreamSourceSampleTrainingType(data_stream=caikit_data_model.runtime.DataStreamSourceSampleTrainingTypeJsonData(data=None))
 
 
 @pytest.mark.parametrize(
@@ -535,7 +520,6 @@ def test_health_check_ok(runtime_http_server):
         assert response.text == "OK"
 
 
-@pytest.mark.skip()
 def test_http_server_shutdown_with_model_poll(open_port):
     """Test that a SIGINT successfully shuts down the running server"""
     with tempfile.TemporaryDirectory() as workdir:

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -295,11 +295,14 @@ def test_global_train_build_caikit_library_request_dict_strips_empty_list_from_r
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(jsondata=stream_type.JsonData(data=[])).to_proto()
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
-        model_name=random_test_id(), training_data=training_data
+        model_name=random_test_id(),
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            training_data=training_data
+        ),
     )
 
     caikit.core_request = build_caikit_library_request_dict(
-        train_request,
+        train_request.parameters,
         sample_lib.modules.sample_task.SampleModule.TRAIN_SIGNATURE,
     )
 
@@ -319,12 +322,15 @@ def test_global_train_build_caikit_library_request_dict_works_for_repeated_field
     training_data = stream_type(jsondata=stream_type.JsonData(data=[])).to_proto()
     train_request = sample_train_service.messages.SampleTaskListModuleTrainRequest(
         model_name=random_test_id(),
-        training_data=training_data,
-        poison_pills=["Bob Marley", "Bunny Livingston"],
+        parameters=sample_train_service.messages.SampleTaskListModuleTrainParameters(
+            training_data=training_data,
+            poison_pills=["Bob Marley", "Bunny Livingston"],
+        ),
     )
 
     caikit.core_request = build_caikit_library_request_dict(
-        train_request, sample_lib.modules.sample_task.ListModule.TRAIN_SIGNATURE
+        train_request.parameters,
+        sample_lib.modules.sample_task.ListModule.TRAIN_SIGNATURE,
     )
 
     # model_name is not expected to be passed through
@@ -346,12 +352,14 @@ def test_global_train_build_caikit_library_request_dict_ok_with_DataStreamSource
 
     train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
         model_name="Bar Training",
-        sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
-        batch_size=100,
-        training_data=training_data,
+        parameters=sample_train_service.messages.OtherTaskOtherModuleTrainParameters(
+            sample_input_sampleinputtype=SampleInputType(name="Gabe").to_proto(),
+            batch_size=100,
+            training_data=training_data,
+        ),
     )
     caikit.core_request = build_caikit_library_request_dict(
-        train_request,
+        train_request.parameters,
         sample_lib.modules.other_task.OtherModule.TRAIN_SIGNATURE,
     )
 
@@ -371,11 +379,13 @@ def test_global_train_build_caikit_library_request_dict_ok_with_data_stream_file
     ).to_proto()
     train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
         model_name=random_test_id(),
-        training_data=training_data,
+        parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
+            training_data=training_data,
+        ),
     )
 
     caikit.core_request = build_caikit_library_request_dict(
-        train_request,
+        train_request.parameters,
         sample_lib.modules.sample_task.SampleModule.TRAIN_SIGNATURE,
     )
 
@@ -395,12 +405,14 @@ def test_global_train_build_caikit_library_request_dict_ok_with_training_data_as
     ).to_proto()
     train_request = sample_train_service.messages.SampleTaskListModuleTrainRequest(
         model_name=random_test_id(),
-        training_data=training_data,
-        poison_pills=["Bob Marley", "Bunny Livingston"],
+        parameters=sample_train_service.messages.SampleTaskListModuleTrainParameters(
+            training_data=training_data,
+            poison_pills=["Bob Marley", "Bunny Livingston"],
+        ),
     )
 
     caikit.core_request = build_caikit_library_request_dict(
-        train_request,
+        train_request.parameters,
         sample_lib.modules.sample_task.ListModule.TRAIN_SIGNATURE,
     )
 
@@ -431,15 +443,15 @@ def test_build_caikit_library_request_dict_works_when_data_stream_directory_incl
         training_data = stream_type(
             directory=stream_type.Directory(dirname=tempdir, extension="json")
         ).to_proto()
-        train_request = (
-            sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
-                model_name=random_test_id(),
+        train_request = sample_train_service.messages.SampleTaskSampleModuleTrainRequest(
+            model_name=random_test_id(),
+            parameters=sample_train_service.messages.SampleTaskSampleModuleTrainParameters(
                 training_data=training_data,
-            )
+            ),
         )
 
         # no error because at least 1 json file exists within the provided dir
         caikit.core_request = build_caikit_library_request_dict(
-            train_request,
+            train_request.parameters,
             sample_lib.modules.sample_task.SampleModule.TRAIN_SIGNATURE,
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

POC for #369 

**Special notes for your reviewer**:

This updates the training RPC to manage an inner and outer request message, and it seems to work pretty slick.
cc @gabe-l-hart, @gkumbhat and @prashantgupta24 I think this'll work if we wanted to rip the bandaid on doing this nesting so we can have the pydantic apis convert these data models directly on the http side as discussed.

Open problem now is getting the caikit user access to the inner data model type so they can construct one of these messages directly. But running via compiled protobuf or REST that won't be an issue.

> Update - the `client_module` has been updated to incorporate ALL DM objects, so that unit tests as well as users can fetch the inner Proto message from it.

## Additional context

Pending pydantic investigation: https://github.com/pydantic/pydantic/discussions/7239 - thinking what to do about `forward-compatibility` - right now adding `extra_forbid` on all `pydantic models` has the unindented consequence that we won't be able to pass in anything that's not in the pydantic model, which means if the clients update before the server does, they won't work.

One quick workaround was to only attach `extra_forbid` to DMs that are a `Union`, but then if we first come across a data model used in a non-union context, and then later it is used within a union, then we would only create the pydantic data model without the `extra_forbid` bit, which is incorrect.

Tracking forward-compatibility issue here: https://github.com/caikit/caikit/issues/450

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [] this PR has been tested for backwards compatibility
