### PR TITLE
Suport modules with multiple tasks

### DIFF
--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -24,7 +24,7 @@
 
 # Standard
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 import collections
 import os
 import shutil
@@ -48,7 +48,7 @@ from caikit import core
 log = alog.use_channel("MODULE")
 error = error_handler.get(log)
 
-
+# pylint: disable=too-many-public-methods
 class ModuleBase(metaclass=_ModuleBaseMeta):
     """Abstract base class from which all modules should inherit."""
 
@@ -86,7 +86,10 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
     @classmethod
     def get_inference_signature(
-        cls, input_streaming: bool, output_streaming: bool, task: Type = None
+        cls,
+        input_streaming: bool,
+        output_streaming: bool,
+        task: Type["caikit.core.TaskBase"] = None,
     ) -> Optional["caikit.core.signature_parsing.CaikitMethodSignature"]:
         """Returns the inference method signature that is capable of running the module's task
         for the given flavors of input and output streaming
@@ -103,6 +106,15 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
             if in_streaming == input_streaming and out_streaming == output_streaming:
                 return signature
         return None
+
+    @classmethod
+    def get_inference_signatures(
+        cls, task: Type["caikit.core.TaskBase"]
+    ) -> List[Tuple[bool, bool, "caikit.core.signature_parsing.CaikitMethodSignature"]]:
+        """Returns inference method signatures for all supported flavors
+        of input and output streaming for a given task
+        """
+        return cls._TASK_INFERENCE_SIGNATURES.get(task)
 
     @property
     def load_backend(self):

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -24,7 +24,7 @@
 
 # Standard
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Type, Union
 import collections
 import os
 import shutil
@@ -86,12 +86,20 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
 
     @classmethod
     def get_inference_signature(
-        cls, input_streaming: bool, output_streaming: bool
+        cls, input_streaming: bool, output_streaming: bool, task: Type = None
     ) -> Optional["caikit.core.signature_parsing.CaikitMethodSignature"]:
         """Returns the inference method signature that is capable of running the module's task
         for the given flavors of input and output streaming
         """
-        for in_streaming, out_streaming, signature in cls._INFERENCE_SIGNATURES:
+
+        if task is not None and task in cls._TASK_INFERENCE_SIGNATURES:
+            signatures = cls._TASK_INFERENCE_SIGNATURES[task]
+        elif cls._TASK_INFERENCE_SIGNATURES:
+            signatures = next(iter(cls._TASK_INFERENCE_SIGNATURES.values()))
+        else:
+            signatures = []
+
+        for in_streaming, out_streaming, signature in signatures:
             if in_streaming == input_streaming and out_streaming == output_streaming:
                 return signature
         return None

--- a/caikit/core/modules/decorator.py
+++ b/caikit/core/modules/decorator.py
@@ -17,7 +17,7 @@ caikit.module
 """
 
 # Standard
-from typing import Dict, Optional, Type, Union
+from typing import Dict, List, Optional, Type, Union
 import collections
 
 # Third Party
@@ -49,6 +49,7 @@ def module(
     name=None,
     version=None,
     task: Type[TaskBase] = None,
+    tasks: Optional[List[Type[TaskBase]]] = None,
     backend_type="LOCAL",
     base_module: Union[str, Type[ModuleBase]] = None,
     backend_config_override: Optional[Dict] = None,
@@ -69,7 +70,10 @@ def module(
             Not required if based on another caikit module using `base_module`
         task:  Type[TaskBase]
             An ML task class that this module is an implementation for
-            Not required if based on another caikit module using `base_module`
+            Not required if based on another caikit module using `base_module`,
+            or if multiple tasks are specified using `tasks`.
+        tasks: Optional[List[Type[TaskBase]]
+            List of ML task classes that this module implements.
         backend_type: backend_type
             Associated backend type for the module.
             Default: `LOCAL`
@@ -92,6 +96,12 @@ def module(
 
     # No mutable default
     backend_config_override = backend_config_override or {}
+
+    if task and tasks:
+        error(
+            "<COR34125316E>",
+            ValueError("Specify either task or tasks parameter, not both."),
+        )
 
     if any([id is None, version is None or name is None]):
         error.type_check(
@@ -140,8 +150,16 @@ def module(
         task = base_module_class.TASK_CLASS
         backend_module_impl = True
 
+    if task is not None:
+        tasks = [task]
+
+    if tasks is None:
+        tasks = []
+
     error.type_check("<COR54118928E>", str, id=id, name=name, version=version)
-    error.subclass_check("<COR90789722E>", task, TaskBase, allow_none=True)
+
+    for t in tasks:
+        error.subclass_check("<COR90789722E>", t, TaskBase, allow_none=True)
 
     semver.VersionInfo.parse(version)  # Make sure this is a valid SemVer
 
@@ -163,39 +181,17 @@ def module(
         cls_.MODULE_CLASS = classname
         cls_.PRODUCER_ID = ProducerId(cls_.MODULE_NAME, cls_.MODULE_VERSION)
 
-        # Tasks: check to see if a super-class has one as well and that they match:
-        tasks = {
-            class_.TASK_CLASS for class_ in cls_.mro() if hasattr(class_, "TASK_CLASS")
-        }
-        if len(tasks) > 1:
-            error(
-                "<COR17197749E>",
-                TypeError(
-                    f"Class {cls_} has multiple task definitions in class hierarchy"
-                ),
-            )
-        if tasks:
-            parent_task = tasks.pop()
-            if task and task != parent_task:
-                error(
-                    "<COR44943734E>",
-                    TypeError(
-                        f"Class {cls_} has task {task} but superclass has task "
-                        f"{parent_task}"
-                    ),
-                )
-            cls_.TASK_CLASS = parent_task
-        else:
-            cls_.TASK_CLASS = task
+        cls_.TASK_CLASS = task
+        cls_.TASK_CLASSES = tasks
 
         # Parse the `train` and `run` signatures
         cls_.RUN_SIGNATURE = CaikitMethodSignature(cls_, "run")
         cls_.TRAIN_SIGNATURE = CaikitMethodSignature(cls_, "train")
-        cls_._INFERENCE_SIGNATURES = []
+        cls_._TASK_INFERENCE_SIGNATURES = {}
 
-        # If the module has a task, validate it:
-        if cls_.TASK_CLASS:
-            if not cls_.TASK_CLASS.has_inference_method_decorators(module_class=cls_):
+        # If the module has tasks, validate them:
+        for t in cls_.TASK_CLASSES:
+            if not t.has_inference_method_decorators(module_class=cls_):
                 # Hackity hack hack - make sure at least one flavor is supported
                 validated = False
                 validation_errs = []
@@ -205,11 +201,11 @@ def module(
                     [False, True],
                 ]:
                     try:
-                        cls_.TASK_CLASS.validate_run_signature(
+                        t.validate_run_signature(
                             cls_.RUN_SIGNATURE, input_streaming, output_streaming
                         )
                         validated = True
-                        cls_._INFERENCE_SIGNATURES.append(
+                        cls_._TASK_INFERENCE_SIGNATURES.setdefault(t, []).append(
                             (input_streaming, output_streaming, cls_.RUN_SIGNATURE)
                         )
                         break
@@ -218,7 +214,19 @@ def module(
                 if not validated:
                     raise validation_errs[0]
 
-            cls_.TASK_CLASS.deferred_method_decoration(cls_)
+            t.deferred_method_decoration(cls_)
+
+        # Check to see if a super-class has any tasks.
+        # These will have been validated by the superclass decorator alreayd.
+        tasks_in_hierarchy = []
+
+        for class_ in cls_.mro():
+            if hasattr(class_, "TASK_CLASSES"):
+                tasks_in_hierarchy.extend(class_.TASK_CLASSES)
+
+        if tasks_in_hierarchy:
+            cls_.TASK_CLASS = tasks_in_hierarchy.pop()
+            cls_.TASK_CLASSES += tasks_in_hierarchy + tasks
 
         # If no backend support described in the class, add current backend
         # as the only backend that can load models trained by this module

--- a/caikit/core/modules/decorator.py
+++ b/caikit/core/modules/decorator.py
@@ -72,7 +72,7 @@ def module(
             An ML task class that this module is an implementation for
             Not required if based on another caikit module using `base_module`,
             or if multiple tasks are specified using `tasks`.
-        tasks: Optional[Set[Type[TaskBase]]
+        tasks: Optional[List[Type[TaskBase]]
             List of ML task classes that this module implements.
         backend_type: backend_type
             Associated backend type for the module.
@@ -101,6 +101,13 @@ def module(
         error(
             "<COR34125316E>",
             ValueError("Specify either task or tasks parameter, not both."),
+        )
+    if tasks:
+        error.type_check(
+            "<COR34125317E>",
+            list,
+            allow_none=True,
+            tasks=tasks,
         )
 
     if any([id is None, version is None or name is None]):

--- a/caikit/core/modules/meta.py
+++ b/caikit/core/modules/meta.py
@@ -66,7 +66,7 @@ is known.
 """
 
 # Standard
-from typing import TYPE_CHECKING, Set
+from typing import Set
 import abc
 import functools
 
@@ -76,10 +76,6 @@ import alog
 # Local
 from ..exceptions import error_handler
 from .config import ModuleConfig
-
-if TYPE_CHECKING:
-    # Local
-    from ..task import TaskBase
 
 log = alog.use_channel("METADATA_INJECT")
 error = error_handler.get(log)
@@ -158,7 +154,7 @@ class _ModuleBaseMeta(abc.ABCMeta):
         return super().__new__(mcs, name, bases, attrs)
 
     @property
-    def tasks(cls) -> Set["TaskBase"]:
+    def tasks(cls) -> Set["caikit.core.TaskBase"]:
         return set(cls._TASK_CLASSES)
 
     def __setattr__(cls, name, val):

--- a/caikit/core/modules/meta.py
+++ b/caikit/core/modules/meta.py
@@ -66,6 +66,7 @@ is known.
 """
 
 # Standard
+from typing import TYPE_CHECKING, Set
 import abc
 import functools
 
@@ -75,6 +76,10 @@ import alog
 # Local
 from ..exceptions import error_handler
 from .config import ModuleConfig
+
+if TYPE_CHECKING:
+    # Local
+    from ..task import TaskBase
 
 log = alog.use_channel("METADATA_INJECT")
 error = error_handler.get(log)
@@ -151,6 +156,10 @@ class _ModuleBaseMeta(abc.ABCMeta):
             attrs["load"] = classmethod(metadata_injecting_load)
 
         return super().__new__(mcs, name, bases, attrs)
+
+    @property
+    def tasks(cls) -> Set["TaskBase"]:
+        return set(cls._TASK_CLASSES)
 
     def __setattr__(cls, name, val):
         """Overwrite __setattr__ to warn on any dynamic updates to the load function.

--- a/caikit/core/task.py
+++ b/caikit/core/task.py
@@ -115,7 +115,7 @@ class TaskBase:
                     signature, decoration.input_streaming, decoration.output_streaming
                 )
 
-                module._INFERENCE_SIGNATURES.append(
+                module._TASK_INFERENCE_SIGNATURES.setdefault(cls, []).append(
                     (decoration.input_streaming, decoration.output_streaming, signature)
                 )
 

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -346,7 +346,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 log.error("<RUN51881106E>", err, exc_info=True)
             return Response(content=json.dumps(error_content), status_code=error_code)
 
-    def _add_unary_input_unary_output_handler(self, rpc: CaikitRPCBase):
+    def _add_unary_input_unary_output_handler(self, rpc: TaskPredictRPC):
         """Add a unary:unary request handler for this RPC signature"""
         pydantic_request = dataobject_to_pydantic(self._get_request_dataobject(rpc))
         pydantic_response = dataobject_to_pydantic(self._get_response_dataobject(rpc))
@@ -373,7 +373,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     model_id=model_id,
                     request_name=rpc.request.name,
                     inference_func_name=model.get_inference_signature(
-                        output_streaming=False, input_streaming=False
+                        output_streaming=False, input_streaming=False, task=rpc.task
                     ).method_name,
                     **request_params,
                 )

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -222,21 +222,18 @@ class ServicePackageFactory:
         for ck_module in modules:
             # Only create for modules from defined included and exclusion list
 
-            if not ck_module.TASK_CLASS:
+            if not ck_module.tasks:
                 log.debug(
-                    "Skipping module %s with no task",
+                    "Skipping module %s with no tasks",
                     ck_module,
                 )
                 continue
-
-            if (
-                excluded_task_types
-                and ck_module.TASK_CLASS.__name__ in excluded_task_types
-            ):
+            task = next(iter(ck_module.tasks))
+            if excluded_task_types and task.__name__ in excluded_task_types:
                 log.debug(
                     "Skipping module %s with excluded task %s",
                     ck_module,
-                    ck_module.TASK_CLASS.__name__,
+                    task.__name__,
                 )
                 continue
 
@@ -257,8 +254,7 @@ class ServicePackageFactory:
             # if inclusion is specified, use that
             else:
                 if (included_modules and ck_module.MODULE_ID in included_modules) or (
-                    included_task_types
-                    and ck_module.TASK_CLASS.__name__ in included_task_types
+                    included_task_types and task.__name__ in included_task_types
                 ):
                     clean_modules.add(ck_module)
 
@@ -285,7 +281,7 @@ def get_inference_request(
         TaskBase,
     )
     task_class = (
-        task_or_module_class.TASK_CLASS
+        next(iter(task_or_module_class.tasks))
         if issubclass(task_or_module_class, ModuleBase)
         else task_or_module_class
     )
@@ -311,9 +307,8 @@ def get_train_request(module_class: Type[ModuleBase]) -> Type[DataBase]:
         module_class,
         ModuleBase,
     )
-    request_class_name = (
-        f"{module_class.TASK_CLASS.__name__}{module_class.__name__}TrainRequest"
-    )
+    first_task = next(iter(module_class.tasks))
+    request_class_name = f"{first_task.__name__}{module_class.__name__}TrainRequest"
     log.debug("Request class name %s for module %s.", request_class_name, module_class)
     return DataBase.get_class_for_name(request_class_name)
 
@@ -325,8 +320,8 @@ def get_train_params(module_class: Type[ModuleBase]) -> Type[DataBase]:
         module_class,
         ModuleBase,
     )
-    request_class_name = (
-        f"{module_class.TASK_CLASS.__name__}{module_class.__name__}TrainParameters"
-    )
+    first_task = next(iter(module_class.tasks))
+
+    request_class_name = f"{first_task.__name__}{module_class.__name__}TrainParameters"
     log.debug("Request class name %s for module %s.", request_class_name, module_class)
     return DataBase.get_class_for_name(request_class_name)

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -70,8 +70,8 @@ def create_training_rpcs(modules: List[Type[ModuleBase]]) -> List[CaikitRPCBase]
     rpcs = []
 
     for ck_module in modules:
-        if not ck_module.TASK_CLASS:
-            log.debug("Skipping module %s with no task", ck_module)
+        if not ck_module.tasks:
+            log.debug("Skipping module %s with no tasks", ck_module)
             continue
 
         # If this train function has not been changed from the base, skip it as
@@ -115,7 +115,7 @@ def _group_modules_by_task(
 ) -> Dict[Type[TaskBase], List[CaikitMethodSignature]]:
     task_groups = {}
     for ck_module in modules:
-        for task_class in ck_module.TASK_CLASSES:
+        for task_class in ck_module.tasks:
             ck_module_task_name = task_class.__name__
             if ck_module_task_name is not None:
                 for (

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -122,7 +122,7 @@ def _group_modules_by_task(
                     input_streaming,
                     output_streaming,
                     signature,
-                ) in ck_module._TASK_INFERENCE_SIGNATURES[task_class]:
+                ) in ck_module.get_inference_signatures(task_class):
                     task_groups.setdefault(task_class, {}).setdefault(
                         (input_streaming, output_streaming), []
                     ).append(signature)

--- a/caikit/runtime/service_generation/create_service.py
+++ b/caikit/runtime/service_generation/create_service.py
@@ -115,15 +115,15 @@ def _group_modules_by_task(
 ) -> Dict[Type[TaskBase], List[CaikitMethodSignature]]:
     task_groups = {}
     for ck_module in modules:
-        if ck_module.TASK_CLASS:
-            ck_module_task_name = ck_module.TASK_CLASS.__name__
+        for task_class in ck_module.TASK_CLASSES:
+            ck_module_task_name = task_class.__name__
             if ck_module_task_name is not None:
                 for (
                     input_streaming,
                     output_streaming,
                     signature,
-                ) in ck_module._INFERENCE_SIGNATURES:
-                    task_groups.setdefault(ck_module.TASK_CLASS, {}).setdefault(
+                ) in ck_module._TASK_INFERENCE_SIGNATURES[task_class]:
+                    task_groups.setdefault(task_class, {}).setdefault(
                         (input_streaming, output_streaming), []
                     ).append(signature)
     return task_groups

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -153,7 +153,7 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         request RPC function
         """
         return snake_to_upper_camel(
-            f"{module_class.TASK_CLASS.__name__}_{module_class.__name__}_Train"
+            f"{next(iter(module_class.tasks)).__name__}_{module_class.__name__}_Train"
         )
 
     @staticmethod

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -350,7 +350,7 @@ class GlobalPredictServicer:
         """Raise if the model is not supported for the task"""
         rpc_set: Set[TaskPredictRPC] = set(self._inference_service.caikit_rpcs.values())
         module_rpc: TaskPredictRPC = next(
-            (rpc for rpc in rpc_set if model.TASK_CLASS == rpc.task),
+            (rpc for rpc in rpc_set if rpc.task in model.__class__.tasks),
             None,
         )
 

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -178,6 +178,7 @@ class GlobalPredictServicer:
                     inference_signature = model_class.get_inference_signature(
                         input_streaming=caikit_rpc.input_streaming,
                         output_streaming=caikit_rpc.output_streaming,
+                        task=caikit_rpc.task,
                     )
                     if not inference_signature:
                         raise CaikitRuntimeException(

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -113,7 +113,7 @@ class GlobalTrainServicer:
             with alog.ContextLog(log.debug, outer_scope_name):
                 module = None
                 for mod in caikit.core.registries.module_registry().values():
-                    if mod.TASK_CLASS:
+                    if mod.tasks:
                         train_request_for_mod = (
                             ModuleClassTrainRPC.module_class_to_req_name(mod)
                         )

--- a/examples/text-sentiment/client.py
+++ b/examples/text-sentiment/client.py
@@ -23,7 +23,7 @@ import requests
 from caikit.config.config import get_config
 from caikit.runtime import get_inference_request
 from caikit.runtime.service_factory import ServicePackageFactory
-from text_sentiment.runtime_model import HuggingFaceSentimentModule
+from text_sentiment.runtime_model.hf_module import HuggingFaceSentimentTask
 import caikit
 
 if __name__ == "__main__":
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
         # Run inference for two sample prompts
         for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
-            request = get_inference_request(HuggingFaceSentimentModule.TASK_CLASS)(
+            request = get_inference_request(HuggingFaceSentimentTask)(
                 text_input=text
             ).to_proto()
             response = client_stub.HuggingFaceSentimentTaskPredict(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,11 @@ def other_good_model_path() -> str:
     return os.path.join(FIXTURES_DIR, "models", "bar")
 
 
+@pytest.fixture
+def multi_task_model_path() -> str:
+    return os.path.join(FIXTURES_DIR, "models", "multi")
+
+
 # Sample data files for testing ###########################
 @pytest.fixture
 def data_stream_inputs() -> str:

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -122,13 +122,15 @@ def test_task_validator_raises_on_wrong_streaming_type():
 
 
 def test_task_is_set_on_module_classes():
-    assert hasattr(SampleModule, "TASK_CLASS")
-    assert SampleModule.TASK_CLASS == SampleTask
+    assert hasattr(SampleModule, "tasks")
+    assert len(SampleModule.tasks) == 1
+    assert SampleTask in SampleModule.tasks
 
 
 def test_multiple_tasks_are_set_on_module_class():
-    assert hasattr(MultiTaskModule, "TASK_CLASSES")
-    assert FirstTask, SecondTask in MultiTaskModule.TASK_CLASSES
+    assert hasattr(MultiTaskModule, "tasks")
+    assert FirstTask in MultiTaskModule.tasks
+    assert SecondTask in MultiTaskModule.tasks
 
 
 def test_task_can_be_inferred_from_parent_module():
@@ -136,7 +138,7 @@ def test_task_can_be_inferred_from_parent_module():
     class Stuff(SampleModule):
         pass
 
-    assert Stuff.TASK_CLASS == SampleModule.TASK_CLASS
+    assert Stuff.tasks == SampleModule.tasks
 
 
 def test_multiple_tasks_inherited_from_parent_module():
@@ -146,7 +148,7 @@ def test_multiple_tasks_inherited_from_parent_module():
     class MultiTaskChildModule(MultiTaskModule):
         pass
 
-    assert FirstTask, SecondTask in MultiTaskChildModule.TASK_CLASSES
+    assert FirstTask, SecondTask in MultiTaskChildModule.tasks
 
 
 def test_tasks_added_from_parent_and_child_module():
@@ -163,7 +165,7 @@ def test_tasks_added_from_parent_and_child_module():
             pass
 
     for t in [FirstTask, SecondTask, ThirdTask]:
-        assert t in MultiTaskChildModule.TASK_CLASSES
+        assert t in MultiTaskChildModule.tasks
 
 
 def test_task_is_not_required_for_modules():
@@ -171,7 +173,7 @@ def test_task_is_not_required_for_modules():
     class Stuff(caikit.core.ModuleBase):
         pass
 
-    assert Stuff.TASK_CLASS is None
+    assert Stuff.tasks == set()
 
 
 def test_task_and_tasks_are_mutually_exclusive():

--- a/tests/fixtures/models/multi/config.yml
+++ b/tests/fixtures/models/multi/config.yml
@@ -1,0 +1,5 @@
+module_class: sample_lib.modules.multi_task.multi_task_module.MultiTaskModule
+module_id: 00110203-0123-0456-0789-0a0b02dd1eef
+created: "2023-03-14 11:24:58.720898"
+name: MultiTaskModule
+version: 0.0.1

--- a/tests/fixtures/sample_lib/modules/__init__.py
+++ b/tests/fixtures/sample_lib/modules/__init__.py
@@ -1,6 +1,7 @@
 # Local
 from .file_processing import BoundingBoxModule
 from .geospatial import GeoStreamingModule
+from .multi_task import FirstTask, MultiTaskModule, SecondTask
 from .other_task import OtherModule
 from .sample_task import (
     CompositeModule,

--- a/tests/fixtures/sample_lib/modules/multi_task/__init__.py
+++ b/tests/fixtures/sample_lib/modules/multi_task/__init__.py
@@ -1,0 +1,2 @@
+# Local
+from .multi_task_module import FirstTask, MultiTaskModule, SecondTask

--- a/tests/fixtures/sample_lib/modules/multi_task/multi_task_module.py
+++ b/tests/fixtures/sample_lib/modules/multi_task/multi_task_module.py
@@ -1,0 +1,51 @@
+# Local
+from ...data_model.sample import (
+    FileDataType,
+    OtherOutputType,
+    SampleInputType,
+    SampleOutputType,
+)
+from caikit.core import TaskBase, module, task
+from caikit.core.data_model import ProducerId
+import caikit
+
+
+@task(
+    unary_parameters={"sample_input": SampleInputType},
+    unary_output_type=SampleOutputType,
+)
+class FirstTask(TaskBase):
+    pass
+
+
+@task(
+    unary_parameters={"file_input": FileDataType},
+    unary_output_type=OtherOutputType,
+)
+class SecondTask(TaskBase):
+    pass
+
+
+@module(
+    id="00110203-0123-0456-0789-0a0b02dd1eef",
+    name="MultiTaskModule",
+    version="0.0.1",
+    tasks=[FirstTask, SecondTask],
+)
+class MultiTaskModule(caikit.core.ModuleBase):
+    def __init__(self):
+        pass
+
+    @classmethod
+    def load(cls, model_path, **kwargs):
+        return cls()
+
+    @FirstTask.taskmethod()
+    def run_some_task(self, sample_input: SampleInputType) -> SampleOutputType:
+        return SampleOutputType("Hello from FirstTask")
+
+    @SecondTask.taskmethod()
+    def run_other_task(self, file_input: FileDataType) -> OtherOutputType:
+        return OtherOutputType(
+            "Goodbye from SecondTask", ProducerId("MultiTaskModule", "0.0.1")
+        )

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -312,6 +312,23 @@ def other_task_model_id(other_good_model_path) -> str:
     model_manager.unload_model(model_id)
 
 
+@pytest.fixture
+def multi_task_model_id(multi_task_model_path) -> str:
+    """Loaded model ID using model manager load model implementation"""
+    model_id = random_test_id()
+    model_manager = ModelManager.get_instance()
+    # model load test already tests with archive - just using a model path here
+    model_manager.load_model(
+        model_id,
+        local_model_path=multi_task_model_path,
+        model_type=Fixtures.get_good_model_type(),  # eventually we'd like to be determining the type from the model itself...
+    )
+    yield model_id
+
+    # teardown
+    model_manager.unload_model(model_id)
+
+
 def register_trained_model(
     servicer: Union[RuntimeGRPCServer, GlobalPredictServicer],
     model_id: str,

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -375,6 +375,20 @@ def test_inference_streaming_sample_module(sample_task_model_id, runtime_http_se
         )
 
 
+def test_inference_multi_task_module(multi_task_model_id, runtime_http_server):
+    """Simple check that we can ping a model"""
+    with TestClient(runtime_http_server.app) as client:
+        # cGRmZGF0Yf//AA== is b"pdfdata\xff\xff\x00" base64 encoded
+        json_input = {"inputs": {"filename": "example.pdf", "data": "cGRmZGF0Yf//AA=="}}
+        response = client.post(
+            f"/api/v1/{multi_task_model_id}/task/second",
+            json=json_input,
+        )
+        json_response = json.loads(response.content.decode(response.default_encoding))
+        assert response.status_code == 200, json_response
+        assert json_response["farewell"] == "Goodbye from SecondTask"
+
+
 def test_model_not_found(runtime_http_server):
     """Simple check that we can ping a model"""
     with TestClient(runtime_http_server.app) as client:

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -80,7 +80,7 @@ def test_predict_raises_with_grpc_errors(
 ):
     with pytest.raises(CaikitRuntimeException) as context:
         # SampleModules will raise a RuntimeError if the throw flag is set
-        predict_class = get_inference_request(SampleModule.TASK_CLASS)
+        predict_class = get_inference_request(SampleTask)
         request = predict_class(
             sample_input=HAPPY_PATH_INPUT_DM,
             throw=True,

--- a/tests/runtime/servicers/test_global_train_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_train_servicer_impl.py
@@ -38,8 +38,10 @@ from caikit.runtime.servicers.global_train_servicer import GlobalTrainServicer
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.data_model.sample import (
     OtherOutputType,
+    OtherTask,
     SampleInputType,
     SampleOutputType,
+    SampleTask,
     SampleTrainingType,
 )
 from sample_lib.modules import CompositeModule, OtherModule, SampleModule
@@ -121,7 +123,7 @@ def test_global_train_sample_task(
         == "sample_lib.modules.sample_task.sample_implementation.SampleModule"
     )
 
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     inference_response = sample_predict_servicer.Predict(
         predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto(),
         Fixtures.build_context(training_response.model_name),
@@ -178,7 +180,7 @@ def test_global_train_other_task(
         == "sample_lib.modules.other_task.other_implementation.OtherModule"
     )
 
-    predict_class = get_inference_request(OtherModule.TASK_CLASS)
+    predict_class = get_inference_request(OtherTask)
     inference_response = sample_predict_servicer.Predict(
         predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto(),
         Fixtures.build_context(training_response.model_name),
@@ -234,7 +236,7 @@ def test_global_train_Another_Widget_that_requires_SampleWidget_loaded_should_no
     )
 
     # make sure the trained model can run inference
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     inference_response = sample_predict_servicer.Predict(
         predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto(),
         Fixtures.build_context(training_response.model_name),
@@ -283,7 +285,7 @@ def test_run_train_job_works_with_wait(
             training_response.training_id,
         )
 
-        predict_class = get_inference_request(SampleModule.TASK_CLASS)
+        predict_class = get_inference_request(SampleTask)
         inference_response = sample_predict_servicer.Predict(
             predict_class(sample_input=SampleInputType(name="Test")).to_proto(),
             Fixtures.build_context(training_response.model_name),

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -60,20 +60,14 @@ from caikit.runtime.protobufs import (
 )
 from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
 from caikit.runtime.utils.servicer_util import build_caikit_library_request_dict
-from sample_lib import (
-    CompositeModule,
-    InnerModule,
-    OtherModule,
-    SampleModule,
-    SamplePrimitiveModule,
-    StreamingModule,
-)
+from sample_lib import CompositeModule, InnerModule, OtherModule, SamplePrimitiveModule
 from sample_lib.data_model import (
     OtherOutputType,
     SampleInputType,
     SampleOutputType,
     SampleTrainingType,
 )
+from sample_lib.data_model.sample import OtherTask, SampleTask, StreamingTask
 from sample_lib.modules import FirstTask
 from tests.conftest import random_test_id, temp_config
 from tests.core.helpers import *
@@ -214,7 +208,7 @@ def test_predict_sample_module_ok_response(
 ):
     """Test RPC CaikitRuntime.SampleTaskPredict successful response"""
     stub = sample_inference_service.stub_class(runtime_grpc_server.make_local_channel())
-    predict_request = get_inference_request(SampleModule.TASK_CLASS)(
+    predict_request = get_inference_request(SampleTask)(
         sample_input=HAPPY_PATH_INPUT_DM
     ).to_proto()
 
@@ -259,7 +253,7 @@ def test_global_predict_build_caikit_library_request_dict_creates_caikit_core_ru
     assert proto_expected_arguments == set(proto_request_dict.keys())
 
     # pythonic data model request
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     python_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
 
     python_sample_module_request_dict = build_caikit_library_request_dict(
@@ -279,7 +273,7 @@ def test_predict_streaming_module(
     """Test RPC CaikitRuntime.StreamingTaskPredict successful response"""
     stub = sample_inference_service.stub_class(runtime_grpc_server.make_local_channel())
     predict_class = get_inference_request(
-        StreamingModule.TASK_CLASS, input_streaming=False, output_streaming=True
+        StreamingTask, input_streaming=False, output_streaming=True
     )
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
 
@@ -302,7 +296,7 @@ def test_predict_sample_module_error_response(
         stub = sample_inference_service.stub_class(
             runtime_grpc_server.make_local_channel()
         )
-        predict_class = get_inference_request(SampleModule.TASK_CLASS)
+        predict_class = get_inference_request(SampleTask)
         predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
 
         stub.SampleTaskPredict(
@@ -317,7 +311,7 @@ def test_rpc_validation_on_predict(
 ):
     """Check that the server catches models sent to the wrong task RPCs"""
     stub = sample_inference_service.stub_class(runtime_grpc_server.make_local_channel())
-    predict_class = get_inference_request(OtherModule.TASK_CLASS)
+    predict_class = get_inference_request(OtherTask)
     predict_request = predict_class(
         sample_input_sampleinputtype=HAPPY_PATH_INPUT_DM
     ).to_proto()
@@ -348,7 +342,7 @@ def test_rpc_validation_on_predict_for_unsupported_model(
         stub = sample_inference_service.stub_class(
             runtime_grpc_server.make_local_channel()
         )
-        predict_class = get_inference_request(SampleModule.TASK_CLASS)
+        predict_class = get_inference_request(SampleTask)
         predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
         with pytest.raises(grpc.RpcError) as context:
             stub.SampleTaskPredict(
@@ -382,7 +376,7 @@ def test_rpc_validation_on_predict_for_wrong_streaming_flavor(
         )
 
         predict_class = get_inference_request(
-            SampleModule.TASK_CLASS,
+            SampleTask,
         )
         predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
         with pytest.raises(grpc.RpcError) as context:
@@ -438,7 +432,7 @@ def test_train_fake_module_ok_response_and_can_predict_with_trained_model(
     )
 
     # make sure the trained model can run inference
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
     inference_response = inference_stub.SampleTaskPredict(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]
@@ -474,7 +468,7 @@ def test_train_fake_module_ok_response_with_loaded_model_can_predict_with_traine
     )
 
     # make sure the trained model can run inference
-    predict_class = get_inference_request(CompositeModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
     inference_response = inference_stub.SampleTaskPredict(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]
@@ -521,7 +515,7 @@ def test_train_fake_module_does_not_change_another_instance_model_of_block(
     )
 
     # make sure the trained model can run inference, and the batch size 100 was used
-    predict_class = get_inference_request(OtherModule.TASK_CLASS)
+    predict_class = get_inference_request(OtherTask)
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
     trained_inference_response = inference_stub.OtherTaskPredict(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]
@@ -581,7 +575,7 @@ def test_train_primitive_model(
     )
 
     # make sure the trained model can run inference
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
 
     inference_response = inference_stub.SampleTaskPredict(
@@ -628,7 +622,7 @@ def test_train_fake_module_ok_response_with_datastream_jsondata(
     )
 
     # make sure the trained model can run inference
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
     inference_response = inference_stub.SampleTaskPredict(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]
@@ -666,7 +660,7 @@ def test_train_fake_module_ok_response_with_datastream_csv_file(
     )
 
     # make sure the trained model can run inference
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
     inference_response = inference_stub.SampleTaskPredict(
         predict_request, metadata=[("mm-model-id", actual_response.model_name)]
@@ -1131,7 +1125,7 @@ def test_metrics_stored_after_server_interrupt(
     with temp_config({"runtime": {"metering": {"enabled": True}}}, "merge"):
         with runtime_grpc_test_server(open_port) as server:
             stub = sample_inference_service.stub_class(server.make_local_channel())
-            predict_class = get_inference_request(SampleModule.TASK_CLASS)
+            predict_class = get_inference_request(SampleTask)
             predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
             _ = stub.SampleTaskPredict(
                 predict_request, metadata=[("mm-model-id", sample_task_model_id)]

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -74,6 +74,7 @@ from sample_lib.data_model import (
     SampleOutputType,
     SampleTrainingType,
 )
+from sample_lib.modules import FirstTask
 from tests.conftest import random_test_id, temp_config
 from tests.core.helpers import *
 from tests.fixtures import Fixtures
@@ -222,6 +223,21 @@ def test_predict_sample_module_ok_response(
     )
 
     assert actual_response == HAPPY_PATH_RESPONSE
+
+
+def test_predict_sample_module_multi_task_response(
+    multi_task_model_id, runtime_grpc_server, sample_inference_service
+):
+    """Test RPC CaikitRuntime.SampleTaskPredict successful response"""
+    stub = sample_inference_service.stub_class(runtime_grpc_server.make_local_channel())
+    predict_class = get_inference_request(FirstTask)
+    predict_request = predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto()
+
+    actual_response = stub.FirstTaskPredict(
+        predict_request, metadata=[("mm-model-id", multi_task_model_id)]
+    )
+
+    assert actual_response == SampleOutputType("Hello from FirstTask").to_proto()
 
 
 def test_global_predict_build_caikit_library_request_dict_creates_caikit_core_run_kwargs(

--- a/tests/runtime/test_service_factory.py
+++ b/tests/runtime/test_service_factory.py
@@ -107,16 +107,6 @@ MODULE_LIST = [
 
 
 ### Test ServicePackageFactory._get_and_filter_modules function
-def test_get_and_filter_modules_respects_excluded_task_type():
-    with temp_config(
-        {
-            "runtime": {
-                "service_generation": {"task_types": {"excluded": ["SampleTask"]}}
-            }
-        }
-    ) as cfg:
-        clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
-        assert "SampleModule" not in str(clean_modules)
 
 
 def test_get_and_filter_modules_respects_excluded_modules():
@@ -136,41 +126,6 @@ def test_get_and_filter_modules_respects_excluded_modules():
         assert "OtherModule" in str(clean_modules)
 
 
-def test_get_and_filter_modules_respects_excluded_modules_and_excluded_task_type():
-    assert "InnerModule" in str(MODULE_LIST)
-    with temp_config(
-        {
-            "runtime": {
-                "service_generation": {
-                    "module_guids": {"excluded": [ListModule.MODULE_ID]},
-                    "task_types": {"excluded": ["OtherTask"]},
-                }
-            }
-        }
-    ) as cfg:
-        clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
-        assert "ListModule" not in str(clean_modules)
-        assert "OtherModule" not in str(clean_modules)
-        assert "SampleModule" in str(clean_modules)
-
-
-def test_get_and_filter_modules_respects_included_modules_and_included_task_types():
-    with temp_config(
-        {
-            "runtime": {
-                "service_generation": {
-                    "module_guids": {"included": [ListModule.MODULE_ID]},
-                    "task_types": {"included": ["OtherTask"]},
-                }
-            }
-        }
-    ) as cfg:
-        clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
-        assert len(clean_modules) == 2
-        assert "OtherModule" in str(clean_modules)
-        assert "ListModule" in str(clean_modules)
-
-
 def test_get_and_filter_modules_respects_included_modules():
     with temp_config(
         {
@@ -185,39 +140,6 @@ def test_get_and_filter_modules_respects_included_modules():
         assert len(clean_modules) == 1
         assert "ListModule" in str(clean_modules)
         assert "SampleModule" not in str(clean_modules)
-
-
-def test_get_and_filter_modules_respects_included_task_types():
-    with temp_config(
-        {
-            "runtime": {
-                "service_generation": {
-                    "task_types": {"included": ["SampleTask"]},
-                }
-            }
-        }
-    ) as cfg:
-        clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
-        assert "SampleModule" in str(clean_modules)
-        assert "OtherModule" not in str(clean_modules)
-        # InnerModule has no task
-        assert "InnerModule" not in str(clean_modules)
-
-
-def test_get_and_filter_modules_respects_included_task_types_and_excluded_modules():
-    with temp_config(
-        {
-            "runtime": {
-                "service_generation": {
-                    "task_types": {"included": ["SampleTask"]},
-                    "module_guids": {"excluded": [ListModule.MODULE_ID]},
-                }
-            }
-        }
-    ) as cfg:
-        clean_modules = ServicePackageFactory._get_and_filter_modules(cfg, "sample_lib")
-        assert "SampleModule" in str(clean_modules)
-        assert "ListModule" not in str(clean_modules)
 
 
 def test_override_domain(clean_data_model):

--- a/tests/runtime/test_service_factory.py
+++ b/tests/runtime/test_service_factory.py
@@ -32,6 +32,7 @@ from caikit.runtime.service_factory import (
 )
 from sample_lib import SampleModule
 from sample_lib.data_model import SampleInputType, SampleOutputType
+from sample_lib.data_model.sample import SampleTask
 from sample_lib.modules import ListModule, OtherModule
 from tests.conftest import temp_config
 from tests.core.helpers import MockBackend
@@ -364,7 +365,7 @@ def test_backend_modules_included_in_service_generation(
     inference_service = ServicePackageFactory.get_service_package(
         ServicePackageFactory.ServiceType.INFERENCE
     )
-    predict_class = get_inference_request(SampleModule.TASK_CLASS)
+    predict_class = get_inference_request(SampleTask)
     sample_task_request = predict_class().to_proto()
 
     # Check that the new parameter defined in this backend module exists in the service
@@ -380,15 +381,13 @@ def test_get_inference_request_throws_wrong_type(runtime_grpc_server):
 def test_get_inference_request(runtime_grpc_server):
     """Test that we are able to get inference request DM with either module or task class"""
     assert get_inference_request(SampleModule).__name__ == "SampleTaskRequest"
-    assert (
-        get_inference_request(SampleModule.TASK_CLASS).__name__ == "SampleTaskRequest"
-    )
+    assert get_inference_request(SampleTask).__name__ == "SampleTaskRequest"
     assert (
         get_inference_request(SampleModule, output_streaming=True).__name__
         == "ServerStreamingSampleTaskRequest"
     )
     assert (
-        get_inference_request(SampleModule.TASK_CLASS, output_streaming=True).__name__
+        get_inference_request(SampleTask, output_streaming=True).__name__
         == "ServerStreamingSampleTaskRequest"
     )
     assert (
@@ -399,7 +398,7 @@ def test_get_inference_request(runtime_grpc_server):
     )
     assert (
         get_inference_request(
-            SampleModule.TASK_CLASS, input_streaming=True, output_streaming=True
+            SampleTask, input_streaming=True, output_streaming=True
         ).__name__
         == "BidiStreamingSampleTaskRequest"
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

refs #246 

**What this PR does / why we need it**:
Today Caikit allows only a single task to be associated with a module. However, some ML models may support multiple tasks. For example, a multi-modal model may support inference tasks for each data modality. The only way to achieve this currently is to create two modules, and a model that refers to each of them. This means the model weights may be loaded twice, wasting memory. 

This PR implements multi-task support as follows:

- A new optional `tasks` parameter on `@module` allows you to specify a list of tasks. This takes precedence over `task`.
- Inference methods for each task are annotated with `@TaskClass.taskmethod()`.
- As a consequence of this, some of the task validation is relaxed as it's now valid to have multiple tasks specified in the class hierarchy of your module. 
- Services are generated for each task.
- At inference time, the global predict servicer looks up the correct service based on the task.
 
**Special notes for your reviewer**:
There are a few other possible considerations I haven't addressed, happy to investigate if we think they need further thought:
- It's now possible to have a module without a generic `run()` implementation.  Should ModuleBase (or maybe a new `MultiTaskModuleBase`) provide a default implementation of `run()` that attempts to delegate to one of the `taskmethod`s baesd on the parameters? Should we require a multi-task module still implement a `run()`?
- What does training mean for multi-task modules? 
- I've introduced `module.TASK_CLASSES` which contains all the tasks implemented by the module. I've kept `TASK_CLASS` for compatibility, but is this necessary? 
- Any other impacts I've missed?


**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
