### PR TITLE
:wrench: Add 9 as another OOM indicative exit code

### DIFF
--- a/caikit/core/toolkit/destroyable_process.py
+++ b/caikit/core/toolkit/destroyable_process.py
@@ -38,7 +38,7 @@ log = alog.use_channel("DESTROY-PROC")
 error = error_handler.get(log)
 
 
-OOM_EXIT_CODES = [137, 9]
+OOM_EXIT_CODES = [137, 9, -9]
 
 FORK_CTX = multiprocessing.get_context("fork")
 SPAWN_CTX = multiprocessing.get_context("spawn")

--- a/caikit/core/toolkit/destroyable_process.py
+++ b/caikit/core/toolkit/destroyable_process.py
@@ -38,7 +38,7 @@ log = alog.use_channel("DESTROY-PROC")
 error = error_handler.get(log)
 
 
-OOM_EXIT_CODE = 137
+OOM_EXIT_CODES = [137, 9]
 
 FORK_CTX = multiprocessing.get_context("fork")
 SPAWN_CTX = multiprocessing.get_context("spawn")
@@ -191,7 +191,7 @@ class _DestroyableProcess(
             return self.__result
 
         if self.exitcode and self.exitcode != os.EX_OK:
-            if self.exitcode == OOM_EXIT_CODE:
+            if self.exitcode in OOM_EXIT_CODES:
                 return MemoryError("Training process died with OOM error!")
             if not self.canceled:
                 return RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,25 @@ def temp_config(config_overrides: dict, merge_strategy="override"):
             yield get_config()
 
 
+@contextmanager
+def set_use_subprocess(use_subprocess: bool):
+    with temp_config(
+        {
+            "model_management": {
+                "trainers": {
+                    "default": {
+                        "config": {
+                            "use_subprocess": use_subprocess,
+                        }
+                    }
+                }
+            }
+        },
+        "merge",
+    ):
+        yield
+
+
 # fixtures to optionally generate the protos for easier debugging
 def pytest_addoption(parser):
     try:

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -113,6 +113,7 @@ class SampleModule(caikit.core.ModuleBase):
         union_list: Optional[Union[List[str], List[int]]] = None,
         batch_size: int = 64,
         oom_exit: bool = False,
+        oom_exit_code: Optional[int] = None,
         sleep_time: float = 0,
         sleep_increment: float = 0.001,
         **kwargs,
@@ -147,7 +148,10 @@ class SampleModule(caikit.core.ModuleBase):
             # exit with OOM code. Note _exit method is used to exit the
             # process with specified status without calling cleanup handlers
             # to replicate OOM scenario
-            os._exit(137)
+            if oom_exit_code:
+                os._exit(oom_exit_code)
+            else:
+                os._exit(137)
 
         if batch_size == cls.POISON_PILL_BATCH_SIZE:
             raise ValueError(

--- a/tests/runtime/servicers/test_global_train_servicer_impl_subprocess.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl_subprocess.py
@@ -1,0 +1,59 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Subprocess only global train servicer tests"""
+# Third Party
+import pytest
+
+# Local
+from caikit.core import MODEL_MANAGER
+from caikit.runtime.service_factory import get_train_params, get_train_request
+from sample_lib.data_model.sample import SampleTrainingType
+from sample_lib.modules import SampleModule
+from tests.conftest import random_test_id, set_use_subprocess
+from tests.fixtures import Fixtures
+import caikit.core
+
+
+@pytest.mark.parametrize("oom_exit_code", [137, 9])
+def test_global_train_returns_exit_code_with_oom(
+    sample_train_servicer, reset_model_manager, oom_exit_code
+):
+    """Test that if module goes into OOM we are able to surface error code"""
+    stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
+    training_data = stream_type(
+        jsondata=stream_type.JsonData(data=[SampleTrainingType(1)])
+    )
+    train_class = get_train_request(SampleModule)
+    train_request_params_class = get_train_params(SampleModule)
+    train_request = train_class(
+        model_name=random_test_id(),
+        parameters=train_request_params_class(
+            batch_size=42,
+            training_data=training_data,
+            oom_exit=True,
+            oom_exit_code=oom_exit_code,
+        ),
+    ).to_proto()
+
+    # Enable sub-processing for test
+    with set_use_subprocess(True):
+        training_response = sample_train_servicer.Train(
+            train_request, Fixtures.build_context("foo")
+        )
+        MODEL_MANAGER.get_model_future(training_response.training_id).wait()
+
+        future_info = MODEL_MANAGER.get_model_future(
+            training_response.training_id
+        ).get_info()
+        assert f"Training process died with OOM error!" in str(future_info.errors[0])


### PR DESCRIPTION
### Changes
- Change `OOM_EXIT_CODE` to a list (and change variable name accordingly)
- Add 9, -9 to OOM exit code list (generally unsigned exit codes are expected but -9 has appeared before)