### PR TITLE
Don't overwrite the __repr__ with dataclass and fix HTTP output format

### DIFF
--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -200,7 +200,7 @@ def dataobject(*args, **kwargs) -> Callable[[_DataObjectBaseT], _DataObjectBaseT
             if _has_dataclass_init(cls):
                 log.debug3("Resetting default dataclass init")
                 delattr(cls, "__init__")
-            cls = dataclasses.dataclass(cls)
+            cls = dataclasses.dataclass(repr=False)(cls)
             setattr(cls, _USER_DEFINED_DEFAULTS, user_defined_defaults)
 
         descriptor = _dataobject_to_proto(dataclass_=cls, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ runtime-grpc = [
 ]
 
 runtime-http = [
-    "fastapi[all]>=0.95,<1",
+    "fastapi[all]>=0.100,<1",
     "sse-starlette>=1.6.1,<2",
 ]
 

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -1129,3 +1129,29 @@ def test_make_dataobject_with_optionals():
     assert data_object.prop == "val"
     assert data_object._proto_class.DESCRIPTOR.name == "SomeOtherFooBar"
     assert data_object._proto_class.DESCRIPTOR.file.package == "foo.bar.baz"
+
+
+def test_dataobject_repr_data_base():
+    """Make sure that the __repr__ on a dataobject uses DataBase.__repr__"""
+
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: int
+
+    inst = Foo(1)
+    assert repr(inst) == DataBase.__repr__(inst)
+
+
+def test_dataobject_custom_repr():
+    """Make sure that a dataobject with a custom __repr__ retains it"""
+    custom_repr = "so custom!"
+
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: int
+
+        def __repr__(self):
+            return custom_repr
+
+    inst = Foo(1)
+    assert repr(inst) == custom_repr

--- a/tests/runtime/test_http_server.py
+++ b/tests/runtime/test_http_server.py
@@ -373,12 +373,17 @@ def test_inference_streaming_sample_module(sample_task_model_id, runtime_http_se
             json=json_input,
         )
         assert stream.status_code == 200
-        assert (
-            stream.content.decode(stream.default_encoding).count("SampleOutputType")
-            == 10
+        stream_content = stream.content.decode(stream.default_encoding)
+        stream_responses = json.loads(
+            "[{}]".format(
+                stream_content.replace("data: ", "")
+                .replace("\r\n", "")
+                .replace("}{", "}, {")
+            )
         )
-        assert (
-            b"SampleOutputType(greeting='Hello world stream')\r\n\r\n" in stream.content
+        assert len(stream_responses) == 10
+        assert all(
+            resp.get("greeting") == "Hello world stream" for resp in stream_responses
         )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #437 

This PR also stumbled on a fuuuun bug: We were never checking the output format of server-side streaming with SSE. Turns out it was just calling `__repr__` on each yielded data object which was returning as `"MyDataObject(foo=1)"` rather than the `json` version `{"foo": 1}`. This made the HTTP output stream virtually useless! Updating the base `__repr__` fixes this, so this PR also fixes the test for server side checking to make sure the output is `json` parsable.
