### PR TITLE
🐛 Propagate sub-process errors properly

### DIFF
--- a/caikit/runtime/types/caikit_runtime_exception.py
+++ b/caikit/runtime/types/caikit_runtime_exception.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 # Standard
+from typing import Dict
 import uuid
+
+# Third Party
+import grpc
 
 
 class CaikitRuntimeException(Exception):
@@ -28,7 +32,12 @@ class CaikitRuntimeException(Exception):
         Same as Args. See above.
     """
 
-    def __init__(self, status_code, message, metadata=None):
+    def __init__(
+        self,
+        status_code: grpc.StatusCode,
+        message: str,
+        metadata: Dict[any, any] = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
         self.message = message
@@ -44,7 +53,7 @@ class CaikitRuntimeException(Exception):
     # This is to make the CaikitRuntimeException pickleable
     # this is needed to ensure we can pass it through sub-processes' pipe
     # which requires objects to be pickleable
-    def __reduce__(self):
+    def __reduce__(self) -> "CaikitRuntimeException":
         return (
             CaikitRuntimeException,
             (self.status_code, self.message, self.metadata),

--- a/caikit/runtime/types/caikit_runtime_exception.py
+++ b/caikit/runtime/types/caikit_runtime_exception.py
@@ -40,3 +40,12 @@ class CaikitRuntimeException(Exception):
         else:
             # metadata is of None type
             self.metadata = {"error_id": self.id}
+
+    # This is to make the CaikitRuntimeException pickleable
+    # this is needed to ensure we can pass it through sub-processes' pipe
+    # which requires objects to be pickleable
+    def __reduce__(self):
+        return (
+            CaikitRuntimeException,
+            (self.status_code, self.message, self.metadata),
+        )

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -29,7 +29,7 @@ from caikit.core.data_model import TrainingStatus
 from caikit.runtime.protobufs import process_pb2
 from caikit.runtime.servicers.model_train_servicer import ModelTrainServicerImpl
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
-from tests.conftest import temp_config
+from tests.conftest import set_use_subprocess
 from tests.fixtures import Fixtures
 import sample_lib
 
@@ -58,11 +58,11 @@ def clear_messages_from_servicer(servicer):
 
 
 @pytest.fixture(autouse=True, params=[True, False])
-def set_train_location(request):
+def set_train_location(request, reset_model_manager):
     """This fixture ensures that all tests in this file will be run with both
     subprocess and local training styles
     """
-    with temp_config({"training": {"use_subprocess": request.param}}):
+    with set_use_subprocess(request.param):
         yield
 
 

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -57,6 +57,13 @@ def clear_messages_from_servicer(servicer):
         servicer._training_service.messages = messages
 
 
+# We need to add reset_model_manager to make sure all trainers use the config that we provide.
+# Without this, it didn't actually work since the get_trainer function always fetches a trainer
+# that was initialized before this config comes into play. Hence we’re never actually checking
+# a training in a sub_process. I verified this by running a failing test and seeing that we always
+# hit destroyable_thread.py in the stacktrace instead of destroyable_process in both scenarios.
+
+
 @pytest.fixture(autouse=True, params=[True, False])
 def set_train_location(request, reset_model_manager):
     """This fixture ensures that all tests in this file will be run with both

--- a/tests/runtime/servicers/test_model_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_train_servicer_impl.py
@@ -29,7 +29,7 @@ from caikit.core.data_model import TrainingStatus
 from caikit.runtime.protobufs import process_pb2
 from caikit.runtime.servicers.model_train_servicer import ModelTrainServicerImpl
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
-from tests.conftest import set_use_subprocess
+from tests.conftest import set_use_subprocess, temp_config
 from tests.fixtures import Fixtures
 import sample_lib
 

--- a/tests/runtime/types/test_caikit_runtime_exception.py
+++ b/tests/runtime/types/test_caikit_runtime_exception.py
@@ -1,0 +1,54 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+import pickle
+
+# Third Party
+import grpc
+
+# Local
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+
+
+def test_caikit_runtime_exception_initialization():
+    """Test that we can construct a CaikitRuntimeException with the right args"""
+
+    caikit_runtime_exception = CaikitRuntimeException(
+        status_code=grpc.StatusCode.INTERNAL,
+        message="This is a test message",
+        metadata={"key1": "val1"},
+    )
+
+    assert isinstance(caikit_runtime_exception, Exception)
+    assert caikit_runtime_exception.id
+    assert caikit_runtime_exception.message == "This is a test message"
+    assert caikit_runtime_exception.metadata == {
+        "key1": "val1",
+        "error_id": caikit_runtime_exception.id,
+    }
+
+
+def test_caikit_runtime_exception_is_pickleable():
+    """This is to ensure we can send caikit_runtime_exception through sub-processes"""
+
+    caikit_runtime_exception = CaikitRuntimeException(
+        status_code=grpc.StatusCode.INTERNAL, message="This is a test message"
+    )
+
+    caikit_runtime_exception_pickle = pickle.dumps(caikit_runtime_exception)
+    caikit_runtime_exception_loaded = pickle.loads(caikit_runtime_exception_pickle)
+
+    assert isinstance(caikit_runtime_exception_loaded, CaikitRuntimeException)
+    assert caikit_runtime_exception_loaded.message == caikit_runtime_exception.message


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

fix https://github.com/caikit/caikit/issues/501

There were 2 issues identified:
1. The tests in `test_model_train_servicer_impl.py` were not using `sub-process` correctly  since the `get_trainer` function always fetches a trainer that was initialized before our custom config (with `sub_process` set to `True`) comes into play. Hence we’re never actually checking a training in a `sub_process`. I verified this by running a failing test and seeing that we always hit `destroyable_thread.py` in the stacktrace instead of `destroyable_process` in both scenarios.
2. `CaikitRuntimeException` was not pickleable, which is a requirement for any object to be passed through sub-processes using `Pipe()`. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
