### PR TITLE
Add Support for Multi-Part Input and Binary File Output in HTTP Server

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -80,6 +80,10 @@ class _DataBaseMetaClass(type):
         if name.startswith("TYPE_") and "INT" in name
     ]
 
+    # Add property to track if a class supports exporting and importing via a
+    # file operation
+    supports_file_operations = False
+
     def __new__(mcs, name, bases, attrs):
         """When constructing a new data model class, we set the 'fields' class variable from the
         protobufs descriptor and then set the '__slots__' magic class attribute to fields.  This
@@ -305,7 +309,7 @@ class _DataBaseMetaClass(type):
         # Check DataBase for file handlers
         setattr(
             cls,
-            "_supports_file_operations",
+            "supports_file_operations",
             cls.to_file != DataBase.to_file and cls.from_file != DataBase.from_file,
         )
 
@@ -527,11 +531,6 @@ class DataBase(metaclass=_DataBaseMetaClass):
     @property
     def backend(self) -> Optional["DataModelBackendBase"]:
         return getattr(self, _DataBaseMetaClass._BACKEND_ATTR, None)
-
-    @classmethod
-    @property
-    def supports_file_operations(cls) -> bool:
-        return getattr(cls, "_supports_file_operations", False)
 
     def which_oneof(self, oneof_name: str) -> Optional[str]:
         """Get the name of the oneof field set for the given oneof or None if no

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -306,7 +306,8 @@ class _DataBaseMetaClass(type):
         setattr(
             cls,
             "_supports_file_operations",
-            cls.to_file is not DataBase.to_file and cls.from_file is not DataBase.from_file,
+            cls.to_file is not DataBase.to_file
+            and cls.from_file is not DataBase.from_file,
         )
 
     @classmethod
@@ -530,7 +531,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
 
     @classmethod
     @property
-    def supports_file_operations(cls)->bool:
+    def supports_file_operations(cls) -> bool:
         return getattr(cls, "_supports_file_operations", False)
 
     def which_oneof(self, oneof_name: str) -> Optional[str]:
@@ -800,6 +801,15 @@ class DataBase(metaclass=_DataBaseMetaClass):
 
     @classmethod
     def from_file(cls, file_obj: IOBase):
+        """Build a DataBase from a given file-like object.
+
+        Args:
+            file_obj IOBase: A file object that contains some representation
+            of the dataobject
+
+        Returns:
+            caikit.core.data_model.DataBase: A DataBase object.
+        """
         raise NotImplementedError(f"from_file not implemented for {cls}")
 
     def to_proto(self):
@@ -979,6 +989,16 @@ class DataBase(metaclass=_DataBaseMetaClass):
         return json.dumps(self.to_dict(), **kwargs)
 
     def to_file(self, file_obj: IOBase) -> Optional["File"]:
+        """Export a DataBaseObject into a file-like object `file_obj`. If the DataBase object
+        has requirements around file name or file type it can return them via
+        the optional "File" return object
+
+        Args:
+            file_obj IOBase: a file object to be filled
+
+        Returns:
+            caikit.interfaces.common.data_mode.stream_sources: File.
+        """
         raise NotImplementedError(f"to_file not implemented for {self.__class__}")
 
     def __repr__(self):

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -995,7 +995,7 @@ class DataBase(metaclass=_DataBaseMetaClass):
             file_obj IOBase: a file object to be filled
 
         Returns:
-            caikit.interfaces.common.data_mode.stream_sources: File.
+            file_descriptor: Optional[caikit.interfaces.common.data_mode.File]
         """
         raise NotImplementedError(f"to_file not implemented for {self.__class__}")
 

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -306,8 +306,7 @@ class _DataBaseMetaClass(type):
         setattr(
             cls,
             "_supports_file_operations",
-            cls.to_file is not DataBase.to_file
-            and cls.from_file is not DataBase.from_file,
+            cls.to_file != DataBase.to_file and cls.from_file != DataBase.from_file,
         )
 
     @classmethod

--- a/caikit/interfaces/common/data_model/__init__.py
+++ b/caikit/interfaces/common/data_model/__init__.py
@@ -29,4 +29,4 @@ from . import primitive_sequences, producer
 from .file import File
 from .primitive_sequences import BoolSequence, FloatSequence, IntSequence, StrSequence
 from .producer import ProducerId
-from .stream_sources import FileStream, ListOfFileStreams
+from .stream_sources import FileReference, ListOfFileReferences

--- a/caikit/interfaces/common/data_model/__init__.py
+++ b/caikit/interfaces/common/data_model/__init__.py
@@ -28,3 +28,4 @@ Domain agnostic data model objects
 from . import primitive_sequences, producer
 from .primitive_sequences import BoolSequence, FloatSequence, IntSequence, StrSequence
 from .producer import ProducerId
+from .stream_sources import File, ListOfFiles

--- a/caikit/interfaces/common/data_model/__init__.py
+++ b/caikit/interfaces/common/data_model/__init__.py
@@ -26,6 +26,7 @@ Domain agnostic data model objects
 # Local
 # Import individual packages
 from . import primitive_sequences, producer
+from .file import File
 from .primitive_sequences import BoolSequence, FloatSequence, IntSequence, StrSequence
 from .producer import ProducerId
-from .stream_sources import File, ListOfFiles
+from .stream_sources import FileStream, ListOfFileStreams

--- a/caikit/interfaces/common/data_model/file.py
+++ b/caikit/interfaces/common/data_model/file.py
@@ -1,0 +1,32 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file contains interfaces required to handle File data
+"""
+
+# Standard
+from typing import Optional
+
+# First Party
+from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
+
+# Local
+from caikit.core.data_model import PACKAGE_COMMON, DataObjectBase, dataobject
+
+
+@dataobject(PACKAGE_COMMON)
+class File(DataObjectBase):
+    data: Annotated[bytes, FieldNumber(1)]
+    filename: Annotated[Optional[str], FieldNumber(2)]
+    type: Annotated[Optional[str], FieldNumber(3)]

--- a/caikit/interfaces/common/data_model/stream_sources.py
+++ b/caikit/interfaces/common/data_model/stream_sources.py
@@ -26,12 +26,12 @@ from caikit.core.data_model import PACKAGE_COMMON, DataObjectBase, dataobject
 
 
 @dataobject(PACKAGE_COMMON)
-class FileStream(DataObjectBase):
+class FileReference(DataObjectBase):
     filename: Annotated[str, FieldNumber(1)]
 
 
 @dataobject(PACKAGE_COMMON)
-class ListOfFileStreams(DataObjectBase):
+class ListOfFileReferences(DataObjectBase):
     files: Annotated[List[str], FieldNumber(1)]
 
 

--- a/caikit/interfaces/common/data_model/stream_sources.py
+++ b/caikit/interfaces/common/data_model/stream_sources.py
@@ -27,7 +27,7 @@ from caikit.core.data_model import PACKAGE_COMMON, DataObjectBase, dataobject
 
 @dataobject(PACKAGE_COMMON)
 class File(DataObjectBase):
-    filename: Annotated[str, FieldNumber(1)]
+    filename: Annotated[Optional[str], FieldNumber(1)]
     data: Annotated[Optional[bytes], FieldNumber(2)]
     type: Annotated[Optional[str], FieldNumber(3)]
 

--- a/caikit/interfaces/common/data_model/stream_sources.py
+++ b/caikit/interfaces/common/data_model/stream_sources.py
@@ -16,7 +16,7 @@ This file contains interfaces required to generate DataStreamSource[T] classes
 """
 
 # Standard
-from typing import List, Optional
+from typing import List
 
 # First Party
 from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
@@ -26,14 +26,12 @@ from caikit.core.data_model import PACKAGE_COMMON, DataObjectBase, dataobject
 
 
 @dataobject(PACKAGE_COMMON)
-class File(DataObjectBase):
-    filename: Annotated[Optional[str], FieldNumber(1)]
-    data: Annotated[Optional[bytes], FieldNumber(2)]
-    type: Annotated[Optional[str], FieldNumber(3)]
+class FileStream(DataObjectBase):
+    filename: Annotated[str, FieldNumber(1)]
 
 
 @dataobject(PACKAGE_COMMON)
-class ListOfFiles(DataObjectBase):
+class ListOfFileStreams(DataObjectBase):
     files: Annotated[List[str], FieldNumber(1)]
 
 

--- a/caikit/interfaces/common/data_model/stream_sources.py
+++ b/caikit/interfaces/common/data_model/stream_sources.py
@@ -16,7 +16,7 @@ This file contains interfaces required to generate DataStreamSource[T] classes
 """
 
 # Standard
-from typing import List
+from typing import List, Optional
 
 # First Party
 from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
@@ -28,6 +28,8 @@ from caikit.core.data_model import PACKAGE_COMMON, DataObjectBase, dataobject
 @dataobject(PACKAGE_COMMON)
 class File(DataObjectBase):
     filename: Annotated[str, FieldNumber(1)]
+    data: Annotated[Optional[bytes], FieldNumber(2)]
+    type: Annotated[Optional[str], FieldNumber(3)]
 
 
 @dataobject(PACKAGE_COMMON)

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -20,7 +20,7 @@ API based on the task definitions available at boot.
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Dict, Iterable, Optional, Type, Union, get_args, get_type_hints
+from typing import Any, Dict, Iterable, Optional, Type, Union, get_args
 import asyncio
 import io
 import json
@@ -358,10 +358,8 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 result = await loop.run_in_executor(None, call)
                 if response_data_object.supports_file_operations:
                     return self._format_file_response(result)
-                else:
-                    return Response(
-                        content=result.to_json(), media_type="application/json"
-                    )
+
+                return Response(content=result.to_json(), media_type="application/json")
             except HTTPException as err:
                 raise err
             except CaikitRuntimeException as err:
@@ -379,7 +377,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     "id": None,
                 }
                 log.error("<RUN51881106E>", err, exc_info=True)
-            return Response(content=json.dumps(error_content), status_code=error_code)
+            return Response(
+                content=json.dumps(error_content), status_code=error_code
+            )  # pylint: disable=used-before-assignment
 
     def _add_unary_input_unary_output_handler(self, rpc: TaskPredictRPC):
         """Add a unary:unary request handler for this RPC signature"""
@@ -436,10 +436,8 @@ class RuntimeHTTPServer(RuntimeServerBase):
 
                 if response_data_object.supports_file_operations:
                     return self._format_file_response(result)
-                else:
-                    return Response(
-                        content=result.to_json(), media_type="application/json"
-                    )
+
+                return Response(content=result.to_json(), media_type="application/json")
 
             except HTTPException as err:
                 raise err
@@ -458,7 +456,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     "id": None,
                 }
                 log.error("<RUN51881106E>", err, exc_info=True)
-            return Response(content=json.dumps(error_content), status_code=error_code)
+            return Response(
+                content=json.dumps(error_content), status_code=error_code
+            )  # pylint: disable=used-before-assignment
 
     def _add_unary_input_stream_output_handler(self, rpc: CaikitRPCBase):
         pydantic_request = dataobject_to_pydantic(self._get_request_dataobject(rpc))

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -397,18 +397,18 @@ class RuntimeHTTPServer(RuntimeServerBase):
         )
         # pylint: disable=unused-argument
         async def _handler(
-            model_id: str,
             context: Request,
         ) -> Response:
-            log.debug("In unary handler for %s for model %s", rpc.name, model_id)
-            loop = asyncio.get_running_loop()
 
             request = await pydantic_from_request(pydantic_request, context)
             request_params = self._get_request_params(rpc, request)
 
-            log.debug4("Sending request %s to model id %s", request_params, model_id)
             try:
                 model_id = self._get_model_id(request)
+                log.debug4(
+                    "Sending request %s to model id %s", request_params, model_id
+                )
+
                 log.debug("In unary handler for %s for model %s", rpc.name, model_id)
                 loop = asyncio.get_running_loop()
 
@@ -470,7 +470,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
             response_model=pydantic_response,
             openapi_extra=self._get_request_openapi(pydantic_request),
         )
-        async def _handler(model_id: str, context: Request) -> EventSourceResponse:
+        async def _handler(context: Request) -> EventSourceResponse:
             log.debug("In streaming handler for %s", rpc.name)
 
             request = await pydantic_from_request(pydantic_request, context)

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -191,7 +191,7 @@ async def pydantic_from_request(
     The currently supported Content-Types are `application/json`
     and `multipart/form-data`"""
     content_type = request.headers.get("Content-Type")
-    log.debug4("Detected request using %s type", content_type)
+    log.debug("Detected request using %s type", content_type)
 
     # If content type is json use pydantic to parse
     if content_type == "application/json":
@@ -199,9 +199,7 @@ async def pydantic_from_request(
         try:
             return pydantic_model.model_validate_json(raw_content)
         except pydantic.ValidationError as err:
-            raise RequestValidationError(  # pylint: disable=raise-missing-from
-                errors=err.errors()
-            )
+            raise RequestValidationError(errors=err.errors()) from err
     # Elif content is form-data then parse the form
     elif "multipart/form-data" in content_type:
         # Get the raw form data
@@ -325,9 +323,7 @@ def _parse_form_data_to_pydantic(
     try:
         return pydantic_model.model_validate(raw_model_obj)
     except pydantic.ValidationError as err:
-        raise RequestValidationError(  # pylint: disable=raise-missing-from
-            errors=err.errors()
-        )
+        raise RequestValidationError(errors=err.errors()) from err
 
 
 def _get_pydantic_subtypes(

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -16,12 +16,19 @@ This module holds the Pydantic wrapping required by the REST server,
 capable of converting to and from Pydantic models to our DataObjects.
 """
 # Standard
-from typing import Dict, List, Type, Union, get_args, get_type_hints
+from typing import Dict, List, Type, Union, get_args, get_type_hints, reveal_type
 import base64
 import enum
+import inspect
+import json
 
 # Third Party
+from fastapi import Request, status
+from fastapi.datastructures import FormData
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import HTTPException, RequestValidationError
 from pydantic.functional_validators import BeforeValidator
+from starlette.datastructures import UploadFile
 import numpy as np
 import pydantic
 
@@ -39,6 +46,7 @@ from caikit.interfaces.common.data_model.primitive_sequences import (
     IntSequence,
     StrSequence,
 )
+from caikit.runtime.http_server.utils import update_dict_at_dot_path
 
 # PYDANTIC_TO_DM_MAPPING is essentially a 2-way map of DMs <-> Pydantic models, you give it a
 # pydantic model, it gives you back a DM class, you give it a
@@ -170,3 +178,141 @@ def _from_base64(data: Union[bytes, str]) -> bytes:
     if isinstance(data, str):
         return base64.b64decode(data.encode("utf-8"))
     return data
+
+
+async def pydantic_from_request(
+    pydantic_model: Type[pydantic.BaseModel], request: Request
+):
+    content_type = request.headers.get("Content-Type")
+
+    # If content type is json use pydantic to parse
+    if content_type == "application/json":
+        raw_content = await request.body()
+        try:
+            return pydantic_model.model_validate_json(raw_content)
+        except pydantic.ValidationError as err:
+            raise RequestValidationError(errors=err.errors())
+    # Elif content is form-data then parse the form
+    elif "multipart/form-data" in content_type:
+        # Get the raw form data
+        raw_form = await request.form()
+        return _parse_form_data_to_pydantic(pydantic_model, raw_form)
+    else:
+        raise HTTPException(
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            f"Unsupported media type: {content_type}.",
+        )
+
+
+def _parse_form_data_to_pydantic(
+    pydantic_model: Type[pydantic.BaseModel], form_data: FormData
+) -> pydantic.BaseModel:
+    """Helper function to parse a fastapi form data into a pydantic model"""
+
+    raw_model_obj = {}
+    for key in form_data.keys():
+        # Get the list of objects that has the key
+        # field name
+        raw_objects = form_data.getlist(key)
+
+        # Make sure form field actually has values
+        if not raw_objects or (len(raw_objects) > 0 and not raw_objects[0]):
+            continue
+
+        # Get the type hint for the requested model
+        sub_key_list = key.split(".")
+        model_type_hints = _get_pydantic_subtypes(pydantic_model, sub_key_list)
+        if not model_type_hints:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown key '{key}'",
+            )
+
+        # Determine the root type hint if the request is a list
+        is_list = False
+        if get_origin(model_type_hints) is list:
+            is_list = True
+            model_type_hints = get_args(model_type_hints)[0]
+
+        # Recheck for union incase list was a list of unions
+        if get_origin(model_type_hints) is Union:
+            model_type_hints = get_args(model_type_hints)
+
+        # Loop through and check for each type hint. This is required to
+        # match unions. We don't have to be too specific with parsing as
+        # pydantic will handle formatting
+        parsed = False
+        for type_hint in model_type_hints:
+            # If type_hint is a pydantic model then parse the json
+            if inspect.isclass(type_hint) and issubclass(type_hint, pydantic.BaseModel):
+                failed_to_parse_json = False
+                for n, sub_obj in enumerate(raw_objects):
+                    try:
+                        raw_objects[n] = json.loads(sub_obj)
+                    except json.JSONDecodeError:
+                        failed_to_parse_json = True
+                        break
+
+                # If the json couldn't be parsed then skip this type
+                if failed_to_parse_json:
+                    continue
+
+            # If type_hint is bytes than parse the file information
+            # TODO This should be a custom caikit type
+            elif type_hint == bytes:
+                for n, sub_obj in enumerate(raw_objects):
+                    if isinstance(sub_obj, UploadFile):
+                        raw_objects[n] = sub_obj.file.read()
+
+            # If object is not supposed to be a list then just grab the first element
+            if not is_list:
+                raw_objects = raw_objects[0]
+
+            if not update_dict_at_dot_path(raw_model_obj, key, raw_objects):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unable to update object at key '{key}'; value already exists",
+                )
+
+            # If we were able to parse the object then break out of the type loop
+            parsed = True
+            break
+
+        # If the data didn't match any of the types return 422
+        if not parsed:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Failed to parse key '{key}' with types {model_type_hints}",
+            )
+
+    # Process the model into a pydantic type
+    try:
+        return pydantic_model.model_validate(raw_model_obj)
+    except pydantic.ValidationError as err:
+        raise RequestValidationError(errors=err.raw_errors)  # This is the key piece
+
+
+def _get_pydantic_subtypes(
+    pydantic_model: Type[pydantic.BaseModel], keys: list[str]
+) -> list[type]:
+    """Recursive helper to get the type_hint for a field"""
+    if len(keys) == 0:
+        return [pydantic_model]
+
+    # Get the type hints for the current key
+    current_key = keys[0]
+    current_type = get_type_hints(pydantic_model).get(current_key)
+    if not current_type:
+        return []
+
+    if get_origin(current_type) is Union:
+        # If we're trying to capture a union then return the entire union result
+        if len(keys) == 1:
+            return get_args(current_type)
+
+        # Get the arg which matches
+        for arg in get_args(current_type):
+            if result := _get_pydantic_subtypes(arg, keys[1:]):
+                return result
+    else:
+        return _get_pydantic_subtypes(current_type, keys[1:])

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -16,7 +16,7 @@ This module holds the Pydantic wrapping required by the REST server,
 capable of converting to and from Pydantic models to our DataObjects.
 """
 # Standard
-from typing import Dict, List, Type, Union, get_args, get_type_hints, reveal_type
+from typing import Dict, List, Type, Union, get_args, get_type_hints
 import base64
 import enum
 import inspect
@@ -25,7 +25,6 @@ import json
 # Third Party
 from fastapi import Request, status
 from fastapi.datastructures import FormData
-from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException, RequestValidationError
 from pydantic.functional_validators import BeforeValidator
 from starlette.datastructures import UploadFile
@@ -200,7 +199,9 @@ async def pydantic_from_request(
         try:
             return pydantic_model.model_validate_json(raw_content)
         except pydantic.ValidationError as err:
-            raise RequestValidationError(errors=err.errors())
+            raise RequestValidationError(  # pylint: disable=raise-missing-from
+                errors=err.errors()
+            )
     # Elif content is form-data then parse the form
     elif "multipart/form-data" in content_type:
         # Get the raw form data
@@ -285,9 +286,10 @@ def _parse_form_data_to_pydantic(
                     try:
                         raw_objects[n] = json.loads(sub_obj)
                     except TypeError:
-                        raise HTTPException(
+                        raise HTTPException(  # pylint: disable=raise-missing-from
                             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                            detail=f"Unable to update object at key '{key}'; expected value to be string",
+                            detail=f"Unable to update object at key '{key};"
+                            "; expected value to be string",
                         )
                     except json.JSONDecodeError:
                         failed_to_parse_json = True
@@ -323,12 +325,14 @@ def _parse_form_data_to_pydantic(
     try:
         return pydantic_model.model_validate(raw_model_obj)
     except pydantic.ValidationError as err:
-        raise RequestValidationError(errors=err.errors())
+        raise RequestValidationError(  # pylint: disable=raise-missing-from
+            errors=err.errors()
+        )
 
 
 def _get_pydantic_subtypes(
-    pydantic_model: Type[pydantic.BaseModel], keys: list[str]
-) -> list[type]:
+    pydantic_model: Type[pydantic.BaseModel], keys: List[str]
+) -> List[type]:
     """Recursive helper to get the type_hint for a field"""
     if len(keys) == 0:
         return [pydantic_model]

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -40,13 +40,13 @@ import alog
 
 # Local
 from caikit.core.data_model.base import DataBase
+from caikit.interfaces.common.data_model import File
 from caikit.interfaces.common.data_model.primitive_sequences import (
     BoolSequence,
     FloatSequence,
     IntSequence,
     StrSequence,
 )
-from caikit.interfaces.common.data_model.stream_sources import File
 from caikit.runtime.http_server.utils import update_dict_at_dot_path
 
 log = alog.use_channel("SERVR-HTTP-PYDNTC")

--- a/caikit/runtime/http_server/utils.py
+++ b/caikit/runtime/http_server/utils.py
@@ -18,6 +18,9 @@ this includes things like parameter handles and openapi spec generation
 # Standard
 from typing import Any, Optional
 
+# Local
+from ...config.config import merge_configs
+
 
 def convert_json_schema_to_multipart(json_schema):
     """Helper function to convert a json schema from applicaiton/json into one
@@ -186,5 +189,11 @@ def update_dict_at_dot_path(dict_obj: dict, key: str, updated_value: Any) -> boo
         dict_obj = dict_obj.setdefault(part, {})
         if not isinstance(dict_obj, dict):
             return False
-    dict_obj[parts[-1]] = updated_value
+
+    # If value already exists and is a dict and the target value is a dict then
+    # deep merge the keys
+    if isinstance(dict_obj.get(parts[-1]), dict) and isinstance(updated_value, dict):
+        merge_configs(dict_obj[parts[-1]], updated_value)
+    else:
+        dict_obj[parts[-1]] = updated_value
     return True

--- a/caikit/runtime/http_server/utils.py
+++ b/caikit/runtime/http_server/utils.py
@@ -26,7 +26,10 @@ def convert_json_schema_to_multipart(json_schema):
     """Helper function to convert a json schema from applicaiton/json into one
     that can be used for multipart requests"""
     sparse_schema, extracted_files = _extract_raw_from_schema(json_schema)
-    sparse_schema["properties"] = {**sparse_schema["properties"], **extracted_files}
+    sparse_schema["properties"] = {
+        **sparse_schema.get("properties", {}),
+        **extracted_files,
+    }
     return sparse_schema
 
 

--- a/caikit/runtime/http_server/utils.py
+++ b/caikit/runtime/http_server/utils.py
@@ -20,7 +20,8 @@ from typing import Any, Optional
 
 
 def convert_json_schema_to_multipart(json_schema):
-    """Helper function to"""
+    """Helper function to convert a json schema from applicaiton/json into one
+    that can be used for multipart requests"""
     sparse_schema, extracted_files = _extract_raw_from_schema(json_schema)
     sparse_schema["properties"] = {**sparse_schema["properties"], **extracted_files}
     return sparse_schema

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -212,6 +212,10 @@ class FileDataStreamSourcePlugin(FilePluginBase):
 
     name = "FileData"
 
+    def get_field_name(self, element_type: type) -> str:
+        """Half-Backwards compatibility and half keep FileReference consistent with ListofFiles/Directory"""
+        return "file"
+
     def get_stream_message_type(self, *_, **__) -> Type[DataBase]:
         return FileReference
 

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -37,8 +37,8 @@ from caikit.core.exceptions import error_handler
 from caikit.core.toolkit.factory import FactoryConstructible, ImportableFactory
 from caikit.interfaces.common.data_model.stream_sources import (
     Directory,
-    File,
-    ListOfFiles,
+    FileReference,
+    ListOfFileReferences,
     S3Files,
 )
 from caikit.runtime.service_generation.proto_package import get_runtime_service_package
@@ -213,9 +213,9 @@ class FileDataStreamSourcePlugin(FilePluginBase):
     name = "FileData"
 
     def get_stream_message_type(self, *_, **__) -> Type[DataBase]:
-        return File
+        return FileReference
 
-    def to_data_stream(self, source_message: File, element_type: type) -> DataStream:
+    def to_data_stream(self, source_message: FileReference, element_type: type) -> DataStream:
         return self._create_data_stream_from_file(
             fname=source_message.filename, element_type=element_type
         )
@@ -230,10 +230,10 @@ class ListOfFilesDataStreamSourcePlugin(FilePluginBase):
     name = "ListOfFiles"
 
     def get_stream_message_type(self, *_, **__) -> Type[DataBase]:
-        return ListOfFiles
+        return ListOfFileReferences
 
     def to_data_stream(
-        self, source_message: ListOfFiles, element_type: type
+        self, source_message: ListOfFileReferences, element_type: type
     ) -> DataStream:
         data_stream_list = []
         for fname in source_message.files:

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -213,7 +213,8 @@ class FileDataStreamSourcePlugin(FilePluginBase):
     name = "FileData"
 
     def get_field_name(self, element_type: type) -> str:
-        """Half-Backwards compatibility and half keep FileReference consistent with ListofFiles/Directory"""
+        """Half-Backwards compatibility and half keep FileReference consistent
+        with ListofFiles/Directory"""
         return "file"
 
     def get_stream_message_type(self, *_, **__) -> Type[DataBase]:
@@ -234,6 +235,11 @@ class ListOfFilesDataStreamSourcePlugin(FilePluginBase):
     """Plugin for a list of files"""
 
     name = "ListOfFiles"
+
+    def get_field_name(self, element_type: type) -> str:
+        """Half-Backwards compatibility and half keep ListOfFile consistent
+        with File/Directory"""
+        return "list_of_files"
 
     def get_stream_message_type(self, *_, **__) -> Type[DataBase]:
         return ListOfFileReferences

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -215,7 +215,9 @@ class FileDataStreamSourcePlugin(FilePluginBase):
     def get_stream_message_type(self, *_, **__) -> Type[DataBase]:
         return FileReference
 
-    def to_data_stream(self, source_message: FileReference, element_type: type) -> DataStream:
+    def to_data_stream(
+        self, source_message: FileReference, element_type: type
+    ) -> DataStream:
         return self._create_data_stream_from_file(
             fname=source_message.filename, element_type=element_type
         )

--- a/caikit/runtime/servicers/model_train_servicer.py
+++ b/caikit/runtime/servicers/model_train_servicer.py
@@ -28,8 +28,8 @@ import alog
 from caikit import get_config
 from caikit.interfaces.common.data_model.stream_sources import (
     Directory,
-    FileStream,
-    ListOfFileStreams,
+    FileReference,
+    ListOfFileReferences,
 )
 from caikit.runtime.protobufs import process_pb2, process_pb2_grpc
 from caikit.runtime.service_factory import ServicePackage
@@ -193,11 +193,11 @@ class ModelTrainServicerImpl(process_pb2_grpc.ProcessServicer):
             if isinstance(val, DataStreamSourceBase):
                 # 3. Look for file pointers and update them
                 source = val.data_stream
-                if isinstance(source, FileStream):
+                if isinstance(source, FileReference):
                     source.filename = self._update_file_ref(
                         source.filename, training_input_dir
                     )
-                if isinstance(source, ListOfFileStreams):
+                if isinstance(source, ListOfFileReferences):
                     source.files = [
                         self._update_file_ref(filename, training_input_dir)
                         for filename in source.files

--- a/caikit/runtime/servicers/model_train_servicer.py
+++ b/caikit/runtime/servicers/model_train_servicer.py
@@ -28,8 +28,8 @@ import alog
 from caikit import get_config
 from caikit.interfaces.common.data_model.stream_sources import (
     Directory,
-    File,
-    ListOfFiles,
+    FileStream,
+    ListOfFileStreams,
 )
 from caikit.runtime.protobufs import process_pb2, process_pb2_grpc
 from caikit.runtime.service_factory import ServicePackage
@@ -193,11 +193,11 @@ class ModelTrainServicerImpl(process_pb2_grpc.ProcessServicer):
             if isinstance(val, DataStreamSourceBase):
                 # 3. Look for file pointers and update them
                 source = val.data_stream
-                if isinstance(source, File):
+                if isinstance(source, FileStream):
                     source.filename = self._update_file_ref(
                         source.filename, training_input_dir
                     )
-                if isinstance(source, ListOfFiles):
+                if isinstance(source, ListOfFileStreams):
                     source.files = [
                         self._update_file_ref(filename, training_input_dir)
                         for filename in source.files

--- a/tests/fixtures/sample_lib/data_model/sample.py
+++ b/tests/fixtures/sample_lib/data_model/sample.py
@@ -24,8 +24,7 @@ class SampleInputType(DataObjectBase):
 
 @dataobject(package="caikit_data_model.sample_lib")
 class SampleListInputType(DataObjectBase):
-    """A sample `domain primitive` input type for this library.
-    The analog to a `Raw Document` for the `Natural Language Processing` domain."""
+    """A sample list input type for this library"""
 
     inputs: List[SampleInputType]
 

--- a/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
@@ -23,7 +23,7 @@ from ...data_model.sample import (
     SampleOutputType,
 )
 from caikit.core.modules import ModuleLoader
-from caikit.interfaces.common.data_model.stream_sources import File
+from caikit.interfaces.common.data_model import File
 import caikit.core
 
 

--- a/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
+++ b/tests/fixtures/sample_lib/modules/file_processing/bounding_box_module.py
@@ -16,8 +16,14 @@
 A sample module for sample things!
 """
 # Local
-from ...data_model.sample import FileDataType, FileTask
+from ...data_model.sample import (
+    FileInputType,
+    FileOutputType,
+    FileTask,
+    SampleOutputType,
+)
 from caikit.core.modules import ModuleLoader
+from caikit.interfaces.common.data_model.stream_sources import File
 import caikit.core
 
 
@@ -27,11 +33,16 @@ import caikit.core
 class BoundingBoxModule(caikit.core.ModuleBase):
     def run(
         self,
-        unprocessed: FileDataType,
-    ) -> FileDataType:
-        filename = f"processed_{unprocessed.filename}"
-        data = b"bounding|" + unprocessed.data + b"|box"
-        return FileDataType(filename, data)
+        input: FileInputType,
+    ) -> FileOutputType:
+        filename = f"processed_{input.file.filename}"
+        data = b"bounding|" + input.file.data + b"|box"
+        return FileOutputType(
+            File(filename=filename, data=data),
+            SampleOutputType(
+                greeting=f"Hello {input.metadata.name} and {input.file.filename}"
+            ),
+        )
 
     @classmethod
     def load(cls, model_path, **kwargs):

--- a/tests/fixtures/sample_lib/modules/multi_task/multi_task_module.py
+++ b/tests/fixtures/sample_lib/modules/multi_task/multi_task_module.py
@@ -1,12 +1,8 @@
 # Local
-from ...data_model.sample import (
-    FileDataType,
-    OtherOutputType,
-    SampleInputType,
-    SampleOutputType,
-)
+from ...data_model.sample import OtherOutputType, SampleInputType, SampleOutputType
 from caikit.core import TaskBase, module, task
 from caikit.core.data_model import ProducerId
+from caikit.interfaces.common.data_model import File
 import caikit
 
 
@@ -19,7 +15,7 @@ class FirstTask(TaskBase):
 
 
 @task(
-    unary_parameters={"file_input": FileDataType},
+    unary_parameters={"file_input": File},
     unary_output_type=OtherOutputType,
 )
 class SecondTask(TaskBase):
@@ -45,7 +41,7 @@ class MultiTaskModule(caikit.core.ModuleBase):
         return SampleOutputType("Hello from FirstTask")
 
     @SecondTask.taskmethod()
-    def run_other_task(self, file_input: FileDataType) -> OtherOutputType:
+    def run_other_task(self, file_input: File) -> OtherOutputType:
         return OtherOutputType(
             "Goodbye from SecondTask", ProducerId("MultiTaskModule", "0.0.1")
         )

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -303,6 +303,7 @@ def test_inference_sample_task(sample_task_model_id, runtime_http_server):
             json=json_input,
         )
         json_response = json.loads(response.content.decode(response.default_encoding))
+        print(json_response)
         assert response.status_code == 200, json_response
         assert json_response["greeting"] == "Hello world"
 
@@ -333,13 +334,12 @@ def test_inference_sample_task_multipart_input(
 
     with TestClient(runtime_http_server.app) as client:
         multipart_input = {
+            "model_id": sample_task_model_id,
             "inputs.name": "world",
             "parameters": json.dumps({"throw": False}),
         }
 
-        response = client.post(
-            f"/api/v1/{sample_task_model_id}/task/sample", files=multipart_input
-        )
+        response = client.post(f"/api/v1/task/sample", files=multipart_input)
 
         json_response = json.loads(response.content.decode(response.default_encoding))
         assert response.status_code == 200, json_response
@@ -347,7 +347,7 @@ def test_inference_sample_task_multipart_input(
 
         multipart_input["parameters"] = json.dumps({"throw": True})
         response = client.post(
-            f"/api/v1/{sample_task_model_id}/task/sample",
+            f"/api/v1/task/sample",
             files=multipart_input,
         )
         # this is 500 because we explicitly pass in `throw` as True, which
@@ -368,12 +368,13 @@ def test_inference_file_task_multipart_flipped_input(
         temp_file.seek(0)
 
         file_input = {
+            "model_id": file_task_model_id,
             "inputs.file": temp_file,
             "inputs": json.dumps({"metadata": {"name": "agoodname"}}),
         }
 
         response = client.post(
-            f"/api/v1/{file_task_model_id}/task/file",
+            f"/api/v1/task/file",
             files=file_input,
         )
         content_stream = BytesIO(response.content)

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -17,11 +17,14 @@ Tests for the caikit HTTP server
 # Standard
 from contextlib import contextmanager
 from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
 from typing import Dict
 import json
 import os
 import signal
 import tempfile
+import zipfile
 
 # Third Party
 from fastapi.testclient import TestClient
@@ -323,6 +326,35 @@ def test_inference_sample_task_optional_field(
         assert response.status_code == 500
 
 
+def test_inference_sample_task_multipart_input(
+    sample_task_model_id, runtime_http_server
+):
+    """Simple check that we can submit multipart requests"""
+
+    with TestClient(runtime_http_server.app) as client:
+        multipart_input = {
+            "inputs.name": "world",
+            "parameters": json.dumps({"throw": False}),
+        }
+
+        response = client.post(
+            f"/api/v1/{sample_task_model_id}/task/sample", files=multipart_input
+        )
+
+        json_response = json.loads(response.content.decode(response.default_encoding))
+        assert response.status_code == 200, json_response
+        assert json_response["greeting"] == "Hello world"
+
+        multipart_input["parameters"] = json.dumps({"throw": True})
+        response = client.post(
+            f"/api/v1/{sample_task_model_id}/task/sample",
+            files=multipart_input,
+        )
+        # this is 500 because we explicitly pass in `throw` as True, which
+        # raises an internal error in the module
+        assert response.status_code == 500
+
+
 def test_inference_other_task(other_task_model_id, runtime_http_server):
     """Simple check that we can ping a model"""
     with TestClient(runtime_http_server.app) as client:
@@ -336,24 +368,36 @@ def test_inference_other_task(other_task_model_id, runtime_http_server):
         assert json_response["farewell"] == "goodbye: world 42 times"
 
 
-def test_json_file_task(file_task_model_id, runtime_http_server):
-    """Simple check that we can ping a model"""
+def test_output_file_task(file_task_model_id, runtime_http_server):
+    """Simple check that we can get a file output"""
     with TestClient(runtime_http_server.app) as client:
         # cGRmZGF0Yf//AA== is b"pdfdata\xff\xff\x00" base64 encoded
-        json_input = {
+        temp_file = tempfile.NamedTemporaryFile()
+        temp_file_name = Path(temp_file.name).name
+        temp_file.write(b"pdfdata\xff\xff\x00")
+        temp_file.flush()
+        temp_file.seek(0)
+
+        file_input = {
             "model_id": file_task_model_id,
-            "inputs": {"filename": "example.pdf", "data": "cGRmZGF0Yf//AA=="},
+            "inputs.file": temp_file,
+            "inputs.metadata": json.dumps({"name": "agoodname"}),
         }
 
         response = client.post(
             f"/api/v1/task/file",
-            json=json_input,
+            files=file_input,
         )
-        json_response = json.loads(response.content.decode(response.default_encoding))
-        assert response.status_code == 200, json_response
-        assert json_response["filename"] == "processed_example.pdf"
-        # Ym91bmRpbmd8cGRmZGF0Yf//AHxib3g= is b"bounding|pdfdata\xff\xff\x00|box" base64 encoded
-        assert json_response["data"] == "Ym91bmRpbmd8cGRmZGF0Yf//AHxib3g="
+        content_stream = BytesIO(response.content)
+
+        assert response.status_code == 200
+        with zipfile.ZipFile(content_stream) as output_file:
+            assert len(output_file.namelist()) == 2
+            assert "metadata.json" in output_file.namelist()
+            assert f"processed_{temp_file_name}" in output_file.namelist()
+
+            with output_file.open(f"processed_{temp_file_name}") as pdf_result:
+                assert pdf_result.read() == b"bounding|pdfdata\xff\xff\x00|box"
 
 
 def test_inference_streaming_sample_module(sample_task_model_id, runtime_http_server):

--- a/tests/runtime/http_server/test_pydantic_wrapper.py
+++ b/tests/runtime/http_server/test_pydantic_wrapper.py
@@ -30,7 +30,7 @@ from py_to_proto.dataclass_to_proto import Annotated
 # Local
 from caikit.core import DataObjectBase, dataobject
 from caikit.core.data_model.base import DataBase
-from caikit.interfaces.common.data_model.stream_sources import File
+from caikit.interfaces.common.data_model import File, FileStream
 from caikit.interfaces.nlp.data_model.text_generation import (
     GeneratedTextStreamResult,
     GeneratedToken,
@@ -111,11 +111,8 @@ def test_pydantic_to_dataobject_datastream_file():
 
     # assert it's our DM object, all fine and dandy
     assert isinstance(datastream_dm_obj, DataBase)
-    assert isinstance(datastream_dm_obj.data_stream, File)
-    assert (
-        datastream_dm_obj.to_json()
-        == '{"file": {"filename": "hello", "data": null, "type": null}}'
-    )
+    assert isinstance(datastream_dm_obj.data_stream, FileStream)
+    assert datastream_dm_obj.to_json() == '{"filestream": {"filename": "hello"}}'
 
 
 @pytest.mark.parametrize(
@@ -251,8 +248,8 @@ def test_dataobject_to_pydantic_oneof():
     assert {
         "data_stream": Union[
             PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.JsonData),
-            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.File),
-            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.ListOfFiles),
+            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.FileStream),
+            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.ListOfFileStreams),
             PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.Directory),
             PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.S3Files),
         ]
@@ -268,7 +265,7 @@ def test_dataobject_to_pydantic_oneof():
         ),
     )
     assert issubclass(
-        PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.File),
+        PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.FileStream),
         type(
             data_stream_source_pydantic_model.model_validate_json(
                 '{"data_stream": {"filename": "file1"}}'

--- a/tests/runtime/http_server/test_pydantic_wrapper.py
+++ b/tests/runtime/http_server/test_pydantic_wrapper.py
@@ -30,7 +30,7 @@ from py_to_proto.dataclass_to_proto import Annotated
 # Local
 from caikit.core import DataObjectBase, dataobject
 from caikit.core.data_model.base import DataBase
-from caikit.interfaces.common.data_model import File, FileStream
+from caikit.interfaces.common.data_model import File, FileReference
 from caikit.interfaces.nlp.data_model.text_generation import (
     GeneratedTextStreamResult,
     GeneratedToken,
@@ -111,8 +111,8 @@ def test_pydantic_to_dataobject_datastream_file():
 
     # assert it's our DM object, all fine and dandy
     assert isinstance(datastream_dm_obj, DataBase)
-    assert isinstance(datastream_dm_obj.data_stream, FileStream)
-    assert datastream_dm_obj.to_json() == '{"filestream": {"filename": "hello"}}'
+    assert isinstance(datastream_dm_obj.data_stream, FileReference)
+    assert datastream_dm_obj.to_json() == '{"filereference": {"filename": "hello"}}'
 
 
 @pytest.mark.parametrize(
@@ -248,8 +248,8 @@ def test_dataobject_to_pydantic_oneof():
     assert {
         "data_stream": Union[
             PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.JsonData),
-            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.FileStream),
-            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.ListOfFileStreams),
+            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.FileReference),
+            PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.ListOfFileReferences),
             PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.Directory),
             PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.S3Files),
         ]
@@ -265,7 +265,7 @@ def test_dataobject_to_pydantic_oneof():
         ),
     )
     assert issubclass(
-        PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.FileStream),
+        PYDANTIC_TO_DM_MAPPING.get(sample_input_dm_class.FileReference),
         type(
             data_stream_source_pydantic_model.model_validate_json(
                 '{"data_stream": {"filename": "file1"}}'

--- a/tests/runtime/http_server/test_pydantic_wrapper.py
+++ b/tests/runtime/http_server/test_pydantic_wrapper.py
@@ -112,7 +112,7 @@ def test_pydantic_to_dataobject_datastream_file():
     # assert it's our DM object, all fine and dandy
     assert isinstance(datastream_dm_obj, DataBase)
     assert isinstance(datastream_dm_obj.data_stream, FileReference)
-    assert datastream_dm_obj.to_json() == '{"filereference": {"filename": "hello"}}'
+    assert datastream_dm_obj.to_json() == '{"file": {"filename": "hello"}}'
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/http_server/test_utils.py
+++ b/tests/runtime/http_server/test_utils.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Union
 
 # Local
 from caikit.core import DataObjectBase, dataobject
-from caikit.interfaces.common.data_model.stream_sources import File
+from caikit.interfaces.common.data_model import File
 from caikit.runtime.http_server.pydantic_wrapper import dataobject_to_pydantic
 from caikit.runtime.http_server.utils import (
     convert_json_schema_to_multipart,

--- a/tests/runtime/http_server/test_utils.py
+++ b/tests/runtime/http_server/test_utils.py
@@ -1,0 +1,94 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+from typing import List, Optional, Union
+
+# Local
+from caikit.core import DataObjectBase, dataobject
+from caikit.interfaces.common.data_model.stream_sources import File
+from caikit.runtime.http_server.pydantic_wrapper import dataobject_to_pydantic
+from caikit.runtime.http_server.utils import (
+    convert_json_schema_to_multipart,
+    flatten_json_schema,
+    update_dict_at_dot_path,
+)
+
+## Setup #########################################################################
+
+
+@dataobject(package="caikit_data_model.test_utils")
+class ComplexUtilBaseClass(DataObjectBase):
+    bytes_type: bytes
+    file_type: Optional[File]
+    metadata: Union[int, str]
+    list_file_type: List[File]
+
+
+@dataobject(package="caikit_data_model.test_utils")
+class ComplexUtilHttpServerInputs(DataObjectBase):
+    inputs: ComplexUtilBaseClass
+
+
+def _recursively_assert_no_refs(obj):
+    if isinstance(obj, dict):
+        assert "$ref" not in obj.keys()
+        [_recursively_assert_no_refs(val) for val in obj.values()]
+    elif isinstance(obj, list):
+        [_recursively_assert_no_refs(val) for val in obj]
+
+
+## Tests ########################################################################
+
+
+### convert_json_schema_to_multipart #############################################################
+
+
+def test_convert_json_schema_to_multipart():
+    pydantic_model = dataobject_to_pydantic(ComplexUtilHttpServerInputs)
+    parsed_schema = flatten_json_schema(pydantic_model.model_json_schema())
+    converted_schema = convert_json_schema_to_multipart(parsed_schema)
+    # Make sure the converted schema has the properly extracted fields
+    assert "inputs" in converted_schema["properties"].keys()
+    assert "inputs.bytes_type" in converted_schema["properties"].keys()
+    assert "inputs.file_type" in converted_schema["properties"].keys()
+    assert "inputs.list_file_type" in converted_schema["properties"].keys()
+    assert converted_schema["properties"]["inputs.list_file_type"]["type"] == "array"
+    _recursively_assert_no_refs(converted_schema)
+
+
+### flatten_json_schema #############################################################
+
+
+def test_flatten_json_schema():
+    """If an invalid module is provided to caikit lib setup, it throws a ValueError"""
+    pydantic_model = dataobject_to_pydantic(ComplexUtilHttpServerInputs)
+    flattened_schema = flatten_json_schema(pydantic_model.model_json_schema())
+    # Assert there are no longer defs in schema
+    assert "$defs" not in flattened_schema
+    _recursively_assert_no_refs(flattened_schema)
+
+
+### update_dict_at_dot_path #############################################################
+
+
+def test_update_dict_at_dot_path():
+    source_object = {"nondict": 1}
+
+    # Assert function can update dict
+    assert update_dict_at_dot_path(source_object, "test.path", "value")
+    assert source_object["test"]["path"] == "value"
+
+    assert not update_dict_at_dot_path(source_object, "nondict.path", "value")
+    assert source_object["nondict"] == 1

--- a/tests/runtime/service_generation/test_create_service.py
+++ b/tests/runtime/service_generation/test_create_service.py
@@ -17,6 +17,7 @@ import uuid
 
 # Local
 from caikit.core import LocalBackend
+from caikit.interfaces.common.data_model import File
 from caikit.runtime.service_generation.create_service import (
     create_inference_rpcs,
     create_training_rpcs,
@@ -27,7 +28,6 @@ from sample_lib.data_model import (
     SampleOutputType,
     SampleTask,
 )
-from sample_lib.data_model.sample import FileDataType
 from sample_lib.modules import FirstTask, MultiTaskModule, SampleModule, SecondTask
 from tests.conftest import temp_config
 import caikit

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -27,8 +27,8 @@ import aconfig
 from caikit.core.data_model.streams.data_stream import DataStream
 from caikit.interfaces.common.data_model.stream_sources import (
     Directory,
-    File,
-    ListOfFiles,
+    FileReference,
+    ListOfFileReferences,
 )
 from caikit.runtime.service_generation.data_stream_source import (
     DataStreamPluginFactory,
@@ -50,7 +50,7 @@ import sample_lib
 def test_file_plugin(sample_json_file):
     # Sample json file has SampleTrainingType data
     element_type = sample_lib.data_model.SampleTrainingType
-    source_message = File(filename=sample_json_file)
+    source_message = FileReference(filename=sample_json_file)
     stream = FileDataStreamSourcePlugin({}, "").to_data_stream(
         source_message, element_type
     )
@@ -70,7 +70,7 @@ def test_directory_plugin(sample_json_collection):
 def test_list_of_files_plugin(sample_json_file, sample_csv_file, sample_jsonl_file):
     # Samples all have SampleTrainingType data
     element_type = sample_lib.data_model.SampleTrainingType
-    source_message = ListOfFiles(
+    source_message = ListOfFileReferences(
         files=[sample_json_file, sample_jsonl_file, sample_csv_file]
     )
     stream = ListOfFilesDataStreamSourcePlugin({}, "").to_data_stream(

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -11,7 +11,11 @@ import pytest
 # Local
 from caikit.core.data_model import DataObjectBase, dataobject
 from caikit.core.data_model.streams.data_stream import DataStream
-from caikit.interfaces.common.data_model.stream_sources import Directory, FileStream, S3Files
+from caikit.interfaces.common.data_model.stream_sources import (
+    Directory,
+    FileStream,
+    S3Files,
+)
 from caikit.runtime.service_generation.data_stream_source import (
     DataStreamSourceBase,
     _make_data_stream_source_type_name,
@@ -386,7 +390,9 @@ def test_make_data_stream_source_list_of_jsonl_files(sample_jsonl_collection):
         os.path.join(sample_jsonl_collection, file)
         for file in os.listdir(sample_jsonl_collection)
     ]
-    ds = stream_type(listoffilestreams=stream_type.ListOfFileStreams(files=sample_files))
+    ds = stream_type(
+        listoffilestreams=stream_type.ListOfFileStreams(files=sample_files)
+    )
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -349,7 +349,7 @@ def test_make_data_stream_source_list_of_json_files(sample_json_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     # does NOT work with sample_json_collection as each file needs to have data in array
     ds = stream_type(
-        listoffilereferences=stream_type.ListOfFileReferences(
+        list_of_files=stream_type.ListOfFileReferences(
             files=[sample_json_file, sample_json_file]
         )
     )
@@ -368,9 +368,7 @@ def test_make_data_stream_source_list_of_csv_files(sample_csv_collection):
         for file in os.listdir(sample_csv_collection)
     ]
     # send all files but last one
-    ds = stream_type(
-        listoffilereferences=stream_type.ListOfFileReferences(files=sample_files)
-    )
+    ds = stream_type(list_of_files=stream_type.ListOfFileReferences(files=sample_files))
 
     assert isinstance(ds, DataStreamSourceBase)
 
@@ -386,9 +384,7 @@ def test_make_data_stream_source_list_of_jsonl_files(sample_jsonl_collection):
         os.path.join(sample_jsonl_collection, file)
         for file in os.listdir(sample_jsonl_collection)
     ]
-    ds = stream_type(
-        listoffilereferences=stream_type.ListOfFileReferences(files=sample_files)
-    )
+    ds = stream_type(list_of_files=stream_type.ListOfFileReferences(files=sample_files))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -138,9 +138,7 @@ def test_data_stream_source_as_data_stream():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl") as handle:
         handle.write("\n".join([str(val) for val in source_list]))
         handle.flush()
-        inst = stream_source(
-            filereference=stream_source.FileReference(filename=handle.name)
-        )
+        inst = stream_source(file=stream_source.FileReference(filename=handle.name))
         assert list(inst) == source_list
 
 
@@ -160,20 +158,14 @@ def test_data_stream_source_base_path():
 
             # Make sure it works with the relative file path
             assert (
-                list(
-                    stream_source(
-                        filereference=stream_source.FileReference(filename=fname)
-                    )
-                )
+                list(stream_source(file=stream_source.FileReference(filename=fname)))
                 == source_data
             )
 
             # Make sure it works with the absolute file path
             assert (
                 list(
-                    stream_source(
-                        filereference=stream_source.FileReference(filename=full_fname)
-                    )
+                    stream_source(file=stream_source.FileReference(filename=full_fname))
                 )
                 == source_data
             )
@@ -202,9 +194,7 @@ def test_data_stream_source_base_path():
             with pytest.raises(CaikitRuntimeException):
                 list(
                     stream_source(
-                        filereference=stream_source.FileReference(
-                            filename="invalid/path.json"
-                        )
+                        file=stream_source.FileReference(filename="invalid/path.json")
                     )
                 )
             with pytest.raises(CaikitRuntimeException):
@@ -253,7 +243,7 @@ def test_make_data_stream_source_jsondata_other_task():
 
 def test_make_data_stream_source_jsonfile(sample_json_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filereference=FileReference(filename=sample_json_file))
+    ds = stream_type(file=FileReference(filename=sample_json_file))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -265,7 +255,7 @@ def test_make_data_stream_source_jsonfile(sample_json_file):
 
 def test_make_data_stream_source_csvfile(sample_csv_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filereference=FileReference(filename=sample_csv_file))
+    ds = stream_type(file=FileReference(filename=sample_csv_file))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -276,7 +266,7 @@ def test_make_data_stream_source_csvfile(sample_csv_file):
 
 def test_make_data_stream_source_jsonlfile(sample_jsonl_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filereference=FileReference(filename=sample_jsonl_file))
+    ds = stream_type(file=FileReference(filename=sample_jsonl_file))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -297,7 +287,7 @@ def test_make_data_stream_source_jsonlfile_extra_fields(tmp_path):
         """
         )
 
-    ds = stream_type(filereference=FileReference(filename=file_path))
+    ds = stream_type(file=FileReference(filename=file_path))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -314,7 +304,7 @@ def test_make_data_stream_source_from_file_with_no_extension(
         no_extension_filename = os.path.join(str(tmp_path), "no_extension")
         shutil.copyfile(file, no_extension_filename)
 
-        ds = stream_type(filereference=FileReference(filename=no_extension_filename))
+        ds = stream_type(file=FileReference(filename=no_extension_filename))
         assert isinstance(ds, DataStreamSourceBase)
 
         data_stream = ds.to_data_stream()
@@ -341,7 +331,7 @@ def test_make_data_stream_source_from_multipart_formdata_file(
         no_extension_filename = os.path.join(str(tmp_path), "no_extension")
         shutil.copyfile(file, no_extension_filename)
 
-        ds = stream_type(filereference=FileReference(filename=no_extension_filename))
+        ds = stream_type(file=FileReference(filename=no_extension_filename))
         assert isinstance(ds, DataStreamSourceBase)
 
         data_stream = ds.to_data_stream()
@@ -477,7 +467,7 @@ def test_data_stream_operators():
 
 def test_make_data_stream_source_invalid_file_raises():
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filereference=FileReference(filename="invalid_file"))
+    ds = stream_type(file=FileReference(filename="invalid_file"))
     with pytest.raises(CaikitRuntimeException):
         ds.to_data_stream()
 
@@ -534,7 +524,7 @@ def test_make_data_stream_source_non_json_array_errors(tmp_path):
         }
         """
         )
-    ds = stream_type(filereference=FileReference(filename=file_path))
+    ds = stream_type(file=FileReference(filename=file_path))
     assert isinstance(ds, DataStreamSourceBase)
 
     with pytest.raises(ValueError, match="Non-array JSON object"):

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -13,7 +13,7 @@ from caikit.core.data_model import DataObjectBase, dataobject
 from caikit.core.data_model.streams.data_stream import DataStream
 from caikit.interfaces.common.data_model.stream_sources import (
     Directory,
-    FileStream,
+    FileReference,
     S3Files,
 )
 from caikit.runtime.service_generation.data_stream_source import (
@@ -138,7 +138,9 @@ def test_data_stream_source_as_data_stream():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl") as handle:
         handle.write("\n".join([str(val) for val in source_list]))
         handle.flush()
-        inst = stream_source(filestream=stream_source.FileStream(filename=handle.name))
+        inst = stream_source(
+            filereference=stream_source.FileReference(filename=handle.name)
+        )
         assert list(inst) == source_list
 
 
@@ -158,7 +160,11 @@ def test_data_stream_source_base_path():
 
             # Make sure it works with the relative file path
             assert (
-                list(stream_source(filestream=stream_source.FileStream(filename=fname)))
+                list(
+                    stream_source(
+                        filereference=stream_source.FileReference(filename=fname)
+                    )
+                )
                 == source_data
             )
 
@@ -166,7 +172,7 @@ def test_data_stream_source_base_path():
             assert (
                 list(
                     stream_source(
-                        filestream=stream_source.FileStream(filename=full_fname)
+                        filereference=stream_source.FileReference(filename=full_fname)
                     )
                 )
                 == source_data
@@ -196,7 +202,7 @@ def test_data_stream_source_base_path():
             with pytest.raises(CaikitRuntimeException):
                 list(
                     stream_source(
-                        filestream=stream_source.FileStream(
+                        filereference=stream_source.FileReference(
                             filename="invalid/path.json"
                         )
                     )
@@ -247,7 +253,7 @@ def test_make_data_stream_source_jsondata_other_task():
 
 def test_make_data_stream_source_jsonfile(sample_json_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filestream=FileStream(filename=sample_json_file))
+    ds = stream_type(filereference=FileReference(filename=sample_json_file))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -259,7 +265,7 @@ def test_make_data_stream_source_jsonfile(sample_json_file):
 
 def test_make_data_stream_source_csvfile(sample_csv_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filestream=FileStream(filename=sample_csv_file))
+    ds = stream_type(filereference=FileReference(filename=sample_csv_file))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -270,7 +276,7 @@ def test_make_data_stream_source_csvfile(sample_csv_file):
 
 def test_make_data_stream_source_jsonlfile(sample_jsonl_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filestream=FileStream(filename=sample_jsonl_file))
+    ds = stream_type(filereference=FileReference(filename=sample_jsonl_file))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -291,7 +297,7 @@ def test_make_data_stream_source_jsonlfile_extra_fields(tmp_path):
         """
         )
 
-    ds = stream_type(filestream=FileStream(filename=file_path))
+    ds = stream_type(filereference=FileReference(filename=file_path))
     assert isinstance(ds, DataStreamSourceBase)
 
     data_stream = ds.to_data_stream()
@@ -308,7 +314,7 @@ def test_make_data_stream_source_from_file_with_no_extension(
         no_extension_filename = os.path.join(str(tmp_path), "no_extension")
         shutil.copyfile(file, no_extension_filename)
 
-        ds = stream_type(filestream=FileStream(filename=no_extension_filename))
+        ds = stream_type(filereference=FileReference(filename=no_extension_filename))
         assert isinstance(ds, DataStreamSourceBase)
 
         data_stream = ds.to_data_stream()
@@ -335,7 +341,7 @@ def test_make_data_stream_source_from_multipart_formdata_file(
         no_extension_filename = os.path.join(str(tmp_path), "no_extension")
         shutil.copyfile(file, no_extension_filename)
 
-        ds = stream_type(filestream=FileStream(filename=no_extension_filename))
+        ds = stream_type(filereference=FileReference(filename=no_extension_filename))
         assert isinstance(ds, DataStreamSourceBase)
 
         data_stream = ds.to_data_stream()
@@ -353,7 +359,7 @@ def test_make_data_stream_source_list_of_json_files(sample_json_file):
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     # does NOT work with sample_json_collection as each file needs to have data in array
     ds = stream_type(
-        listoffilestreams=stream_type.ListOfFileStreams(
+        listoffilereferences=stream_type.ListOfFileReferences(
             files=[sample_json_file, sample_json_file]
         )
     )
@@ -373,7 +379,7 @@ def test_make_data_stream_source_list_of_csv_files(sample_csv_collection):
     ]
     # send all files but last one
     ds = stream_type(
-        listoffilestreams=stream_type.ListOfFileStreams(files=sample_files)
+        listoffilereferences=stream_type.ListOfFileReferences(files=sample_files)
     )
 
     assert isinstance(ds, DataStreamSourceBase)
@@ -391,7 +397,7 @@ def test_make_data_stream_source_list_of_jsonl_files(sample_jsonl_collection):
         for file in os.listdir(sample_jsonl_collection)
     ]
     ds = stream_type(
-        listoffilestreams=stream_type.ListOfFileStreams(files=sample_files)
+        listoffilereferences=stream_type.ListOfFileReferences(files=sample_files)
     )
     assert isinstance(ds, DataStreamSourceBase)
 
@@ -471,7 +477,7 @@ def test_data_stream_operators():
 
 def test_make_data_stream_source_invalid_file_raises():
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    ds = stream_type(filestream=FileStream(filename="invalid_file"))
+    ds = stream_type(filereference=FileReference(filename="invalid_file"))
     with pytest.raises(CaikitRuntimeException):
         ds.to_data_stream()
 
@@ -528,7 +534,7 @@ def test_make_data_stream_source_non_json_array_errors(tmp_path):
         }
         """
         )
-    ds = stream_type(filestream=FileStream(filename=file_path))
+    ds = stream_type(filereference=FileReference(filename=file_path))
     assert isinstance(ds, DataStreamSourceBase)
 
     with pytest.raises(ValueError, match="Non-array JSON object"):

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -38,11 +38,12 @@ import grpc
 import pytest
 
 # Local
+from caikit.interfaces.common.data_model import File
 from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
 from caikit.runtime.types.aborted_exception import AbortedException
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.data_model import SampleInputType, SampleOutputType
-from sample_lib.data_model.sample import FileDataType, OtherOutputType, SampleTask
+from sample_lib.data_model.sample import OtherOutputType, SampleTask
 from sample_lib.modules.sample_task import SampleModule
 from tests.conftest import temp_config
 from tests.fixtures import Fixtures
@@ -205,7 +206,7 @@ def test_global_predict_works_for_multitask_model(
     with patch.object(sample_predict_servicer, "_model_manager", mock_manager):
         response = sample_predict_servicer.Predict(
             predict_class(
-                file_input=FileDataType(filename="foo", data=bytes("bar", "utf-8"))
+                file=File(filename="foo", data=bytes("bar", "utf-8"))
             ).to_proto(),
             Fixtures.build_context(sample_task_model_id),
             caikit_rpc=sample_inference_service.caikit_rpcs["SecondTaskPredict"],

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -206,7 +206,7 @@ def test_global_predict_works_for_multitask_model(
     with patch.object(sample_predict_servicer, "_model_manager", mock_manager):
         response = sample_predict_servicer.Predict(
             predict_class(
-                file=File(filename="foo", data=bytes("bar", "utf-8"))
+                file_input=File(filename="foo", data=bytes("bar", "utf-8"))
             ).to_proto(),
             Fixtures.build_context(sample_task_model_id),
             caikit_rpc=sample_inference_service.caikit_rpcs["SecondTaskPredict"],

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -385,7 +385,9 @@ def test_global_train_surfaces_caikit_errors(sample_train_servicer, sample_text_
     """Test whether global trainer surfaces errors from Caikit using both sub-process and thread"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     # we don't support .txt files yet, hence this should throw an error
-    training_data = stream_type(file=stream_type.File(filename=sample_text_file))
+    training_data = stream_type(
+        filereference=stream_type.FileReference(filename=sample_text_file)
+    )
 
     train_class = get_train_request(SampleModule)
     train_request_params_class = get_train_params(SampleModule)

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -386,7 +386,7 @@ def test_global_train_surfaces_caikit_errors(sample_train_servicer, sample_text_
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     # we don't support .txt files yet, hence this should throw an error
     training_data = stream_type(
-        filereference=stream_type.FileReference(filename=sample_text_file)
+        file=stream_type.FileReference(filename=sample_text_file)
     )
 
     train_class = get_train_request(SampleModule)

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -213,7 +213,7 @@ def test_model_train_surfaces_caikit_errors(sample_model_train_servicer, output_
                     "model_name": "abc",
                     "parameters": {
                         "training_data": {
-                            "file": {
+                            "filereference": {
                                 "filename": input_file_name  # This is relative to training_input_dir
                             },
                         },
@@ -352,7 +352,7 @@ def test_files_from_training_input_dir_are_used(
                     "model_name": "abc",
                     "parameters": {
                         "training_data": {
-                            "filestream": {
+                            "filereference": {
                                 "filename": input_file_name  # This is relative to training_input_dir
                             },
                         },

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -213,7 +213,7 @@ def test_model_train_surfaces_caikit_errors(sample_model_train_servicer, output_
                     "model_name": "abc",
                     "parameters": {
                         "training_data": {
-                            "filereference": {
+                            "file": {
                                 "filename": input_file_name  # This is relative to training_input_dir
                             },
                         },
@@ -352,7 +352,7 @@ def test_files_from_training_input_dir_are_used(
                     "model_name": "abc",
                     "parameters": {
                         "training_data": {
-                            "filereference": {
+                            "file": {
                                 "filename": input_file_name  # This is relative to training_input_dir
                             },
                         },

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -352,7 +352,7 @@ def test_files_from_training_input_dir_are_used(
                     "model_name": "abc",
                     "parameters": {
                         "training_data": {
-                            "file": {
+                            "filestream": {
                                 "filename": input_file_name  # This is relative to training_input_dir
                             },
                         },

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -494,7 +494,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
     # Train an OtherModule with batch size 100
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
     training_data = stream_type(
-        filereference=stream_type.FileReference(filename=sample_int_file)
+        file=stream_type.FileReference(filename=sample_int_file)
     )
 
     train_request = get_train_request(OtherModule)(
@@ -644,7 +644,7 @@ def test_train_fake_module_ok_response_with_datastream_csv_file(
     """Test RPC CaikitRuntime.SampleTaskSampleModuleTrainRequest successful response with training data file type"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(
-        filereference=stream_type.FileReference(filename=sample_csv_file)
+        file=stream_type.FileReference(filename=sample_csv_file)
     )
     model_name = random_test_id()
 
@@ -1265,7 +1265,7 @@ def test_construct_with_options(open_port, sample_train_service, sample_int_file
             # rejected
             stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
             training_data = stream_type(
-                filereference=stream_type.FileReference(filename=sample_int_file)
+                file=stream_type.FileReference(filename=sample_int_file)
             ).to_proto()
             train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
                 model_name="Bar Training",

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -493,7 +493,9 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
 
     # Train an OtherModule with batch size 100
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
-    training_data = stream_type(file=stream_type.File(filename=sample_int_file))
+    training_data = stream_type(
+        filestream=stream_type.FileStream(filename=sample_int_file)
+    )
 
     train_request = get_train_request(OtherModule)(
         model_name="Bar Training",
@@ -641,7 +643,9 @@ def test_train_fake_module_ok_response_with_datastream_csv_file(
 ):
     """Test RPC CaikitRuntime.SampleTaskSampleModuleTrainRequest successful response with training data file type"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    training_data = stream_type(file=stream_type.File(filename=sample_csv_file))
+    training_data = stream_type(
+        filestream=stream_type.FileStream(filename=sample_csv_file)
+    )
     model_name = random_test_id()
 
     train_request = get_train_request(SampleModule)(
@@ -1261,7 +1265,7 @@ def test_construct_with_options(open_port, sample_train_service, sample_int_file
             # rejected
             stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
             training_data = stream_type(
-                file=stream_type.File(filename=sample_int_file)
+                filestream=stream_type.FileStream(filename=sample_int_file)
             ).to_proto()
             train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
                 model_name="Bar Training",

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -494,7 +494,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
     # Train an OtherModule with batch size 100
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
     training_data = stream_type(
-        filestream=stream_type.FileStream(filename=sample_int_file)
+        filereference=stream_type.FileReference(filename=sample_int_file)
     )
 
     train_request = get_train_request(OtherModule)(
@@ -644,7 +644,7 @@ def test_train_fake_module_ok_response_with_datastream_csv_file(
     """Test RPC CaikitRuntime.SampleTaskSampleModuleTrainRequest successful response with training data file type"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(
-        filestream=stream_type.FileStream(filename=sample_csv_file)
+        filereference=stream_type.FileReference(filename=sample_csv_file)
     )
     model_name = random_test_id()
 
@@ -1265,7 +1265,7 @@ def test_construct_with_options(open_port, sample_train_service, sample_int_file
             # rejected
             stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
             training_data = stream_type(
-                filestream=stream_type.FileStream(filename=sample_int_file)
+                filereference=stream_type.FileReference(filename=sample_int_file)
             ).to_proto()
             train_request = sample_train_service.messages.OtherTaskOtherModuleTrainRequest(
                 model_name="Bar Training",

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -507,7 +507,9 @@ def test_global_train_build_caikit_library_request_dict_ok_with_training_data_as
     """Global train build_caikit_library_request_dict works for list of data files"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(
-        listoffiles=stream_type.ListOfFiles(files=[sample_csv_file, sample_json_file])
+        listoffilestreams=stream_type.ListOfFileStreams(
+            files=[sample_csv_file, sample_json_file]
+        )
     )
     train_class = DataBase.get_class_for_name("SampleTaskListModuleTrainRequest")
     train_request_params_class = DataBase.get_class_for_name(

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -507,7 +507,7 @@ def test_global_train_build_caikit_library_request_dict_ok_with_training_data_as
     """Global train build_caikit_library_request_dict works for list of data files"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(
-        listoffilereferences=stream_type.ListOfFileReferences(
+        list_of_files=stream_type.ListOfFileReferences(
             files=[sample_csv_file, sample_json_file]
         )
     )

--- a/tests/runtime/utils/test_servicer_util.py
+++ b/tests/runtime/utils/test_servicer_util.py
@@ -507,7 +507,7 @@ def test_global_train_build_caikit_library_request_dict_ok_with_training_data_as
     """Global train build_caikit_library_request_dict works for list of data files"""
     stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
     training_data = stream_type(
-        listoffilestreams=stream_type.ListOfFileStreams(
+        listoffilereferences=stream_type.ListOfFileReferences(
             files=[sample_csv_file, sample_json_file]
         )
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds support for multi-part input and binary file output in the HTTP server. This allows users to submit requests via json or multi-part/form-data. The form-data is structured so that each key is the subpath where the value should live. For example the following form-data:
```
----
inputs.name
"test"
---
inputs.other
"test2"
---
parameters
'{"json":"field"}'
```
Would be parsed into the following structure:
```
{
   "inputs":{
       "name":"test",
       "other":"test2"
    },
    "parameters":{
         "json":"field"
    }
}
```
The Binary file output is controlled via two new optional methods on `DataObjectBase`: `to_file` and `from_file`. If these functions are implemented then the HTTP server will automatically return a bytes file using `to_file`. Currently this functionally is not configurable at runtime.

**Special notes for your reviewer**:
The parsing of form-data into pydantic is a little complex so please let me know if you have any questions or concerns. 

Another thing I'd like to note is that fastapi doesn't natively support multiple input content-types so I had to add some manual input parsing and openapi.json generation. 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
