### PR TITLE
Mt save path 478

### DIFF
--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -167,7 +167,7 @@ class GlobalTrainServicer:
         self,
         request: ProtoMessageType,
         module: Type[ModuleBase],
-        training_output_dir: str,
+        training_output_dir: Optional[str] = None,
         *,
         context: Optional[ServicerContext] = None,
         wait: bool = False,
@@ -179,8 +179,9 @@ class GlobalTrainServicer:
         Args:
             request (ProtoMessageType): The message that stimulated this request
             module (Type[ModuleBase]): The module class to train
-            training_output_dir (str): The base directory where trained models
-                should be saved
+            training_output_dir (Optional[str]): The base directory where
+                the trained model should be saved, falling back to the
+                configured output dir if not given.
 
         Kwargs:
             context (Optional[ServicerContext]): The grpc context for the


### PR DESCRIPTION
**NOTE**: This is an API breaking change as it will change the behavior of training jobs to result in models failing to be updated unless corresponding changes are made in the server's config to set `runtime.training.output_dir` to `""`.

**What this PR does / why we need it**:

Closes #478 

This PR adjusts the behavior of the Model Train servicer so that if `runtime.training.output_dir` is configured in the global config, the model will be saved there rather than in `request.training_output_dir`. This is needed to support the usecase of saving models to mounted PVCs rather than uploading them to S3 when S3 is not available.

**If applicable**:
- [X] this PR contains unit tests
