### PR TITLE
Model train save with custom

### DIFF
--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -54,9 +54,6 @@ class GlobalTrainServicer:
     def __init__(self, training_service: ServicePackage):
         self._training_service = training_service
         self._model_manager = ModelManager.get_instance()
-        caikit_config = get_config()
-        self.training_output_dir = caikit_config.runtime.training.output_dir
-        self.save_with_id = caikit_config.runtime.training.save_with_id
 
         # TODO: think about if we really want to do this here:
         self.cdm = get_data_model()
@@ -69,7 +66,7 @@ class GlobalTrainServicer:
         # Or grab the `libraries` off of the `training_service` instead of config here?
         # Duplicate code in global_train_servicer
         # pylint: disable=duplicate-code
-        self.library = clean_lib_names(caikit_config.runtime.library)[0]
+        self.library = clean_lib_names(get_config().runtime.library)[0]
         try:
             lib_version = version(self.library)
         except Exception:  # pylint: disable=broad-exception-caught
@@ -82,6 +79,14 @@ class GlobalTrainServicer:
             lib_version,
         )
         super()
+
+    @property
+    def training_output_dir(self) -> str:
+        return get_config().runtime.training.output_dir
+
+    @property
+    def save_with_id(self) -> str:
+        return get_config().runtime.training.save_with_id
 
     def Train(
         self,

--- a/caikit/runtime/servicers/model_train_servicer.py
+++ b/caikit/runtime/servicers/model_train_servicer.py
@@ -130,7 +130,7 @@ class ModelTrainServicerImpl(process_pb2_grpc.ProcessServicer):
             log.debug("<RUN00837184D>", "training_response: %s", training_response)
             # return response
             process_response = process_pb2.ProcessResponse(
-                trainingID=training_response.training_id,
+                trainingID=request.trainingID,
                 customTrainingID=request.customTrainingID,
             )
             return process_response

--- a/caikit/runtime/servicers/model_train_servicer.py
+++ b/caikit/runtime/servicers/model_train_servicer.py
@@ -125,7 +125,7 @@ class ModelTrainServicerImpl(process_pb2_grpc.ProcessServicer):
                 #   external_training_id override. If that is ever not the case
                 #   this will be brokenly passing that kwarg through to the
                 #   module's train function.
-                external_training_id=request.trainingID,
+                external_training_id=request.customTrainingID or request.trainingID,
             )
             log.debug("<RUN00837184D>", "training_response: %s", training_response)
             # return response

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -122,7 +122,6 @@ def test_model_train(runtime_grpc_server):
     model_name = "abc"
     model_train_request = process_pb2.ProcessRequest(
         trainingID=training_id,
-        customTrainingID=str(uuid.uuid4()),
         request_dict={
             "train_module": "00110203-0405-0607-0809-0a0b02dd0e0f",
             "training_params": json.dumps(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the `model_train_servicer` to use the inbound `ProcessRequest`'s `customTrainingID` if given. It is needed so that the fully-external `caikit` ID can be used in the save path.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
