### PR TITLE
Fix DataObjects with Sequence in names

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -710,10 +710,13 @@ class DataBase(metaclass=_DataBaseMetaClass):
                         oneof = cls._fields_to_oneof[field]
                         contained_class = cls.get_class_for_proto(proto_attr)
                         contained_obj = contained_class.from_proto(proto_attr)
-                        if hasattr(
-                            contained_obj, "values"
-                        ) and contained_class.__module__.startswith(
-                            "caikit.core.data_model"
+                        if hasattr(contained_obj, "values") and (
+                            contained_class.__module__.startswith(
+                                "caikit.core.data_model"
+                            )
+                            or contained_class.__module__.startswith(
+                                "caikit.interfaces.common.data_model"
+                            )
                         ):
                             kwargs[oneof] = getattr(contained_obj, "values")
                         else:

--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -710,7 +710,14 @@ class DataBase(metaclass=_DataBaseMetaClass):
                         oneof = cls._fields_to_oneof[field]
                         contained_class = cls.get_class_for_proto(proto_attr)
                         contained_obj = contained_class.from_proto(proto_attr)
-                        kwargs[oneof] = getattr(contained_obj, "values")
+                        if hasattr(
+                            contained_obj, "values"
+                        ) and contained_class.__module__.startswith(
+                            "caikit.core.data_model"
+                        ):
+                            kwargs[oneof] = getattr(contained_obj, "values")
+                        else:
+                            kwargs[oneof] = contained_obj
                     else:
                         contained_class = cls.get_class_for_proto(proto_attr)
                         contained_obj = contained_class.from_proto(proto_attr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses: https://github.com/caikit/caikit/issues/443

Adds some additional checks in `DataBase.from_proto()` to ensure that we only apply sequence-specific logic to sequences that were generated by `py_to_proto` not data objects which happen to have names ending in "sequence".

Some unit tests were added to test the added functionality on edge cases which previously failed.

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
