### PR TITLE
Convert to json before returning fastapi response

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -611,6 +611,10 @@ class DataBase(metaclass=_DataBaseMetaClass):
         if field_descriptor.type == field_descriptor.TYPE_BOOL:
             return isinstance(val, bool)
 
+        # Proto doesn't allow non utf-8 bytes fields; however, python does.
+        if field_descriptor.type == field_descriptor.TYPE_BYTES:
+            return isinstance(val, bytes)
+
         # If it's a primitive, use protobuf type checkers
         checker = proto_type_checkers.GetTypeChecker(field_descriptor)
         try:
@@ -933,7 +937,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
             - datetime.datetime
             """
             if isinstance(obj, bytes):
-                return base64.encodebytes(obj).decode("utf-8")
+                return base64.b64encode(obj).decode("utf-8")
             if isinstance(obj, datetime.datetime):
                 # Use the timestamp's proto-serialized format to get the proper json serializer
                 return timestamp.datetime_to_proto(obj).ToJsonString()

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -18,7 +18,7 @@ API based on the task definitions available at boot.
 """
 # Standard
 from functools import partial
-from typing import Any, Dict, Iterable, Optional, Type, Union, get_args
+from typing import Any, Dict, Iterable, Optional, Type, get_args
 import asyncio
 import json
 import re

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -17,13 +17,13 @@ capable of converting to and from Pydantic models to our DataObjects.
 """
 # Standard
 from typing import Dict, List, Type, Union, get_args, get_type_hints
-import enum
 import base64
+import enum
 
 # Third Party
+from pydantic.functional_validators import BeforeValidator
 import numpy as np
 import pydantic
-from pydantic.functional_validators import BeforeValidator
 
 # First Party
 from py_to_proto.dataclass_to_proto import (  # Imported here for 3.8 compat
@@ -166,7 +166,7 @@ def _get_pydantic_type(field_type: type) -> type:
     raise TypeError(f"Cannot get pydantic type for type [{field_type}]")
 
 
-def _from_base64(data: Union[bytes, str])->bytes:
+def _from_base64(data: Union[bytes, str]) -> bytes:
     if isinstance(data, str):
         return base64.b64decode(data.encode("utf-8"))
     return data

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -18,10 +18,12 @@ capable of converting to and from Pydantic models to our DataObjects.
 # Standard
 from typing import Dict, List, Type, Union, get_args, get_type_hints
 import enum
+import base64
 
 # Third Party
 import numpy as np
 import pydantic
+from pydantic.functional_validators import BeforeValidator
 
 # First Party
 from py_to_proto.dataclass_to_proto import (  # Imported here for 3.8 compat
@@ -129,7 +131,9 @@ def _get_pydantic_type(field_type: type) -> type:
         return int
     if np.issubclass_(field_type, np.floating):
         return float
-    if field_type in (int, float, bool, str, bytes, dict, type(None)):
+    if field_type == bytes:
+        return Annotated[bytes, BeforeValidator(_from_base64)]
+    if field_type in (int, float, bool, str, dict, type(None)):
         return field_type
     if isinstance(field_type, type) and issubclass(field_type, enum.Enum):
         return field_type
@@ -160,3 +164,9 @@ def _get_pydantic_type(field_type: type) -> type:
         ]
 
     raise TypeError(f"Cannot get pydantic type for type [{field_type}]")
+
+
+def _from_base64(data: Union[bytes, str])->bytes:
+    if isinstance(data, str):
+        return base64.b64decode(data.encode("utf-8"))
+    return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,11 @@ def good_model_path() -> str:
 
 
 @pytest.fixture
+def box_model_path() -> str:
+    return os.path.join(FIXTURES_DIR, "models", "box")
+
+
+@pytest.fixture
 def streaming_model_path() -> str:
     return os.path.join(FIXTURES_DIR, "dummy_streaming_module")
 

--- a/tests/fixtures/models/box/config.yml
+++ b/tests/fixtures/models/box/config.yml
@@ -1,0 +1,8 @@
+module_class: sample_lib.modules.file_processing.BoundingBoxModule
+module_id: 750cad4d-c3b8-4327-b52e-e772f0d6f311
+created: "2023-03-28 16:34:58.720898"
+name: BoundingBoxModule
+sample_lib_version: 1.2.3
+saved: "2023-03-28 16:34:58.720929"
+tracking_id: e56dbd48-9231-432b-ad04-c02eeffdd158
+version: 0.0.1

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -2,8 +2,9 @@
 Dummy data model object for testing
 """
 # Standard
-from typing import Iterable
+from typing import Iterable, Union
 import typing
+import base64
 
 # Local
 from caikit.core import DataObjectBase, TaskBase, dataobject, task
@@ -34,6 +35,13 @@ class OtherOutputType(DataObjectBase):
 
 
 @dataobject(package="caikit_data_model.sample_lib")
+class FileDataType(DataObjectBase):
+    """A simple type for tasks that deal with file data"""
+
+    filename: str
+    data: bytes
+
+@dataobject(package="caikit_data_model.sample_lib")
 class SampleTrainingType(DataObjectBase):
     """A sample `training data` type for the `sample_task` task."""
 
@@ -56,6 +64,14 @@ class SampleTask(TaskBase):
 )
 class OtherTask(TaskBase):
     """Another sample `task` for our test models"""
+
+
+@task(
+    unary_parameters={"unprocessed": FileDataType},
+    unary_output_type=FileDataType,
+)
+class FileTask(TaskBase):
+    """A sample task for processing files"""
 
 
 @task(

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -3,8 +3,8 @@ Dummy data model object for testing
 """
 # Standard
 from typing import Iterable, Union
-import typing
 import base64
+import typing
 
 # Local
 from caikit.core import DataObjectBase, TaskBase, dataobject, task
@@ -40,6 +40,7 @@ class FileDataType(DataObjectBase):
 
     filename: str
     data: bytes
+
 
 @dataobject(package="caikit_data_model.sample_lib")
 class SampleTrainingType(DataObjectBase):

--- a/tests/fixtures/sample_lib/modules/__init__.py
+++ b/tests/fixtures/sample_lib/modules/__init__.py
@@ -7,3 +7,4 @@ from .sample_task import (
     SampleModule,
     SamplePrimitiveModule,
 )
+from .file_processing import BoundingBoxModule

--- a/tests/fixtures/sample_lib/modules/__init__.py
+++ b/tests/fixtures/sample_lib/modules/__init__.py
@@ -1,4 +1,5 @@
 # Local
+from .file_processing import BoundingBoxModule
 from .geospatial import GeoStreamingModule
 from .other_task import OtherModule
 from .sample_task import (
@@ -7,4 +8,3 @@ from .sample_task import (
     SampleModule,
     SamplePrimitiveModule,
 )
-from .file_processing import BoundingBoxModule

--- a/tests/fixtures/sample_lib/modules/file_processing/__init__.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/__init__.py
@@ -1,1 +1,2 @@
+# Local
 from .bounding_box_module import BoundingBoxModule

--- a/tests/fixtures/sample_lib/modules/file_processing/__init__.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/__init__.py
@@ -1,0 +1,1 @@
+from .bounding_box_module import BoundingBoxModule

--- a/tests/fixtures/sample_lib/modules/file_processing/__init__.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/__init__.py
@@ -1,2 +1,16 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Local
 from .bounding_box_module import BoundingBoxModule

--- a/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
@@ -1,0 +1,29 @@
+"""
+A sample module for sample things!
+"""
+# Standard
+
+# Local
+from ...data_model.sample import FileTask, FileDataType
+from caikit.core.modules import ModuleLoader
+import caikit.core
+
+
+@caikit.core.module(
+    "750cad4d-c3b8-4327-b52e-e772f0d6f311", "BoundingBoxModule", "0.0.1", FileTask
+)
+class BoundingBoxModule(caikit.core.ModuleBase):
+
+    def run(
+        self,
+        unprocessed: FileDataType,
+    ) -> FileDataType:
+        filename = f"processed_{unprocessed.filename}"
+        data = b"bounding|" + unprocessed.data + b"|box"
+        return FileDataType(filename, data)
+
+    @classmethod
+    def load(cls, model_path, **kwargs):
+        loader = ModuleLoader(model_path)
+        config = loader.config
+        return cls()

--- a/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
@@ -1,8 +1,20 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 A sample module for sample things!
 """
-# Standard
-
 # Local
 from ...data_model.sample import FileDataType, FileTask
 from caikit.core.modules import ModuleLoader

--- a/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
@@ -4,7 +4,7 @@ A sample module for sample things!
 # Standard
 
 # Local
-from ...data_model.sample import FileTask, FileDataType
+from ...data_model.sample import FileDataType, FileTask
 from caikit.core.modules import ModuleLoader
 import caikit.core
 
@@ -13,7 +13,6 @@ import caikit.core
     "750cad4d-c3b8-4327-b52e-e772f0d6f311", "BoundingBoxModule", "0.0.1", FileTask
 )
 class BoundingBoxModule(caikit.core.ModuleBase):
-
     def run(
         self,
         unprocessed: FileDataType,

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -252,6 +252,23 @@ def sample_task_model_id(good_model_path) -> str:
 
 
 @pytest.fixture
+def file_task_model_id(box_model_path) -> str:
+    """Loaded model ID using model manager load model implementation"""
+    model_id = random_test_id()
+    model_manager = ModelManager.get_instance()
+    # model load test already tests with archive - just using a model path here
+    model_manager.load_model(
+        model_id,
+        local_model_path=box_model_path,
+        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
+    )
+    yield model_id
+
+    # teardown
+    model_manager.unload_model(model_id)
+
+
+@pytest.fixture
 def sample_task_unary_rpc(sample_inference_service: ServicePackage) -> TaskPredictRPC:
     return sample_inference_service.caikit_rpcs["SampleTaskPredict"]
 

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -301,6 +301,23 @@ def test_inference_other_task(other_task_model_id, runtime_http_server):
         assert json_response["farewell"] == "goodbye: world 42 times"
 
 
+def test_json_file_task(file_task_model_id, runtime_http_server):
+    """Simple check that we can ping a model"""
+    with TestClient(runtime_http_server.app) as client:
+        # cGRmZGF0Yf//AA== is b"pdfdata\xff\xff\x00" base64 encoded
+        json_input = {"inputs": {"filename": "example.pdf", "data": "cGRmZGF0Yf//AA=="}}
+
+        response = client.post(
+            f"/api/v1/{file_task_model_id}/task/file",
+            json=json_input,
+        )
+        json_response = json.loads(response.content.decode(response.default_encoding))
+        assert response.status_code == 200, json_response
+        assert json_response["filename"] == "processed_example.pdf"
+        # Ym91bmRpbmd8cGRmZGF0Yf//AHxib3g= is b"bounding|pdfdata\xff\xff\x00|box" base64 encoded
+        assert json_response["data"] == "Ym91bmRpbmd8cGRmZGF0Yf//AHxib3g="
+
+
 def test_inference_streaming_sample_module(sample_task_model_id, runtime_http_server):
     """Simple check for testing a happy path unary-stream case"""
     with TestClient(runtime_http_server.app) as client:

--- a/tests/runtime/http_server/test_pydantic_wrapper.py
+++ b/tests/runtime/http_server/test_pydantic_wrapper.py
@@ -36,6 +36,7 @@ from caikit.interfaces.nlp.data_model.text_generation import (
 )
 from caikit.runtime.http_server.pydantic_wrapper import (
     PYDANTIC_TO_DM_MAPPING,
+    _from_base64,
     _get_pydantic_type,
     dataobject_to_pydantic,
     pydantic_to_dataobject,
@@ -116,7 +117,12 @@ def test_pydantic_to_dataobject_datastream_file():
         (float, float),
         (bool, bool),
         (str, str),
-        (bytes, bytes),
+        (
+            bytes,
+            Annotated[
+                bytes, pydantic.functional_validators.BeforeValidator(_from_base64)
+            ],
+        ),
         (type(None), type(None)),
         (enum.Enum, enum.Enum),
         (Annotated[str, "blah"], str),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR updates the `http_server` runtime to directly call a data object's `to_json` function before returning the fastapi Response. This allows users to customize a models json representation instead of defaulting to fastapi's [jsonable_encoder](https://fastapi.tiangolo.com/tutorial/encoder/?h=jsonable_enc#using-the-jsonable_encoder)

**Special notes for your reviewer**:
This is my first PR to caikit so please let me know if there is anything I should do differently!

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
