### PR TITLE
remove unused '*args'  when calling _extract_pred_set()

### DIFF
--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -447,7 +447,6 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
     def evaluate_quality(
         self,
         dataset_path,
-        *args,
         preprocess_func=None,
         detailed_metrics=False,
         labels=None,
@@ -502,7 +501,7 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         # 4) obtain pred set predictions
         # pylint: disable=assignment-from-no-return
         pred_set = self._extract_pred_set(
-            dataset, preprocess_func=preprocess_func, *args, **kwargs
+            dataset, preprocess_func=preprocess_func, **kwargs
         )
         pred_annos = self._extract_pred_annotations(pred_set)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The previous [PR](https://github.com/caikit/caikit/pull/432/files) removed `*args` from `def _extract_pred_set()` signature. This PR will remove `*args` where `_extract_pred_set()` is called. Additionally since `*args` is no longer used above this can be removed from `evaluate_quality()` params as well.

**Special notes for your reviewer**:
This update was  tested in Watson NLP.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
