### PR TITLE
Pluggable data input

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -69,6 +69,22 @@ data_streams:
     # Base directory where stream source relative paths should be found
     file_source_base: null
 
+    # Config for data stream source plugins. The keys in the map are names for
+    # environment scoping and the values are factory blobs for an importable
+    # factory. Each blob requires a `type` and can optionally have `config` and
+    # `import_class`.
+    source_plugins:
+        inline:
+            type: JsonData
+        file:
+            type: FileData
+        file_list:
+            type: ListOfFiles
+        directory:
+            type: Directory
+        s3:
+            type: S3Files
+
 ### Runtime configurations
 runtime:
     # The runtime library (or libraries) whose models we want to serve using Caikit Runtime. This should

--- a/caikit/core/model_management/factories.py
+++ b/caikit/core/model_management/factories.py
@@ -14,77 +14,13 @@
 """
 Global factories for model management
 """
-# Standard
-from typing import Optional
-import importlib
-
-# First Party
-import alog
 
 # Local
-from ..exceptions import error_handler
-from ..toolkit.factory import Factory, FactoryConstructible
+from ..toolkit.factory import ImportableFactory
 from .local_model_finder import LocalModelFinder
 from .local_model_initializer import LocalModelInitializer
 from .local_model_trainer import LocalModelTrainer
 from .multi_model_finder import MultiModelFinder
-
-log = alog.use_channel("MMFCTRY")
-error = error_handler.get(log)
-
-
-class ImportableFactory(Factory):
-    """An ImportableFactory extends the base Factory to allow the construction
-    to specify an "import_class" field that will be used to import and register
-    the implementation class before attempting to initialize it.
-    """
-
-    IMPORT_CLASS_KEY = "import_class"
-
-    def construct(
-        self,
-        instance_config: dict,
-        instance_name: Optional[str] = None,
-    ):
-        # Look for an import_class and import and register it if found
-        import_class_val = instance_config.get(self.__class__.IMPORT_CLASS_KEY)
-        if import_class_val:
-            error.type_check(
-                "<COR85108801E>",
-                str,
-                **{self.__class__.IMPORT_CLASS_KEY: import_class_val},
-            )
-            module_name, class_name = import_class_val.rsplit(".", 1)
-            try:
-                imported_module = importlib.import_module(module_name)
-            except ImportError:
-                error(
-                    "<COR46837141E>",
-                    ValueError(
-                        "Invalid {}: Module cannot be imported [{}]".format(
-                            self.__class__.IMPORT_CLASS_KEY,
-                            module_name,
-                        )
-                    ),
-                )
-            try:
-                imported_class = getattr(imported_module, class_name)
-            except AttributeError:
-                error(
-                    "<COR46837142E>",
-                    ValueError(
-                        "Invalid {}: No such class [{}] on module [{}]".format(
-                            self.__class__.IMPORT_CLASS_KEY,
-                            class_name,
-                            module_name,
-                        )
-                    ),
-                )
-            error.subclass_check("<COR52306423E>", imported_class, FactoryConstructible)
-
-            self.register(imported_class)
-        return super().construct(instance_config, instance_name)
-
 
 # Model trainer factory. A trainer is responsible for performing the train
 # operation against a configured framework connection.

--- a/caikit/core/toolkit/factory.py
+++ b/caikit/core/toolkit/factory.py
@@ -19,6 +19,7 @@ base class for classes that can be constructed via caikit config
 # Standard
 from typing import Optional, Type
 import abc
+import importlib
 
 # First Party
 import aconfig
@@ -105,3 +106,56 @@ class Factory:
         )
         instance_name = instance_name or inst_cls.name
         return inst_cls(inst_cfg, instance_name)
+
+
+class ImportableFactory(Factory):
+    """An ImportableFactory extends the base Factory to allow the construction
+    to specify an "import_class" field that will be used to import and register
+    the implementation class before attempting to initialize it.
+    """
+
+    IMPORT_CLASS_KEY = "import_class"
+
+    def construct(
+        self,
+        instance_config: dict,
+        instance_name: Optional[str] = None,
+    ):
+        # Look for an import_class and import and register it if found
+        import_class_val = instance_config.get(self.__class__.IMPORT_CLASS_KEY)
+        if import_class_val:
+            error.type_check(
+                "<COR85108801E>",
+                str,
+                **{self.__class__.IMPORT_CLASS_KEY: import_class_val},
+            )
+            module_name, class_name = import_class_val.rsplit(".", 1)
+            try:
+                imported_module = importlib.import_module(module_name)
+            except ImportError:
+                error(
+                    "<COR46837141E>",
+                    ValueError(
+                        "Invalid {}: Module cannot be imported [{}]".format(
+                            self.__class__.IMPORT_CLASS_KEY,
+                            module_name,
+                        )
+                    ),
+                )
+            try:
+                imported_class = getattr(imported_module, class_name)
+            except AttributeError:
+                error(
+                    "<COR46837142E>",
+                    ValueError(
+                        "Invalid {}: No such class [{}] on module [{}]".format(
+                            self.__class__.IMPORT_CLASS_KEY,
+                            class_name,
+                            module_name,
+                        )
+                    ),
+                )
+            error.subclass_check("<COR52306423E>", imported_class, FactoryConstructible)
+
+            self.register(imported_class)
+        return super().construct(instance_config, instance_name)

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -340,7 +340,7 @@ class S3FilesDataStreamSourcePlugin(DataStreamSourcePlugin):
 
     def to_data_stream(self, *_, **__) -> DataStream:
         error(
-            "<COR80419785E>",
+            "<RUN80419785E>",
             NotImplementedError(
                 "S3Files are not implemented as stream sources in this runtime."
             ),
@@ -381,7 +381,7 @@ class DataStreamPluginFactory(ImportableFactory):
                 if field_numbers.count(plugin.get_field_number()) > 1
             ]
             error.value_check(
-                "<COR69189361E>",
+                "<RUN69189361E>",
                 not duplicate_field_number_names,
                 "Duplicate plugin field numbers found for plugins: {}",
                 duplicate_field_number_names,
@@ -447,14 +447,14 @@ class DataStreamSourceBase(DataStream):
         for field_name in self.get_proto_class().DESCRIPTOR.fields_by_name:
             if getattr(self, field_name) is not None:
                 error.value_check(
-                    "<COR80421785E>",
+                    "<RUN80421785E>",
                     set_field is None,
                     "Found DataStreamSource with multiple sources set: {} and {}",
                     set_field,
                     field_name,
                 )
                 error.value_check(
-                    "<COR80420785E>",
+                    "<RUN80420785E>",
                     field_name in self.name_to_plugin_map,
                     "no data stream plugin found for field: {}",
                     field_name,
@@ -504,7 +504,7 @@ def make_data_stream_source(
             if all_field_names.count(field_name) > 1
         }
         error.value_check(
-            "<COR66854455E>",
+            "<RUN66854455E>",
             not duplicates,
             "Duplicate plugin field names found for type {}: {}",
             data_element_type,

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -67,7 +67,7 @@ class DataStreamSourcePlugin(FactoryConstructible):
     """
 
     def __init__(self, config: aconfig.Config, instance_name: str):
-        """Construct with the basic factor constructible interface and store the
+        """Construct with the basic factory constructible interface and store the
         args for use by the child
         """
         self._config = config
@@ -89,7 +89,9 @@ class DataStreamSourcePlugin(FactoryConstructible):
 
     @abc.abstractmethod
     def get_field_number(self) -> int:
-        """Allow plugins to return a static field number"""
+        """Each plugin must define its field number which may be informed by
+        self._config
+        """
 
     ## Public Methods ##
 
@@ -248,7 +250,7 @@ class ListOfFilesDataStreamSourcePlugin(FilePluginBase):
 
 
 class DirectoryDataStreamSourcePlugin(FilePluginBase):
-    """Plugin for a list of files"""
+    """Plugin for a directory holding files"""
 
     name = "Directory"
 
@@ -348,11 +350,11 @@ class S3FilesDataStreamSourcePlugin(DataStreamSourcePlugin):
         return 5
 
 
-## DataStreamSourceRegistry ####################################################
+## DataStreamPluginFactory #####################################################
 
 
 class DataStreamPluginFactory(ImportableFactory):
-    """The DataStreamSourceRegistry is responsible for holding a registry of
+    """The DataStreamPluginFactory is responsible for holding a registry of
     plugin instances that will be used to create and manage data stream sources
     """
 
@@ -373,16 +375,16 @@ class DataStreamPluginFactory(ImportableFactory):
 
             # Make sure field numbers are unique
             field_numbers = [plugin.get_field_number() for plugin in self._plugins]
-            duplicates_field_numbers = [
+            duplicate_field_number_names = [
                 plugin.name
                 for plugin in self._plugins
                 if field_numbers.count(plugin.get_field_number()) > 1
             ]
             error.value_check(
                 "<COR69189361E>",
-                not duplicates_field_numbers,
+                not duplicate_field_number_names,
                 "Duplicate plugin field numbers found for plugins: {}",
-                duplicates_field_numbers,
+                duplicate_field_number_names,
             )
         return self._plugins
 

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -118,7 +118,7 @@ class FilePluginBase(DataStreamSourcePlugin):
 
         _, extension = os.path.splitext(fname)
         if not extension:
-            return cls._load_from_file_without_extension(fname)
+            return cls._load_from_file_without_extension(fname, element_type)
 
         full_fname = cls._get_resolved_source_path(fname)
         log.debug3("Pulling data stream from %s file [%s]", extension, full_fname)
@@ -144,7 +144,7 @@ class FilePluginBase(DataStreamSourcePlugin):
         )
 
     @classmethod
-    def _load_from_file_without_extension(cls, fname) -> DataStream:
+    def _load_from_file_without_extension(cls, fname, element_type: type) -> DataStream:
         """Similar to _create_data_stream_from_file, but we don't have a file extension to work
         with. Attempt to create a data stream using one of a few well-known formats.
         🌶🌶🌶️ on ordering here:
@@ -157,6 +157,7 @@ class FilePluginBase(DataStreamSourcePlugin):
             confidently return a stream even if that's not the case.
         """
         full_fname = cls._get_resolved_source_path(fname)
+        to_element_type = cls._to_element_partial(element_type)
         log.debug3("Attempting to guess file type for file: %s", full_fname)
         for factory_method in (
             DataStream.from_json_array,
@@ -165,7 +166,7 @@ class FilePluginBase(DataStreamSourcePlugin):
             DataStream.from_header_csv,
         ):
             try:
-                stream = factory_method(full_fname).map(cls._to_element_type)
+                stream = factory_method(full_fname).map(to_element_type)
                 # Iterate once and assume we have the correct file type if this works
                 stream.peek()
                 return stream

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Standard
-from functools import partial
+from functools import cached_property, partial
 from glob import glob
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 import abc
@@ -432,14 +432,11 @@ class DataStreamSourceBase(DataStream):
         self.generator_args = tuple()
         self.generator_kwargs = {}
 
-    @property
+    @cached_property
     def name_to_plugin_map(self):
-        if not hasattr(self, "_name_to_plugin_map"):
-            self._name_to_plugin_map = {
-                plugin.get_field_name(self.ELEMENT_TYPE): plugin
-                for plugin in self.PLUGINS
-            }
-        return self._name_to_plugin_map
+        return {
+            plugin.get_field_name(self.ELEMENT_TYPE): plugin for plugin in self.PLUGINS
+        }
 
     # pylint: disable=too-many-return-statements
     def to_data_stream(self) -> DataStream:

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -286,7 +286,7 @@ class JsonDataStreamSourcePlugin(DataStreamSourcePlugin):
             return
 
         package = get_runtime_service_package()
-        cls_name = self._make_data_stream_source_type_name(element_type)
+        cls_name = _make_data_stream_source_type_name(element_type)
 
         JsonData = make_dataobject(
             package=package,
@@ -306,12 +306,6 @@ class JsonDataStreamSourcePlugin(DataStreamSourcePlugin):
         """source_message should be of type self.get_stream_message_type
         So it _should_ contain an attribute named `data`, which is a list"""
         return DataStream.from_iterable(source_message.data)
-
-    @staticmethod
-    def _make_data_stream_source_type_name(data_element_type: Type) -> str:
-        """Make the name for data stream source class that wraps the given type"""
-        element_name = data_element_type.__name__
-        return "DataStreamSource{}".format(element_name[0].upper() + element_name[1:])
 
 
 class DataStreamSourceBase(DataStream):
@@ -599,3 +593,9 @@ def make_data_stream_source(data_element_type: Type) -> Type[DataBase]:
 
     # Return the global stream source object for this element type
     return _DATA_STREAM_SOURCE_TYPES[data_element_type]
+
+
+def _make_data_stream_source_type_name(data_element_type: Type) -> str:
+    """Make the name for data stream source class that wraps the given type"""
+    element_name = data_element_type.__name__
+    return "DataStreamSource{}".format(element_name[0].upper() + element_name[1:])

--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -338,7 +338,6 @@ class DataStreamSourceBase(DataStream):
 
     def __init__(self):
         super().__init__(self._generator)
-        self.name_to_plugin_map = {plugin.get_field_name(): plugin for plugin in self.PLUGINS}
 
     def _generator(self):
         stream = self.to_data_stream()
@@ -362,6 +361,12 @@ class DataStreamSourceBase(DataStream):
         self.generator_func = self._generator
         self.generator_args = tuple()
         self.generator_kwargs = {}
+
+    @property
+    def name_to_plugin_map(self):
+        if not hasattr(self, "_name_to_plugin_map"):
+            self._name_to_plugin_map = {plugin.get_field_name(): plugin for plugin in self.PLUGINS}
+        return self._name_to_plugin_map
 
     # pylint: disable=too-many-return-statements
     def to_data_stream(self) -> DataStream:

--- a/docs/adrs/022-pluggable-runtime-io.md
+++ b/docs/adrs/022-pluggable-runtime-io.md
@@ -6,6 +6,53 @@ Some users of `caikit` will require application-specific logic to fetch data fro
 
 This proposal is to make the Input/Output mechanisms for `caikit.runtime` pluggable. Currently, this means updating `DataStreamSource` and the current `output_path` mechanism to use `oneof` semantics that can be extended by new implementations and bound at boot time with config options.
 
+**Example Implementation**
+```py
+from caikit.core.data_model import DataBase, DataObjectBase, DataStream, dataobject
+from caikit.runtime.service_generation.data_stream_source import DataStreamSourcePlugin, PluginFactory
+from typing import List, Type
+
+@dataobject
+class NumericStreamInput(DataObjectBase):
+    values: List[float]
+
+@dataobject
+class EncodedBytesStreamInput(DataObjectBase):
+    value: bytes
+    encoding: str
+
+class MyDataStreamPlugin(DataStreamSourcePlugin):
+
+    name = "MINE"
+
+    def get_stream_message_type(self, element_type: type) -> Type[DataBase]:
+        if element_type in [int, float]:
+            return NumericStreamInput
+        return EncodedBytesStreamInput
+
+    def get_field_number(self) -> int:
+        return 99 # Make this unique from all other plugins
+
+    def to_data_stream(self, source_message: Type[DataBase], element_type: type) -> DataStream:
+        if element_type in [int, float]:
+            return DataStream.from_iterable(source_message.values).map(element_type)
+        return DataStream.from_iterable(source_message.value.decode(source_message.encoding))
+
+
+# Register the plugin with the factory so it can be configured
+PluginFactory.register(MyDataStreamPlugin)
+```
+
+**Example Config**
+```yaml
+data_streams:
+    source_plugins:
+        inline:
+            type: JsonData
+        custom:
+            type: MINE
+```
+
 ## Status
 
 choose one: Accepted

--- a/docs/adrs/022-pluggable-runtime-io.md
+++ b/docs/adrs/022-pluggable-runtime-io.md
@@ -1,0 +1,18 @@
+# ADR N022: Pluggable Runtime IO
+
+Some users of `caikit` will require application-specific logic to fetch data from secure locations. These implementations will not be sufficiently generic to be maintained in the core of `caikit`, but for these security-minded applications, they are a must-have in order to satisfy security posture that fits the existing application.
+
+## Decision
+
+This proposal is to make the Input/Output mechanisms for `caikit.runtime` pluggable. Currently, this means updating `DataStreamSource` and the current `output_path` mechanism to use `oneof` semantics that can be extended by new implementations and bound at boot time with config options.
+
+## Status
+
+choose one: Accepted
+
+## Consequences
+
+* New `config` section `data_streams.source_plugins` that will control which data stream source types are supported in the running `caikit` environment
+* Equivalent section for `output_path` (naming TBD)
+* An API breaking change to change `output_path` to something like `output_target` to be more generic and support a `oneof` for different output target representations
+* New base classes and factories to register user-defined implementations of the plugins

--- a/tests/data_model_helpers.py
+++ b/tests/data_model_helpers.py
@@ -124,8 +124,10 @@ def temp_dpool(inherit_global: bool = False, skip_inherit: Optional[List[str]] =
     # Nothing to do for protobuf 3.X
     except ImportError:
         pass
-    yield dpool
-    descriptor_pool._DEFAULT = global_dpool
+    try:
+        yield dpool
+    finally:
+        descriptor_pool._DEFAULT = global_dpool
 
 
 def justify_script_string(script_str):

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -11,17 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Tests for the plugin mechanism for data stream sources
+"""
+# Third Party
+import pytest
+
+# First Party
+import aconfig
+
 # Local
+from caikit.core.data_model.streams.data_stream import DataStream
 from caikit.interfaces.common.data_model.stream_sources import (
     Directory,
     File,
     ListOfFiles,
 )
 from caikit.runtime.service_generation.data_stream_source import (
+    DataStreamPluginFactory,
+    DataStreamSourcePlugin,
     DirectoryDataStreamSourcePlugin,
     FileDataStreamSourcePlugin,
     JsonDataStreamSourcePlugin,
     ListOfFilesDataStreamSourcePlugin,
+    S3FilesDataStreamSourcePlugin,
+    make_data_stream_source,
 )
 from tests.runtime.service_generation.test_data_stream_source import (
     validate_data_stream,
@@ -92,3 +106,114 @@ def test_json_data_plugin_can_be_reinitialized():
     )
 
     assert strm_type is strm_type2
+
+
+## PluginFactory ###############################################################
+
+
+@pytest.fixture
+def plugin_factory():
+    fct = DataStreamPluginFactory("TestFactory")
+    fct.register(JsonDataStreamSourcePlugin)
+    fct.register(FileDataStreamSourcePlugin)
+    fct.register(ListOfFilesDataStreamSourcePlugin)
+    fct.register(DirectoryDataStreamSourcePlugin)
+    fct.register(S3FilesDataStreamSourcePlugin)
+    yield fct
+
+
+class SampleTrainingPlugin(DataStreamSourcePlugin):
+    """Dummy plugin that can be registered with a factory"""
+
+    name = "TEST"
+
+    def get_stream_message_type(self, *_, **__):
+        return sample_lib.data_model.SampleTrainingType
+
+    def to_data_stream(self, source_message, *_, **__):
+        count = self._config.get("count", 5)
+        DataStream.from_iterable(count * [source_message])
+
+    def get_field_number(self) -> int:
+        return self._config.get("field_number", 42)
+
+    def get_field_name(self, element_type):
+        return self._config.get("field_name", super().get_field_name(element_type))
+
+
+def test_plugin_factory_is_configurable(plugin_factory):
+    """Make sure new plugins can be registered and configured"""
+    cfg = aconfig.Config(
+        {"foo": {"type": SampleTrainingPlugin.name}},
+        override_env_vars=False,
+    )
+    # Before registration, it's a ValueError
+    with pytest.raises(ValueError):
+        plugin_factory.construct(cfg.foo, "foo")
+
+    # After registration, it's valid
+    plugin_factory.register(SampleTrainingPlugin)
+    plug = plugin_factory.construct(cfg.foo, "foo")
+    assert isinstance(plug, SampleTrainingPlugin)
+
+    # Make sure there's an instance in get_plugins
+    all_plugins = plugin_factory.get_plugins(cfg)
+    assert any(isinstance(plug, SampleTrainingPlugin) for plug in all_plugins)
+
+
+def test_plugin_factory_reuses_plugins(plugin_factory):
+    """Make sure that the list of plugins gets reused"""
+    plugins = plugin_factory.get_plugins()
+    assert plugin_factory.get_plugins() is plugins
+
+
+def test_no_duplicate_field_numbers(plugin_factory):
+    """Make sure that duplicate field numbers cause a ValueError"""
+    plugin_factory.register(SampleTrainingPlugin)
+    cfg = aconfig.Config(
+        {
+            "foo": {"type": SampleTrainingPlugin.name},
+            "bar": {"type": SampleTrainingPlugin.name},
+        },
+        override_env_vars=False,
+    )
+    with pytest.raises(ValueError):
+        plugin_factory.get_plugins(cfg)
+
+
+def test_no_duplicate_field_names(plugin_factory):
+    """Make sure that new data stream sources cannot be created with duplicate
+    field names
+    """
+    plugin_factory.register(SampleTrainingPlugin)
+    cfg = aconfig.Config(
+        {
+            "foo": {"type": SampleTrainingPlugin.name, "config": {"field_number": 42}},
+            "bar": {"type": SampleTrainingPlugin.name, "config": {"field_number": 43}},
+        },
+        override_env_vars=False,
+    )
+    with pytest.raises(ValueError):
+        make_data_stream_source(int, plugin_factory, cfg)
+
+
+def test_multiple_instances(plugin_factory):
+    """Make sure that multiple instances of a type with different configs can be
+    instantiated as long as field numbers and names are unique
+    """
+    plugin_factory.register(SampleTrainingPlugin)
+    cfg = aconfig.Config(
+        {
+            "foo": {
+                "type": SampleTrainingPlugin.name,
+                "config": {"field_number": 42, "field_name": "foo"},
+            },
+            "bar": {
+                "type": SampleTrainingPlugin.name,
+                "config": {"field_number": 43, "field_name": "bar"},
+            },
+        },
+        override_env_vars=False,
+    )
+    plugin_factory.get_plugins(cfg)
+    make_data_stream_source(int, plugin_factory, cfg)

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -63,3 +63,9 @@ def test_json_data_plugin():
     validate_data_stream(stream, 5, element_type)
 
 
+def test_json_data_plugin_acn_be_reinitialized():
+    element_type = sample_lib.data_model.SampleTrainingType
+    plugin = JsonDataStreamSourcePlugin(element_type=element_type)
+    plugin2 = JsonDataStreamSourcePlugin(element_type=element_type)
+
+    assert plugin.get_stream_message_type() is plugin2.get_stream_message_type()

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -11,11 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Local
+from caikit.interfaces.common.data_model.stream_sources import (
+    Directory,
+    File,
+    ListOfFiles,
+)
+from caikit.runtime.service_generation.data_stream_source import (
+    DirectoryDataStreamSourcePlugin,
+    FileDataStreamSourcePlugin,
+    JsonDataStreamSourcePlugin,
+    ListOfFilesDataStreamSourcePlugin,
+)
+from tests.runtime.service_generation.test_data_stream_source import (
+    validate_data_stream,
+)
 import sample_lib
-from caikit.interfaces.common.data_model.stream_sources import File, Directory, ListOfFiles
-from caikit.runtime.service_generation.data_stream_source import FileDataStreamSourcePlugin, \
-    DirectoryDataStreamSourcePlugin, ListOfFilesDataStreamSourcePlugin, JsonDataStreamSourcePlugin
-from tests.runtime.service_generation.test_data_stream_source import validate_data_stream
 
 
 def test_file_plugin(sample_json_file):
@@ -33,7 +44,9 @@ def test_directory_plugin(sample_json_collection):
     element_type = sample_lib.data_model.SampleTrainingType
     source_message = Directory(dirname=sample_json_collection, extension="json")
 
-    stream = DirectoryDataStreamSourcePlugin.to_data_stream(source_message, element_type)
+    stream = DirectoryDataStreamSourcePlugin.to_data_stream(
+        source_message, element_type
+    )
 
     validate_data_stream(stream, 3, element_type)
 
@@ -41,9 +54,13 @@ def test_directory_plugin(sample_json_collection):
 def test_list_of_files_plugin(sample_json_file, sample_csv_file, sample_jsonl_file):
     # Samples all have SampleTrainingType data
     element_type = sample_lib.data_model.SampleTrainingType
-    source_message = ListOfFiles(files=[sample_json_file, sample_jsonl_file, sample_csv_file])
+    source_message = ListOfFiles(
+        files=[sample_json_file, sample_jsonl_file, sample_csv_file]
+    )
 
-    stream = ListOfFilesDataStreamSourcePlugin.to_data_stream(source_message, element_type)
+    stream = ListOfFilesDataStreamSourcePlugin.to_data_stream(
+        source_message, element_type
+    )
 
     validate_data_stream(stream, 9, element_type)
 
@@ -51,21 +68,27 @@ def test_list_of_files_plugin(sample_json_file, sample_csv_file, sample_jsonl_fi
 def test_json_data_plugin():
     element_type = sample_lib.data_model.SampleTrainingType
     foo = sample_lib.data_model.SampleTrainingType(number=1, label="foo")
-    data = [foo]*5
+    data = [foo] * 5
 
     # This plugin is actually initialized so that it can build the source message type
-    plugin = JsonDataStreamSourcePlugin(element_type=element_type)
-    source_message_type = plugin.get_stream_message_type()
+    plugin = JsonDataStreamSourcePlugin({}, "")
+    source_message_type = plugin.get_stream_message_type(element_type=element_type)
     source_messsage = source_message_type(data=data)
 
-    stream = plugin.to_data_stream(source_message=source_messsage, element_type=element_type)
+    stream = plugin.to_data_stream(
+        source_message=source_messsage, element_type=element_type
+    )
 
     validate_data_stream(stream, 5, element_type)
 
 
-def test_json_data_plugin_acn_be_reinitialized():
+def test_json_data_plugin_can_be_reinitialized():
     element_type = sample_lib.data_model.SampleTrainingType
-    plugin = JsonDataStreamSourcePlugin(element_type=element_type)
-    plugin2 = JsonDataStreamSourcePlugin(element_type=element_type)
+    strm_type = JsonDataStreamSourcePlugin({}, "inst1").get_stream_message_type(
+        element_type=element_type
+    )
+    strm_type2 = JsonDataStreamSourcePlugin({}, "inst2").get_stream_message_type(
+        element_type=element_type
+    )
 
-    assert plugin.get_stream_message_type() is plugin2.get_stream_message_type()
+    assert strm_type is strm_type2

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -51,9 +51,9 @@ def test_file_plugin(sample_json_file):
     # Sample json file has SampleTrainingType data
     element_type = sample_lib.data_model.SampleTrainingType
     source_message = File(filename=sample_json_file)
-
-    stream = FileDataStreamSourcePlugin.to_data_stream(source_message, element_type)
-
+    stream = FileDataStreamSourcePlugin({}, "").to_data_stream(
+        source_message, element_type
+    )
     validate_data_stream(stream, 2, element_type)
 
 
@@ -61,11 +61,9 @@ def test_directory_plugin(sample_json_collection):
     # Sample json collection has SampleTrainingType data
     element_type = sample_lib.data_model.SampleTrainingType
     source_message = Directory(dirname=sample_json_collection, extension="json")
-
-    stream = DirectoryDataStreamSourcePlugin.to_data_stream(
+    stream = DirectoryDataStreamSourcePlugin({}, "").to_data_stream(
         source_message, element_type
     )
-
     validate_data_stream(stream, 3, element_type)
 
 
@@ -75,11 +73,9 @@ def test_list_of_files_plugin(sample_json_file, sample_csv_file, sample_jsonl_fi
     source_message = ListOfFiles(
         files=[sample_json_file, sample_jsonl_file, sample_csv_file]
     )
-
-    stream = ListOfFilesDataStreamSourcePlugin.to_data_stream(
+    stream = ListOfFilesDataStreamSourcePlugin({}, "").to_data_stream(
         source_message, element_type
     )
-
     validate_data_stream(stream, 9, element_type)
 
 
@@ -92,7 +88,6 @@ def test_json_data_plugin():
     plugin = JsonDataStreamSourcePlugin({}, "")
     source_message_type = plugin.get_stream_message_type(element_type=element_type)
     source_messsage = source_message_type(data=data)
-
     stream = plugin.to_data_stream(
         source_message=source_messsage, element_type=element_type
     )

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -230,4 +230,9 @@ def test_multiple_instances(plugin_factory, reset_stream_source_types):
     class LocalFoobar:
         pass
 
-    make_data_stream_source(LocalFoobar, plugin_factory, cfg)
+    strm_src_cls = make_data_stream_source(LocalFoobar, plugin_factory, cfg)
+    assert strm_src_cls.ELEMENT_TYPE is LocalFoobar
+    assert set(strm_src_cls.get_proto_class().DESCRIPTOR.fields_by_name.keys()) == {
+        "foo",
+        "bar",
+    }

--- a/tests/runtime/service_generation/test_data_stream_plugins.py
+++ b/tests/runtime/service_generation/test_data_stream_plugins.py
@@ -1,0 +1,65 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sample_lib
+from caikit.interfaces.common.data_model.stream_sources import File, Directory, ListOfFiles
+from caikit.runtime.service_generation.data_stream_source import FileDataStreamSourcePlugin, \
+    DirectoryDataStreamSourcePlugin, ListOfFilesDataStreamSourcePlugin, JsonDataStreamSourcePlugin
+from tests.runtime.service_generation.test_data_stream_source import validate_data_stream
+
+
+def test_file_plugin(sample_json_file):
+    # Sample json file has SampleTrainingType data
+    element_type = sample_lib.data_model.SampleTrainingType
+    source_message = File(filename=sample_json_file)
+
+    stream = FileDataStreamSourcePlugin.to_data_stream(source_message, element_type)
+
+    validate_data_stream(stream, 2, element_type)
+
+
+def test_directory_plugin(sample_json_collection):
+    # Sample json collection has SampleTrainingType data
+    element_type = sample_lib.data_model.SampleTrainingType
+    source_message = Directory(dirname=sample_json_collection, extension="json")
+
+    stream = DirectoryDataStreamSourcePlugin.to_data_stream(source_message, element_type)
+
+    validate_data_stream(stream, 3, element_type)
+
+
+def test_list_of_files_plugin(sample_json_file, sample_csv_file, sample_jsonl_file):
+    # Samples all have SampleTrainingType data
+    element_type = sample_lib.data_model.SampleTrainingType
+    source_message = ListOfFiles(files=[sample_json_file, sample_jsonl_file, sample_csv_file])
+
+    stream = ListOfFilesDataStreamSourcePlugin.to_data_stream(source_message, element_type)
+
+    validate_data_stream(stream, 9, element_type)
+
+
+def test_json_data_plugin():
+    element_type = sample_lib.data_model.SampleTrainingType
+    foo = sample_lib.data_model.SampleTrainingType(number=1, label="foo")
+    data = [foo]*5
+
+    # This plugin is actually initialized so that it can build the source message type
+    plugin = JsonDataStreamSourcePlugin(element_type=element_type)
+    source_message_type = plugin.get_stream_message_type()
+    source_messsage = source_message_type(data=data)
+
+    stream = plugin.to_data_stream(source_message=source_messsage, element_type=element_type)
+
+    validate_data_stream(stream, 5, element_type)
+
+

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -309,6 +309,7 @@ def test_make_data_stream_source_from_multipart_formdata_file(
     sample_multipart_json,
     sample_multipart_csv,
     sample_multipart_json_with_content_header,
+    sample_train_service,
     tmp_path,
 ):
     """Test multipart streams. NB: We expect that multipart files will not have an extension"""

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -26,6 +26,15 @@ import caikit
 ## Helper functions
 
 
+@pytest.fixture(autouse=True)
+def train_service(sample_train_service):
+    """This autoused fixture ensures that the training APIs will be created
+    when individual tests are run. Each test, however, does not
+    use the fixture explicitly
+    """
+    pass
+
+
 def validate_data_stream(data_stream, length, data_item_type, data_item_length=None):
     assert isinstance(data_stream, DataStream)
     assert len(data_stream) == length
@@ -299,7 +308,6 @@ def test_make_data_stream_source_from_multipart_formdata_file(
     sample_multipart_json,
     sample_multipart_csv,
     sample_multipart_json_with_content_header,
-    sample_train_service,
     tmp_path,
 ):
     """Test multipart streams. NB: We expect that multipart files will not have an extension"""

--- a/tests/runtime/service_generation/test_data_stream_source.py
+++ b/tests/runtime/service_generation/test_data_stream_source.py
@@ -65,16 +65,6 @@ def test_multiple_make_data_stream_source():
     assert stream_type.from_proto(proto_repr).to_proto() == proto_repr
 
 
-def test_data_model_element_type():
-    stream_type = caikit.interfaces.common.data_model.DataStreamSourceSampleTrainingType
-    assert isinstance(stream_type._to_element_type({"number": 1}), SampleTrainingType)
-
-
-def test_primitive_element_type():
-    stream_type = caikit.interfaces.common.data_model.DataStreamSourceInt
-    assert isinstance(stream_type._to_element_type(1), int)
-
-
 def test_make_data_stream_source_types():
     assert issubclass(make_data_stream_source(int), DataStreamSourceBase)
     assert issubclass(make_data_stream_source(float), DataStreamSourceBase)


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses #517 

This PR refactors `DataStreamSource` to us a pluggable/extensible factory pattern to allow for external library extensions. Concretely, this adds the following:

* New config section `data_streams.source_plugins` to define the set of source plugins
    * The keys in this map are arbitrary labels that are used for logging, but nothing else. Do we like this?
* New base class (`DataStreamSourcePlugin`) that can be extended for new plugins
* New factory for stream source plugins

The ADR also contains details about plans to handle pluggable output with `OutputTarget`s, though those are not implemented in this PR

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
