### PR TITLE
🐛  ServerBootLogMessage: Use the right config path in the log message!

### DIFF
--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -211,7 +211,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
             "<RUN10001001I>",
             "Caikit Runtime is serving on port: %s with thread pool size: %s",
             self.port,
-            self.config.runtime.server_thread_pool_size,
+            self.config.runtime.grpc.server_thread_pool_size,
         )
 
         if blocking:


### PR DESCRIPTION
**What this PR does / why we need it**:

When we added the `runtime.grpc` level of indentation in config for the `grpc/http` split, we missed this log message!