### PR TITLE
🐛 fix Data model objects with Bytes bug

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -477,20 +477,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
 
         # If attempting to set one of the named fields or a oneof, instead set
         # the private version of the attribute.
-        if name in cls.fields:
-            field_descriptor = cls._proto_class.DESCRIPTOR.fields_by_name[name]
-            # for bytes, convert to bytes if not already
-            if field_descriptor.type == field_descriptor.TYPE_BYTES:
-                error.value_check(
-                    "<COR13072712E>",
-                    isinstance(val, (bytes, str)),
-                    "{} must be string or bytes",
-                    val,
-                )
-                if isinstance(val, str):
-                    val = val.encode("utf-8")
-            super().__setattr__(f"_{name}", val)
-        elif name in cls._fields_oneofs_map:
+        if name in cls.fields or name in cls._fields_oneofs_map:
             super().__setattr__(f"_{name}", val)
         else:
             super().__setattr__(name, val)

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -481,7 +481,13 @@ class DataBase(metaclass=_DataBaseMetaClass):
             field_descriptor = cls._proto_class.DESCRIPTOR.fields_by_name[name]
             # for bytes, convert to bytes if not already
             if field_descriptor.type == field_descriptor.TYPE_BYTES:
-                if not isinstance(val, bytes):
+                error.value_check(
+                    "<COR13072712E>",
+                    isinstance(val, (bytes, str)),
+                    "{} must be string or bytes",
+                    val,
+                )
+                if isinstance(val, str):
                     val = val.encode("utf-8")
             super().__setattr__(f"_{name}", val)
         elif name in cls._fields_oneofs_map:

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -18,7 +18,7 @@
 # Standard
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union, get_type_hints
 import base64
 import datetime
 import json
@@ -759,6 +759,17 @@ class DataBase(metaclass=_DataBaseMetaClass):
         if isinstance(json_str, dict):
             # Convert dict object to a JSON string
             json_str = json.dumps(json_str)
+
+        # check if the field is of type bytes
+        json_dict = json.loads(json_str)
+        for field_name, field_type in get_type_hints(cls).items():
+            if field_type == bytes:
+                str_val = json_dict[field_name]
+                json_dict[field_name] = str(
+                    base64.b64encode(str_val.encode("utf-8")), encoding="utf-8"
+                )
+
+        json_str = json.dumps(json_dict)
 
         try:
             # Parse given JSON into google.protobufs.pyext.cpp_message.GeneratedProtocolMessageType

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -89,6 +89,25 @@ def check_field_enum_type(proto_class, field_name, exp_enum_descriptor):
 ## Tests #######################################################################
 
 
+def test_dataobject_bytes():
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: bytes
+
+    # f1 = Foo(b"asdf")
+    # assert f1.foo == b"asdf"
+    # assert f1.to_json() == '{"foo": "YXNkZg=="}'
+    # initialize without explicit bytes
+    f2 = Foo("asdf")
+    assert f2.foo == b"asdf"
+    assert f2.to_json() == '{"foo": "YXNkZg=="}'
+    # f2 = Foo.from_json(f.to_json())
+    # print(f2.foo)
+    # print(f2.to_json())
+    # # This fails!
+    # assert f.foo == f2.foo
+
+
 def test_dataobject_native_types():
     """Make sure that a simple usage of dataobject for a flat object works with
     fields declared using  native python types works

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -94,18 +94,36 @@ def test_dataobject_bytes():
     class Foo(DataObjectBase):
         foo: bytes
 
-    # f1 = Foo(b"asdf")
-    # assert f1.foo == b"asdf"
-    # assert f1.to_json() == '{"foo": "YXNkZg=="}'
-    # initialize without explicit bytes
+    f1 = Foo(b"asdf")
+    assert f1.foo == b"asdf"
+    assert f1.to_json() == '{"foo": "YXNkZg=="}'
+    # initialize without explicit bytes declaration
     f2 = Foo("asdf")
     assert f2.foo == b"asdf"
     assert f2.to_json() == '{"foo": "YXNkZg=="}'
-    # f2 = Foo.from_json(f.to_json())
-    # print(f2.foo)
-    # print(f2.to_json())
-    # # This fails!
-    # assert f.foo == f2.foo
+    # test round-trip json
+    f3 = Foo.from_json(f1.to_json())
+    assert f3.foo == b"asdf"
+    assert f3.to_json() == '{"foo": "YXNkZg=="}'
+    assert f3.foo == f2.foo == f1.foo
+
+
+def test_dataobject_bytes_union():
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: Union[bytes, int]
+
+    f1 = Foo(b"asdf")
+    assert f1.foo == b"asdf"
+    assert f1.to_json() == '{"foo_bytes": "YXNkZg=="}'
+    f2 = Foo(1)
+    assert f2.foo == 1
+    assert f2.to_json() == '{"foo_int": 1}'
+    # # test round-trip json
+    f3 = Foo.from_json(f1.to_json())
+    assert f3.foo == b"asdf"
+    assert f3.to_json() == '{"foo_bytes": "YXNkZg=="}'
+    assert f3.foo == f1.foo
 
 
 def test_dataobject_native_types():

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -97,24 +97,10 @@ def test_dataobject_bytes():
     f1 = Foo(b"asdf")
     assert f1.foo == b"asdf"
     assert f1.to_json() == '{"foo": "YXNkZg=="}'
-    # initialize without explicit bytes declaration
-    f2 = Foo("asdf")
-    assert f2.foo == b"asdf"
-    assert f2.to_json() == '{"foo": "YXNkZg=="}'
     # test round-trip json
-    f3 = Foo.from_json(f1.to_json())
-    assert f3.foo == b"asdf"
-    assert f3.to_json() == '{"foo": "YXNkZg=="}'
-    assert f3.foo == f2.foo == f1.foo
-
-
-def test_dataobject_bytes_throws_incorrect_val():
-    @dataobject
-    class Foo(DataObjectBase):
-        foo: bytes
-
-    with pytest.raises(ValueError) as e:
-        Foo(1)
+    f2 = Foo.from_json(f1.to_json())
+    assert f2.foo == f1.foo
+    assert f2.to_json() == f1.to_json()
 
 
 def test_dataobject_bytes_union():
@@ -130,9 +116,8 @@ def test_dataobject_bytes_union():
     assert f2.to_json() == '{"foo_int": 1}'
     # # test round-trip json
     f3 = Foo.from_json(f1.to_json())
-    assert f3.foo == b"asdf"
-    assert f3.to_json() == '{"foo_bytes": "YXNkZg=="}'
     assert f3.foo == f1.foo
+    assert f3.to_json() == f1.to_json()
 
 
 def test_dataobject_native_types():

--- a/tests/core/data_model/test_dataobject.py
+++ b/tests/core/data_model/test_dataobject.py
@@ -108,6 +108,15 @@ def test_dataobject_bytes():
     assert f3.foo == f2.foo == f1.foo
 
 
+def test_dataobject_bytes_throws_incorrect_val():
+    @dataobject
+    class Foo(DataObjectBase):
+        foo: bytes
+
+    with pytest.raises(ValueError) as e:
+        Foo(1)
+
+
 def test_dataobject_bytes_union():
     @dataobject
     class Foo(DataObjectBase):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds a couple of test cases to make sure that #460 (round tripping a DM object with bytes) works fine if we explicitly declare a `bytes` object.

**Special notes for your reviewer**:

There was quite a bit of back-and-forth regarding this PR. I will try to summarize the discussion.

When Gabe created the issue #460, he tried to create a DM object having a `bytes` field with a `string`, and that was failing. In the original implementation to fix this, I manually checked if the object type was a `string` and the field type was `bytes`, and I explicitly converted the `string` to `bytes`, which made the failing test work.

However, Gabe pointed out that if we go down this route, this type of conversion will have to be done holistically, which presents a lot of complexity in terms of figuring out how to convert various types to another.

So Gabe came up with 3 options:

1. Type cast (what we tried doing) - Really hard to do holistically.
2. Pedantically reject (if it's not a bytes you can't use it for TYPE_BYTES)
3. Be "pythony" and let whatever happens happen - the thing with python in this case is that it's pretty standard practice to use a type hint to tell users "this should be bytes" but then not actually bother checking at runtime. Since the thing we're building explicitly cares about typing, that's **not really a great user experience**, especially with "similar" types (e.g. `int` being assigned to a `float` field).

Hence we decided to reject the 1st and 3rd idea, and instead go with `#2` - tracked here: https://github.com/caikit/caikit/issues/464.


**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
