### PR TITLE
Oneof fix

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -670,11 +670,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
             if field in cls._fields_primitive or field in cls._fields_enum:
                 # special case for oneofs
                 if field not in cls._fields_to_oneof or proto.HasField(field):                    
-                    if proto.HasField(field): # this is a union type
-                        oneof = cls._fields_to_oneof.get(field)
-                        kwargs[oneof] = proto_attr
-                    else:
-                        kwargs[field] = proto_attr
+                    kwargs[field] = proto_attr
             elif (
                 field in cls._fields_primitive_repeated
                 or field in cls._fields_enum_repeated

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -902,7 +902,11 @@ class DataBase(metaclass=_DataBaseMetaClass):
         to_dict = {}
         for field in fields_to_dict:
             dict_value = self._field_to_dict_element(field)
-            if field.endswith("_sequence") and "values" not in dict_value:
+            if (
+                field in self._fields_to_oneof
+                and not hasattr(dict_value, "values")
+                and isinstance(dict_value, list)
+            ):
                 dict_value = {"values": dict_value}
             to_dict[field] = dict_value
         return to_dict

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -554,9 +554,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
         """
         # NOTE: The list of field names are guaranteed to be sorted so that
         #   bool < int < float
-        log.debug4("in _infer_which_oneof, cls._fields_oneofs_map is: %s", cls._fields_oneofs_map)
         for field_name in cls._fields_oneofs_map.get(oneof_name, []):
-            log.debug4("in _infer_which_oneof, field_name is: %s", field_name)
             if cls._is_valid_type_for_field(field_name, oneof_val):
                 return field_name
 
@@ -666,17 +664,14 @@ class DataBase(metaclass=_DataBaseMetaClass):
                     ),
                 )
 
-            log.debug4("ANGEL DEBUG: from_proto for field %s", field)
             if field in cls._fields_primitive or field in cls._fields_enum:
                 # special case for oneofs
-                if field not in cls._fields_to_oneof or proto.HasField(field):                    
+                if field not in cls._fields_to_oneof or proto.HasField(field):
                     kwargs[field] = proto_attr
             elif (
                 field in cls._fields_primitive_repeated
                 or field in cls._fields_enum_repeated
             ):
-                log.debug4("ANGEL DEBUG, inside block _fields_primitive_repeated, and field is: %s", field)
-                log.debug4("ANGEL DEBUG, kwargs are: %s", kwargs)
                 kwargs[field] = list(proto_attr)
 
             elif field in cls._fields_map:
@@ -692,8 +687,6 @@ class DataBase(metaclass=_DataBaseMetaClass):
                         kwargs[field][key] = value
 
             elif field in cls._fields_message:
-                log.debug4("ANGEL DEBUG, inside block _fields_message, and field is: %s", field)
-                log.debug4("ANGEL DEBUG, kwargs are: %s", kwargs)
                 if proto.HasField(field):
                     if (
                         proto_attr.DESCRIPTOR.full_name
@@ -738,8 +731,6 @@ class DataBase(metaclass=_DataBaseMetaClass):
                         "repeated".format(field)
                     ),
                 )
-
-            log.debug4("ANGEL DEBUG, end of from_proto, kwargs are: %s", kwargs)
 
         return cls(**kwargs)
 
@@ -864,7 +855,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
                     seq_dm = subproto.__class__
                     try:
                         subproto.CopyFrom(seq_dm(values=attr))
-                        log.debug4("Successfully fill proto for", field)
+                        log.debug4("Successfully fill proto for %s", field)
                     except TypeError:
                         log.debug4("not the correct union list type")
                 else:

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -580,8 +580,12 @@ class DataBase(metaclass=_DataBaseMetaClass):
                 log.info("Assuming the type is valid since list is empty")
                 return True
 
-            val_list_type = type(val[0]).__name__ 
-            return field_descriptor.message_type and f"{val_list_type}" in field_descriptor.message_type.full_name.lower()
+            val_list_type = type(val[0]).__name__
+            return (
+                field_descriptor.message_type
+                and f"{val_list_type}"
+                in field_descriptor.message_type.full_name.lower()
+            )
 
         # If it's a data object or an enum and the descriptors match, it's a
         # good type
@@ -699,11 +703,10 @@ class DataBase(metaclass=_DataBaseMetaClass):
                     ):
                         kwargs[field] = timestamp.proto_to_datetime(proto_attr)
                     elif proto_attr.DESCRIPTOR.full_name.endswith("Sequence"):
-                        # "foo_bar_int_sequence" has original field name "foo_bar"
-                        original_field_name = "_".join(field.split("_")[:-2])
+                        oneof = cls._fields_to_oneof[field]
                         contained_class = cls.get_class_for_proto(proto_attr)
                         contained_obj = contained_class.from_proto(proto_attr)
-                        kwargs[original_field_name] = getattr(contained_obj, "values")
+                        kwargs[oneof] = getattr(contained_obj, "values")
                     else:
                         contained_class = cls.get_class_for_proto(proto_attr)
                         contained_obj = contained_class.from_proto(proto_attr)

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -575,13 +575,13 @@ class DataBase(metaclass=_DataBaseMetaClass):
             return False
 
         # If val is a list, this maybe a union of list field
-        if isinstance(val, list) and field_name.endswith("_sequence"):
+        if isinstance(val, list) and field_name in cls._fields_to_oneof:
             if len(val) == 0:
                 log.info("Assuming the type is valid since list is empty")
                 return True
 
-            list_type = type(val[0]).__name__
-            return f"{list_type}_sequence" in field_name
+            val_list_type = type(val[0]).__name__ 
+            return field_descriptor.message_type and f"{val_list_type}" in field_descriptor.message_type.full_name.lower()
 
         # If it's a data object or an enum and the descriptors match, it's a
         # good type

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -667,18 +667,18 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
-    # assert foo1.to_dict() == {"myfoointseq": {"values": [2]}}
-    # assert foo2.to_dict() == {"myfoointseq": {"values": [2]}}
-    # assert foo3.to_dict() == {"myfoostrseq": {"values": ["hello"]}}
-    # assert foo4.to_dict() == {"myfoointseq": {"values": [2]}}
+    assert foo1.to_dict() == {"myfoointseq": {"values": [2]}}
+    assert foo2.to_dict() == {"myfoointseq": {"values": [2]}}
+    assert foo3.to_dict() == {"myfoostrseq": {"values": ["hello"]}}
+    assert foo4.to_dict() == {"myfoostrseq": {"values": ["hello"]}}
 
     # json round trip
     json_repr_foo = foo1.to_json()
-    # assert json.loads(json_repr_foo) == {
-    #     "myfoointseq": {"values": [2]},
-    # }
+    assert json.loads(json_repr_foo) == {
+        "myfoointseq": {"values": [2]},
+    }
 
-    # assert Foo.from_json(json_repr_foo) == foo1
+    assert Foo.from_json(json_repr_foo) == foo1
 
 
 def test_dataobject_list_oneof_round_trips_with_no_custom_names():

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -601,7 +601,7 @@ def test_dataobject_primitive_oneof_round_trips_no_custom_name():
     assert foo1.which_oneof("foo") == "foo_int"
     proto_repr_foo = foo1.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
-    
+
     # proto round trip for Foo with oneof name
     foo2 = Foo(foo=2)
     assert foo2.which_oneof("foo") == "foo_int"
@@ -638,32 +638,47 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
     @dataobject
     class Foo(DataObjectBase):
         foo: Union[
-            Annotated[List[int], FieldNumber(10), OneofField("foointseq")],
-            Annotated[List[str], FieldNumber(20), OneofField("foostrseq")],
+            Annotated[List[int], FieldNumber(10), OneofField("myfoointseq")],
+            Annotated[List[str], FieldNumber(20), OneofField("myfoostrseq")],
         ]
 
-    # proto round trip
+    # proto round trip for Foo with no param name
     foo1 = Foo([2])
-    assert foo1.which_oneof("foo") == "foointseq"
+    assert foo1.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo1.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    # proto round trip for Foo with oneof param name
     foo2 = Foo(foo=[2])
-    assert foo2.which_oneof("foo") == "foointseq"
+    # assert foo2.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo2.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    # proto round trip for Foo with no param name
+    foo3 = Foo(["hello"])
+    # assert foo3.which_oneof("foo") == "myfoostrseq"
+    proto_repr_foo = foo3.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # proto round trip for Foo with field name
+    # foo4 = Foo(myfoostrseq=["hello"])
+    # assert foo4.which_oneof("foo") == "myfoostrseq"
+    # proto_repr_foo = foo4.to_proto()
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
     # dict test
-    assert foo1.to_dict() == {"foointseq": {"values": [2]}}
+    # assert foo1.to_dict() == {"myfoointseq": {"values": [2]}}
+    # assert foo2.to_dict() == {"myfoointseq": {"values": [2]}}
+    # assert foo3.to_dict() == {"myfoostrseq": {"values": ["hello"]}}
+    # assert foo4.to_dict() == {"myfoointseq": {"values": [2]}}
 
     # json round trip
     json_repr_foo = foo1.to_json()
-    assert json.loads(json_repr_foo) == {
-        "foointseq": {"values": [2]},
-    }
+    # assert json.loads(json_repr_foo) == {
+    #     "myfoointseq": {"values": [2]},
+    # }
 
-    foo3 = Foo(foo=Foo.FooIntSequence(values=[2]))
-    assert Foo.from_json(json_repr_foo) == foo3
+    # assert Foo.from_json(json_repr_foo) == foo1
 
 
 def test_dataobject_list_oneof_round_trips_with_no_custom_names():
@@ -674,19 +689,35 @@ def test_dataobject_list_oneof_round_trips_with_no_custom_names():
             Annotated[List[str], FieldNumber(20)],
         ]
 
-    # proto round trip
+    # proto round trip for Foo with no param name
     foo1 = Foo([2])
     assert foo1.which_oneof("foo") == "foo_int_sequence"
     proto_repr_foo = foo1.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    # proto round trip for Foo with oneof name
     foo2 = Foo(foo=[2])
     assert foo2.which_oneof("foo") == "foo_int_sequence"
     proto_repr_foo = foo2.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # proto round trip for Foo with no param name
+    foo3 = Foo(foo=["hello"])
+    assert foo3.which_oneof("foo") == "foo_str_sequence"
+    proto_repr_foo = foo3.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # proto round trip for Foo with field name
+    foo4 = Foo(foo_int_sequence=[2])
+    assert foo4.which_oneof("foo") == "foo_int_sequence"
+    proto_repr_foo = foo4.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
     assert foo1.to_dict() == {"foo_int_sequence": {"values": [2]}}
+    assert foo2.to_dict() == {"foo_int_sequence": {"values": [2]}}
+    assert foo3.to_dict() == {"foo_str_sequence": {"values": ["hello"]}}
+    assert foo4.to_dict() == {"foo_int_sequence": {"values": [2]}}
 
     # json round trip
     json_repr_foo = foo1.to_json()
@@ -695,7 +726,6 @@ def test_dataobject_list_oneof_round_trips_with_no_custom_names():
             "values": [2],
         },
     }
-
     assert Foo.from_json(json_repr_foo) == foo1
 
 

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -646,24 +646,24 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
     foo1 = Foo([2])
     assert foo1.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo1.to_proto()
-    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with oneof param name
     foo2 = Foo(foo=[2])
     assert foo2.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo2.to_proto()
-    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with no param name
     foo3 = Foo(["hello"])
     assert foo3.which_oneof("foo") == "myfoostrseq"
     proto_repr_foo = foo3.to_proto()
-    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with field name
-    # foo4 = Foo(myfoostrseq=["hello"])
-    # assert foo4.which_oneof("foo") == "myfoostrseq"
-    # proto_repr_foo = foo4.to_proto()
+    foo4 = Foo(myfoostrseq=["hello"])
+    assert foo4.which_oneof("foo") == "myfoostrseq"
+    proto_repr_foo = foo4.to_proto()
     # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -549,15 +549,17 @@ def test_dataobject_primitive_oneof_round_trips():
     @dataobject
     class Foo(DataObjectBase):
         foo: Union[
-            Annotated[int, FieldNumber(10), OneofField("foo_int")],
-            Annotated[float, FieldNumber(20), OneofField("foo_float")],
+            Annotated[int, FieldNumber(10), OneofField("fooint")],
+            Annotated[float, FieldNumber(20), OneofField("foofloat")],
         ]
 
     # proto round trip
-    foo1 = Foo(foo_int=2)
-    assert foo1.which_oneof("foo") == "foo_int"
+    foo1 = Foo(2)
+    assert foo1.which_oneof("foo") == "fooint"
     proto_repr_foo = foo1.to_proto()
-    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    print("proto_repr_foo is: ", proto_repr_foo)
+    Foo.from_proto(proto=proto_repr_foo)
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo2 = Foo(foo=2)
     assert foo2.which_oneof("foo") == "foo_int"

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -555,32 +555,72 @@ def test_dataobject_primitive_oneof_round_trips():
 
     # proto round trip
     foo1 = Foo(2)
-    # assert foo1.which_oneof("foo") == "fooint"
+    assert foo1.which_oneof("foo") == "fooint"
     proto_repr_foo = foo1.to_proto()
     print("proto_repr_foo is: ", proto_repr_foo)
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
-    # foo2 = Foo(foo=2)
-    # assert foo2.which_oneof("foo") == "foo_int"
-    # proto_repr_foo = foo2.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    foo2 = Foo(foo=2)
+    assert foo2.which_oneof("foo") == "fooint"
+    proto_repr_foo = foo2.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    foo3 = Foo(1.2)
+    assert foo3.which_oneof("foo") == "foofloat"
+    proto_repr_foo = foo3.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
-    # assert foo1.to_dict() == {"foo_int": 2}
+    assert foo1.to_dict() == {"fooint": 2}
 
     # json round trip
-    # json_repr_foo = foo1.to_json()
-    # assert json.loads(json_repr_foo) == {
-    #     "foo_int": 2,
-    # }
-    # assert Foo.from_json(json_repr_foo) == foo1
+    json_repr_foo = foo1.to_json()
+    assert json.loads(json_repr_foo) == {
+        "fooint": 2,
+    }
+    assert Foo.from_json(json_repr_foo) == foo1
+
+def test_dataobject_primitive_oneof_round_trips_no_custom_name():
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: Union[
+            Annotated[int, FieldNumber(10)],
+            Annotated[float, FieldNumber(20)],
+        ]
+
+    # proto round trip
+    foo1 = Foo(2)
+    assert foo1.which_oneof("foo") == "foo_int"
+    proto_repr_foo = foo1.to_proto()
+    print("proto_repr_foo is: ", proto_repr_foo)
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    foo2 = Foo(foo=2)
+    assert foo2.which_oneof("foo") == "foo_int"
+    proto_repr_foo = foo2.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    foo3 = Foo(1.2)
+    assert foo3.which_oneof("foo") == "foo_float"
+    proto_repr_foo = foo3.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # dict test
+    assert foo1.to_dict() == {"foo_int": 2}
+
+    # json round trip
+    json_repr_foo = foo1.to_json()
+    assert json.loads(json_repr_foo) == {
+        "foo_int": 2,
+    }
+    assert Foo.from_json(json_repr_foo) == foo1
 
 
 def test_dataobject_list_oneof_round_trips_with_specified_names():
     @dataobject
     class Foo(DataObjectBase):
         foo: Union[
-            Annotated[List[int], FieldNumber(10), OneofField("fooint")],
+            Annotated[List[int], FieldNumber(10), OneofField("foointseq")],
             Annotated[List[str], FieldNumber(20), OneofField("foostrseq")],
         ]
 
@@ -590,20 +630,50 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
     proto_repr_foo = foo1.to_proto()
     print("proto_repr_foo is: ", proto_repr_foo)
     Foo.from_proto(proto=proto_repr_foo)
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
-    # foo2 = Foo(foo=2)
-    # assert foo2.which_oneof("foo") == "foo_int"
-    # proto_repr_foo = foo2.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    foo2 = Foo(foo=[2])
+    # assert foo2.which_oneof("foo") == "foointseq"
+    proto_repr_foo = foo2.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
-    # assert foo1.to_dict() == {"foo_int": 2}
+    # assert foo1.to_dict() == {"foointseq": 2}
 
     # json round trip
     # json_repr_foo = foo1.to_json()
     # assert json.loads(json_repr_foo) == {
-    #     "foo_int": 2,
+    #     "foointseq": 2,
+    # }
+    # assert Foo.from_json(json_repr_foo) == foo1
+
+def test_dataobject_list_oneof_round_trips_with_no_custom_names():
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: Union[
+            Annotated[List[int], FieldNumber(10)],
+            Annotated[List[str], FieldNumber(20)],
+        ]
+
+    # proto round trip
+    foo1 = Foo([2])
+    # assert foo1.which_oneof("foo") == "foo_int_sequence"
+    proto_repr_foo = foo1.to_proto()
+    Foo.from_proto(proto=proto_repr_foo)
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    foo2 = Foo(foo=[2])
+    # assert foo2.which_oneof("foo") == "foo_int_sequence"
+    proto_repr_foo = foo2.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # dict test
+    # assert foo1.to_dict() == {"foo_int_sequence": 2}
+
+    # json round trip
+    # json_repr_foo = foo1.to_json()
+    # assert json.loads(json_repr_foo) == {
+    #     "foo_int_sequence": 2,
     # }
     # assert Foo.from_json(json_repr_foo) == foo1
 

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -555,26 +555,25 @@ def test_dataobject_primitive_oneof_round_trips():
 
     # proto round trip
     foo1 = Foo(2)
-    assert foo1.which_oneof("foo") == "fooint"
+    # assert foo1.which_oneof("foo") == "fooint"
     proto_repr_foo = foo1.to_proto()
     print("proto_repr_foo is: ", proto_repr_foo)
-    Foo.from_proto(proto=proto_repr_foo)
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
-
-    foo2 = Foo(foo=2)
-    assert foo2.which_oneof("foo") == "foo_int"
-    proto_repr_foo = foo2.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    # foo2 = Foo(foo=2)
+    # assert foo2.which_oneof("foo") == "foo_int"
+    # proto_repr_foo = foo2.to_proto()
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
     # dict test
-    assert foo1.to_dict() == {"foo_int": 2}
+    # assert foo1.to_dict() == {"foo_int": 2}
 
     # json round trip
-    json_repr_foo = foo1.to_json()
-    assert json.loads(json_repr_foo) == {
-        "foo_int": 2,
-    }
-    assert Foo.from_json(json_repr_foo) == foo1
+    # json_repr_foo = foo1.to_json()
+    # assert json.loads(json_repr_foo) == {
+    #     "foo_int": 2,
+    # }
+    # assert Foo.from_json(json_repr_foo) == foo1
 
 
 def test_dataobject_list_oneof_round_trips_with_specified_names():
@@ -587,7 +586,7 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
 
     # proto round trip
     foo1 = Foo([2])
-    assert foo1.which_oneof("foo") == "foointseq"
+    # assert foo1.which_oneof("foo") == "foointseq"
     proto_repr_foo = foo1.to_proto()
     print("proto_repr_foo is: ", proto_repr_foo)
     Foo.from_proto(proto=proto_repr_foo)

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -646,25 +646,25 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
     foo1 = Foo([2])
     assert foo1.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo1.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with oneof param name
     foo2 = Foo(foo=[2])
     assert foo2.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo2.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with no param name
     foo3 = Foo(["hello"])
     assert foo3.which_oneof("foo") == "myfoostrseq"
     proto_repr_foo = foo3.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with field name
     foo4 = Foo(myfoostrseq=["hello"])
     assert foo4.which_oneof("foo") == "myfoostrseq"
     proto_repr_foo = foo4.to_proto()
-    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
     # assert foo1.to_dict() == {"myfoointseq": {"values": [2]}}

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -557,7 +557,6 @@ def test_dataobject_primitive_oneof_round_trips():
     foo1 = Foo(2)
     assert foo1.which_oneof("foo") == "fooint"
     proto_repr_foo = foo1.to_proto()
-    print("proto_repr_foo is: ", proto_repr_foo)
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo2 = Foo(foo=2)
@@ -580,6 +579,7 @@ def test_dataobject_primitive_oneof_round_trips():
     }
     assert Foo.from_json(json_repr_foo) == foo1
 
+
 def test_dataobject_primitive_oneof_round_trips_no_custom_name():
     @dataobject
     class Foo(DataObjectBase):
@@ -592,7 +592,6 @@ def test_dataobject_primitive_oneof_round_trips_no_custom_name():
     foo1 = Foo(2)
     assert foo1.which_oneof("foo") == "foo_int"
     proto_repr_foo = foo1.to_proto()
-    print("proto_repr_foo is: ", proto_repr_foo)
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo2 = Foo(foo=2)
@@ -626,26 +625,27 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
 
     # proto round trip
     foo1 = Foo([2])
-    # assert foo1.which_oneof("foo") == "foointseq"
+    assert foo1.which_oneof("foo") == "foointseq"
     proto_repr_foo = foo1.to_proto()
-    print("proto_repr_foo is: ", proto_repr_foo)
-    Foo.from_proto(proto=proto_repr_foo)
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo2 = Foo(foo=[2])
-    # assert foo2.which_oneof("foo") == "foointseq"
+    assert foo2.which_oneof("foo") == "foointseq"
     proto_repr_foo = foo2.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
-    # assert foo1.to_dict() == {"foointseq": 2}
+    assert foo1.to_dict() == {"foointseq": {"values": [2]}}
 
     # json round trip
-    # json_repr_foo = foo1.to_json()
-    # assert json.loads(json_repr_foo) == {
-    #     "foointseq": 2,
-    # }
-    # assert Foo.from_json(json_repr_foo) == foo1
+    json_repr_foo = foo1.to_json()
+    assert json.loads(json_repr_foo) == {
+        "foointseq": {"values": [2]},
+    }
+
+    foo3 = Foo(foo=Foo.FooIntSequence(values=[2]))
+    assert Foo.from_json(json_repr_foo) == foo3
+
 
 def test_dataobject_list_oneof_round_trips_with_no_custom_names():
     @dataobject
@@ -657,25 +657,27 @@ def test_dataobject_list_oneof_round_trips_with_no_custom_names():
 
     # proto round trip
     foo1 = Foo([2])
-    # assert foo1.which_oneof("foo") == "foo_int_sequence"
+    assert foo1.which_oneof("foo") == "foo_int_sequence"
     proto_repr_foo = foo1.to_proto()
-    Foo.from_proto(proto=proto_repr_foo)
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo2 = Foo(foo=[2])
-    # assert foo2.which_oneof("foo") == "foo_int_sequence"
+    assert foo2.which_oneof("foo") == "foo_int_sequence"
     proto_repr_foo = foo2.to_proto()
-    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # dict test
-    # assert foo1.to_dict() == {"foo_int_sequence": 2}
+    assert foo1.to_dict() == {"foo_int_sequence": {"values": [2]}}
 
     # json round trip
-    # json_repr_foo = foo1.to_json()
-    # assert json.loads(json_repr_foo) == {
-    #     "foo_int_sequence": 2,
-    # }
-    # assert Foo.from_json(json_repr_foo) == foo1
+    json_repr_foo = foo1.to_json()
+    assert json.loads(json_repr_foo) == {
+        "foo_int_sequence": {
+            "values": [2],
+        },
+    }
+
+    assert Foo.from_json(json_repr_foo) == foo1
 
 
 def test_dataobject_oneof_from_backend():

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -650,13 +650,13 @@ def test_dataobject_list_oneof_round_trips_with_specified_names():
 
     # proto round trip for Foo with oneof param name
     foo2 = Foo(foo=[2])
-    # assert foo2.which_oneof("foo") == "myfoointseq"
+    assert foo2.which_oneof("foo") == "myfoointseq"
     proto_repr_foo = foo2.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     # proto round trip for Foo with no param name
     foo3 = Foo(["hello"])
-    # assert foo3.which_oneof("foo") == "myfoostrseq"
+    assert foo3.which_oneof("foo") == "myfoostrseq"
     proto_repr_foo = foo3.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -549,33 +549,41 @@ def test_dataobject_primitive_oneof_round_trips():
     @dataobject
     class Foo(DataObjectBase):
         foo: Union[
-            Annotated[int, FieldNumber(10), OneofField("fooint")],
-            Annotated[float, FieldNumber(20), OneofField("foofloat")],
+            Annotated[int, FieldNumber(10), OneofField("myfooint")],
+            Annotated[float, FieldNumber(20), OneofField("myfoofloat")],
         ]
 
     # proto round trip
     foo1 = Foo(2)
-    assert foo1.which_oneof("foo") == "fooint"
+    assert foo1.which_oneof("foo") == "myfooint"
     proto_repr_foo = foo1.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo2 = Foo(foo=2)
-    assert foo2.which_oneof("foo") == "fooint"
+    assert foo2.which_oneof("foo") == "myfooint"
     proto_repr_foo = foo2.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
     foo3 = Foo(1.2)
-    assert foo3.which_oneof("foo") == "foofloat"
+    assert foo3.which_oneof("foo") == "myfoofloat"
     proto_repr_foo = foo3.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    foo4 = Foo(myfooint=4)
+    assert foo4.which_oneof("foo") == "myfooint"
+    proto_repr_foo = foo4.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
     # dict test
-    assert foo1.to_dict() == {"fooint": 2}
+    assert foo1.to_dict() == {"myfooint": 2}
+    assert foo2.to_dict() == {"myfooint": 2}
+    assert foo3.to_dict() == {"myfoofloat": 1.2}
+    assert foo4.to_dict() == {"myfooint": 4}
 
     # json round trip
     json_repr_foo = foo1.to_json()
     assert json.loads(json_repr_foo) == {
-        "fooint": 2,
+        "myfooint": 2,
     }
     assert Foo.from_json(json_repr_foo) == foo1
 
@@ -588,24 +596,35 @@ def test_dataobject_primitive_oneof_round_trips_no_custom_name():
             Annotated[float, FieldNumber(20)],
         ]
 
-    # proto round trip
+    # proto round trip for Foo with no param name
     foo1 = Foo(2)
     assert foo1.which_oneof("foo") == "foo_int"
     proto_repr_foo = foo1.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
-
+    
+    # proto round trip for Foo with oneof name
     foo2 = Foo(foo=2)
     assert foo2.which_oneof("foo") == "foo_int"
     proto_repr_foo = foo2.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    # proto round trip for Foo with no param name
     foo3 = Foo(1.2)
     assert foo3.which_oneof("foo") == "foo_float"
     proto_repr_foo = foo3.to_proto()
     assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
 
+    # proto round trip for Foo with field name
+    foo4 = Foo(foo_int=4)
+    assert foo4.which_oneof("foo") == "foo_int"
+    proto_repr_foo = foo4.to_proto()
+    assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
     # dict test
     assert foo1.to_dict() == {"foo_int": 2}
+    assert foo2.to_dict() == {"foo_int": 2}
+    assert foo3.to_dict() == {"foo_float": 1.2}
+    assert foo4.to_dict() == {"foo_int": 4}
 
     # json round trip
     json_repr_foo = foo1.to_json()

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -577,6 +577,38 @@ def test_dataobject_primitive_oneof_round_trips():
     assert Foo.from_json(json_repr_foo) == foo1
 
 
+def test_dataobject_list_oneof_round_trips_with_specified_names():
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: Union[
+            Annotated[List[int], FieldNumber(10), OneofField("fooint")],
+            Annotated[List[str], FieldNumber(20), OneofField("foostrseq")],
+        ]
+
+    # proto round trip
+    foo1 = Foo([2])
+    assert foo1.which_oneof("foo") == "foointseq"
+    proto_repr_foo = foo1.to_proto()
+    print("proto_repr_foo is: ", proto_repr_foo)
+    Foo.from_proto(proto=proto_repr_foo)
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # foo2 = Foo(foo=2)
+    # assert foo2.which_oneof("foo") == "foo_int"
+    # proto_repr_foo = foo2.to_proto()
+    # assert Foo.from_proto(proto=proto_repr_foo).to_proto() == proto_repr_foo
+
+    # dict test
+    # assert foo1.to_dict() == {"foo_int": 2}
+
+    # json round trip
+    # json_repr_foo = foo1.to_json()
+    # assert json.loads(json_repr_foo) == {
+    #     "foo_int": 2,
+    # }
+    # assert Foo.from_json(json_repr_foo) == foo1
+
+
 def test_dataobject_oneof_from_backend():
     """Make sure that a oneof can be correctly accessed from a backend"""
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The previous code relies on the existence of `_sequence` in the field name for union of list types, or splitting on underscores `_` to get the oneof name (how silly!). 

This PR:
- removes the check for `_sequence` because users could name their oneof field names custom names without the word `sequence` and without `_`.
- lots of tests to cover the cases of default union of list names when users don't provide a field name (ex: "foo_int_sequence") as well as when they provide custom names (ex: "myfooseq")

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
