### PR TITLE
:sparkles: Add input token count to nlp interfaces for text gen

### DIFF
--- a/caikit/interfaces/nlp/data_model/text_generation.py
+++ b/caikit/interfaces/nlp/data_model/text_generation.py
@@ -50,6 +50,7 @@ class GeneratedTextResult(DataObjectBase):
     generated_tokens: Annotated[int, FieldNumber(2)]
     finish_reason: Annotated[FinishReason, FieldNumber(3)]
     producer_id: Annotated[ProducerId, FieldNumber(4)]
+    input_token_count: Annotated[int, FieldNumber(5)]
 
 
 @dataobject(package=NLP_PACKAGE)
@@ -72,3 +73,4 @@ class GeneratedTextStreamResult(DataObjectBase):
     generated_text: Annotated[str, FieldNumber(1)]
     tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(2)]
     details: Annotated[Optional[TokenStreamDetails], FieldNumber(3)]
+    input_token_count: Annotated[int, FieldNumber(4)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Add `input_token_count` text generation responses. Since the information about tokenization used by the model is not available to the user, it can become confusing to understand how many tokens were considered from the input. This parameter solves that problem and provides number of input token information with every generation response.


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
