### PR TITLE
🐛  Backends fix

### DIFF
--- a/caikit/core/registries.py
+++ b/caikit/core/registries.py
@@ -65,7 +65,7 @@ def module_backend_registry() -> Dict[
     Dict[ module_id, Dict[ backend_type, Tuple[ backend_impl_class, backend_config_dict ] ] ]
 
     Returns:
-        Dict[str, Dict[str, Tuple["caikit.core.BackendBase", Dict]]]: The module
+        Dict[str, Dict[str, Tuple["caikit.core.ModuleBase", Dict]]]: The module
             backend registry
     """
     # TODO: put a real data structure here instead of nested dicts

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -17,9 +17,6 @@ from typing import Optional, Type
 import os
 import uuid
 
-# Third Party
-import pytest
-
 # Local
 from caikit.core import MODEL_MANAGER
 from caikit.core.data_model import TrainingStatus
@@ -35,12 +32,6 @@ from caikit.core.model_management import (
 from caikit.core.model_management.local_model_initializer import LocalModelInitializer
 from caikit.core.module_backends import BackendBase, backend_types
 from caikit.core.modules import ModuleBase, ModuleConfig
-from caikit.core.registries import (
-    module_backend_classes,
-    module_backend_registry,
-    module_backend_types,
-    module_registry,
-)
 from sample_lib.modules import SampleModule
 
 
@@ -192,59 +183,3 @@ def configured_backends():
         if isinstance(loader, LocalModelInitializer)
     ]
     return [backend for loader in local_initializers for backend in loader._backends]
-
-
-@pytest.fixture
-def reset_backend_types():
-    """Fixture that will reset the backend types if a test modifies them"""
-    base_backend_types = {key: val for key, val in module_backend_types().items()}
-    base_backend_classes = {key: val for key, val in module_backend_classes().items()}
-    yield
-    module_backend_types().clear()
-    module_backend_types().update(base_backend_types)
-    module_backend_classes().clear()
-    module_backend_classes().update(base_backend_classes)
-
-
-@pytest.fixture
-def reset_module_backend_registry():
-    """Fixture that will reset the module distribution registry if a test modifies them"""
-    orig_module_backend_registry = {
-        key: val for key, val in module_backend_registry().items()
-    }
-    yield
-    module_backend_registry().clear()
-    module_backend_registry().update(orig_module_backend_registry)
-
-
-@pytest.fixture
-def reset_module_registry():
-    """Fixture that will reset caikit.core module registry if a test modifies it"""
-    orig_module_registry = {key: val for key, val in module_registry().items()}
-    yield
-    module_registry().clear()
-    module_registry().update(orig_module_registry)
-
-
-@pytest.fixture
-def reset_model_manager():
-    prev_finders = MODEL_MANAGER._finders
-    prev_initializers = MODEL_MANAGER._initializers
-    prev_trainers = MODEL_MANAGER._trainers
-    MODEL_MANAGER._finders = {}
-    MODEL_MANAGER._initializers = {}
-    MODEL_MANAGER._trainers = {}
-    yield
-    MODEL_MANAGER._finders = prev_finders
-    MODEL_MANAGER._initializers = prev_initializers
-    MODEL_MANAGER._trainers = prev_trainers
-
-
-@pytest.fixture
-def reset_globals(
-    reset_backend_types,
-    reset_model_manager,
-    reset_module_backend_registry,
-    reset_module_registry,
-):
-    """Fixture that will reset the backend types and module registries if a test modifies them"""

--- a/tests/core/module_backends/test_backend_types.py
+++ b/tests/core/module_backends/test_backend_types.py
@@ -24,7 +24,8 @@ import pytest
 # Local
 from caikit.core import backend_types
 from caikit.core.module_backends.base import BackendBase
-from tests.core.helpers import MockBackend, reset_backend_types
+from tests.conftest import reset_backend_types
+from tests.core.helpers import MockBackend
 
 ## Tests #######################################################################
 

--- a/tests/core/modules/test_module.py
+++ b/tests/core/modules/test_module.py
@@ -17,12 +17,16 @@ import io
 import os
 import tempfile
 
+# Third Party
+import pytest
+
 # First Party
 import aconfig
 
 # Local
 from caikit.core import ModuleConfig, ModuleLoader, ModuleSaver
 from caikit.core.modules.decorator import SUPPORTED_LOAD_BACKENDS_VAR_NAME
+from caikit.core.registries import module_backend_registry, module_registry
 
 # pylint: disable=import-error
 from sample_lib.data_model.sample import SampleInputType

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -20,6 +20,9 @@ import os
 import tempfile
 import uuid
 
+# Third Party
+import pytest
+
 # Local
 from caikit.core import LocalBackend
 from caikit.core.data_model import DataStream, TrainingStatus

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -231,7 +231,7 @@ def test_with_batching_collect_delay(model_loader):
         )
 
 
-def test_load_distributed_impl():
+def test_load_distributed_impl(reset_module_registry):
     """Make sure that when configured, an alternate distributed
     implementation of a module can be loaded
     """

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -14,9 +14,7 @@
 # Standard
 from concurrent.futures import Future
 from contextlib import contextmanager
-from typing import Callable
 from unittest import mock
-import copy
 import tempfile
 
 # Third Party
@@ -236,62 +234,45 @@ def test_load_distributed_impl(reset_globals):
     implementation of a module can be loaded
     """
 
-    reg_copy = copy.deepcopy(caikit.core.registries.module_registry())
-    backend_registry_copy = copy.deepcopy(
-        caikit.core.registries.module_backend_registry()
+    @module(
+        base_module=SampleModule,
+        backend_type=backend_types.MOCK,
+        backend_config_override={"bar1": 1},
     )
-    # 🌶️🌶️🌶️: the MODULE_BACKEND_REGISTRY can't be easily patched since two separate modules hold
-    # an imported reference to it and one edits it (decorator.py) while the other reads it
-    # (model_manager.py)
+    class DistributedGadget(caikit.core.ModuleBase):
+        """An alternate implementation of a Gadget"""
 
-    with mock.patch.object(caikit.core.registries, "MODULE_REGISTRY", reg_copy):
-        with mock.patch.object(
-            caikit.core.registries,
-            "MODULE_BACKEND_REGISTRY",
-            backend_registry_copy,
-        ):
+        SUPPORTED_LOAD_BACKENDS = [
+            MockBackend.backend_type,
+            backend_types.LOCAL,
+        ]
 
-            @module(
-                base_module=SampleModule,
-                backend_type=backend_types.MOCK,
-                backend_config_override={"bar1": 1},
-            )
-            class DistributedGadget(caikit.core.ModuleBase):
-                """An alternate implementation of a Gadget"""
+        def __init__(self, bar):
+            self.bar = bar
 
-                SUPPORTED_LOAD_BACKENDS = [
-                    MockBackend.backend_type,
-                    backend_types.LOCAL,
-                ]
+        def run(self, sample_input: SampleInputType) -> SampleOutputType:
+            return SampleOutputType(greeting=f"hello distributed {sample_input.name}")
 
-                def __init__(self, bar):
-                    self.bar = bar
+        @classmethod
+        def load(cls, model_load_path, **kwargs) -> "DistributedGadget":
+            # NOTE: kwargs needed here for load_backend
+            config = ModuleConfig.load(model_load_path)
+            return cls(bar=config.bar)
 
-                def run(self, sample_input: SampleInputType) -> SampleOutputType:
-                    return SampleOutputType(
-                        greeting=f"hello distributed {sample_input.name}"
-                    )
+    with tempfile.TemporaryDirectory() as model_path:
+        # Create and save the model directly with the local impl
+        SampleModule().save(model_path)
 
-                @classmethod
-                def load(cls, model_load_path, **kwargs) -> "DistributedGadget":
-                    # NOTE: kwargs needed here for load_backend
-                    config = ModuleConfig.load(model_load_path)
-                    return cls(bar=config.bar)
+        model_type = "gadget"
 
-            with tempfile.TemporaryDirectory() as model_path:
-                # Create and save the model directly with the local impl
-                SampleModule().save(model_path)
-
-                model_type = "gadget"
-
-                with temp_model_loader() as model_loader:
-                    # Load the distributed version
-                    model = model_loader.load_model(
-                        random_test_id(),
-                        model_path,
-                        model_type=model_type,
-                    ).model()
-                    assert isinstance(model, DistributedGadget)
+        with temp_model_loader() as model_loader:
+            # Load the distributed version
+            model = model_loader.load_model(
+                random_test_id(),
+                model_path,
+                model_type=model_type,
+            ).model()
+            assert isinstance(model, DistributedGadget)
 
 
 def test_load_model_without_waiting_success(model_loader):

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -231,7 +231,7 @@ def test_with_batching_collect_delay(model_loader):
         )
 
 
-def test_load_distributed_impl(reset_module_registry):
+def test_load_distributed_impl(reset_globals):
     """Make sure that when configured, an alternate distributed
     implementation of a module can be loaded
     """

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -38,8 +38,7 @@ from sample_lib.data_model.sample import (
     SampleTrainingType,
 )
 from sample_lib.modules.sample_task.sample_implementation import SampleModule
-from tests.conftest import random_test_id, temp_config
-from tests.core.helpers import reset_model_manager
+from tests.conftest import random_test_id, reset_model_manager, temp_config
 from tests.fixtures import Fixtures
 from tests.runtime.conftest import register_trained_model
 import caikit.core

--- a/tests/runtime/test_service_factory.py
+++ b/tests/runtime/test_service_factory.py
@@ -345,7 +345,9 @@ def test_override_package_and_domain_with_proto_gen(clean_data_model):
                                     assert service_name == f"{domain_override}Service"
 
 
-def test_backend_modules_included_in_service_generation(clean_data_model, reset_module_registry):
+def test_backend_modules_included_in_service_generation(
+    clean_data_model, reset_globals
+):
     # Add a new backend module for the good ol' `SampleModule`
     @caikit.module(backend_type=MockBackend.backend_type, base_module=SampleModule)
     class NewBackendModule(caikit.core.ModuleBase):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #446 

This includes backend modules in the service generation.
It also fixes our `reset_globals` fixture since that wasn't properly cleaning up backend modules.
It also moves the `reset_*` stuff into `conftest.py` so that
- We don't need squirrely imports in our tests, and
- The runtime tests can use them too

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
