### PR TITLE
Set Bytes Json Schema to base64

### DIFF
--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -69,7 +69,7 @@ PYDANTIC_TO_DM_MAPPING = {
 # This is done to make sure any oneofs can be
 # correctly inferred by pydantic
 class ParentPydanticBaseModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="forbid", protected_namespaces=())
+    model_config = pydantic.ConfigDict(extra="forbid", protected_namespaces=(), ser_json_bytes="base64")
 
 
 def pydantic_to_dataobject(pydantic_model: pydantic.BaseModel) -> DataBase:

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -69,7 +69,11 @@ PYDANTIC_TO_DM_MAPPING = {
 # This is done to make sure any oneofs can be
 # correctly inferred by pydantic
 class ParentPydanticBaseModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="forbid", protected_namespaces=(), ser_json_bytes="base64")
+    model_config = pydantic.ConfigDict(
+        extra="forbid",
+        ser_json_bytes="base64",
+        protected_namespaces=(),
+    )
 
 
 def pydantic_to_dataobject(pydantic_model: pydantic.BaseModel) -> DataBase:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ runtime-grpc = [
 
 runtime-http = [
     "fastapi[all]>=0.100,<1",
+    "pydantic>=2.4",
     "requests>=2.28.2,<3",
     "sse-starlette>=1.6.1,<2",
 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR sets the pydantic bytes json schema to `base64`. This updates the auto-generated openapi docs to correctly list `bytes` fields as `base64` formatted strings instead of raw `binary` strings. 

**Special notes for your reviewer**:
I discovered this config while exploring the [pydantic repo](https://github.com/pydantic/pydantic/blob/9c03680ff08fceabfba0db6402e12ca8970bfdcf/pydantic/config.py#L158). The [PR](https://github.com/pydantic/pydantic/pull/7269) that created the config was only merged last week so it hasn't been released. I tested my changes with a local clone of pydantic and `ConfigDict` is backwards compatible so this should be safe to merge but for abundance of caution this PR can wait until an official version is released. 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
