### PR TITLE
:sparkles: set timers to daemon

### DIFF
--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -273,6 +273,7 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
             self._lazy_sync_timer = threading.Timer(
                 self._lazy_load_poll_period_seconds, self.sync_local_models
             )
+            self._lazy_sync_timer.daemon = True
             self._lazy_sync_timer.start()
 
     def unload_model(self, model_id) -> int:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Just looking around at timers for other reasons and I noticed that the lazy load poll timer is not set as a daemon. I think we'd want this set so that we don't have a child thread here interfering with shutdown.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
