### PR TITLE
Handle Pydantic "model_" conflict warning

### DIFF
--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -58,8 +58,7 @@ PYDANTIC_TO_DM_MAPPING = {
 # This is done to make sure any one-offs can be
 # correctly inferred by pydantic
 class ParentPydanticBaseModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="forbid")
-    model_config["protected_namespaces"] = ()
+    model_config = pydantic.ConfigDict(extra="forbid", protected_namespaces=())
 
 
 def pydantic_to_dataobject(pydantic_model: pydantic.BaseModel) -> DataBase:

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -55,10 +55,11 @@ PYDANTIC_TO_DM_MAPPING = {
 # Base class for pydantic models
 # We want to set the config to forbid extra attributes
 # while instantiating any pydantic models
-# This is done to make sure any oneofs can be
-# correctly infered by pydantic
+# This is done to make sure any one-offs can be
+# correctly inferred by pydantic
 class ParentPydanticBaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="forbid")
+    model_config["protected_namespaces"] = ()
 
 
 def pydantic_to_dataobject(pydantic_model: pydantic.BaseModel) -> DataBase:

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -55,7 +55,7 @@ PYDANTIC_TO_DM_MAPPING = {
 # Base class for pydantic models
 # We want to set the config to forbid extra attributes
 # while instantiating any pydantic models
-# This is done to make sure any one-offs can be
+# This is done to make sure any oneofs can be
 # correctly inferred by pydantic
 class ParentPydanticBaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="forbid", protected_namespaces=())

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not examples"}
+commands = pytest --cov=caikit --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not examples"} -W error::UserWarning
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
Pydantic [protected namespaces](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces) raised warnings as per #448. 

This PR resolves the warning and closes #448 (along with a couple of typo fixes). 
