### PR TITLE
:loud_sound: add comments, warning for multi-task train

### DIFF
--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -286,6 +286,8 @@ def get_train_request(module_class: Type[ModuleBase]) -> Type[DataBase]:
         module_class,
         ModuleBase,
     )
+    # 🌶️🌶️🌶️ This is coupled to the naming scheme code in
+    # caikit.runtime.service_generation.rpcs, which is likely to change.
     first_task = next(iter(module_class.tasks))
     request_class_name = f"{first_task.__name__}{module_class.__name__}TrainRequest"
     log.debug("Request class name %s for module %s.", request_class_name, module_class)

--- a/caikit/runtime/service_generation/rpcs.py
+++ b/caikit/runtime/service_generation/rpcs.py
@@ -152,9 +152,28 @@ class ModuleClassTrainRPC(CaikitRPCBase):
         """Helper function to convert from the name of a module to the name of the
         request RPC function
         """
-        return snake_to_upper_camel(
+        # 🌶️🌶️🌶️ The naming scheme for training RPCs probably needs to change.
+        # This uses the first task from the `tasks` kwarg in the `@caikit.module` decorator.
+        # This is both:
+        # - Flaky, since re-ordering that list would be perfectly reasonable and valid to do except
+        #   for the side effect of breaking the training service api
+        # - Not very intuitive, since a module supporting multiple tasks will have a training
+        #   endpoint that lists only one of them
+        rpc_name = snake_to_upper_camel(
             f"{next(iter(module_class.tasks)).__name__}_{module_class.__name__}_Train"
         )
+
+        if len(module_class.tasks) > 1:
+            log.warning(
+                "<RUN35134050W>",
+                "Multiple tasks detected for training rpc. "
+                "Module: [%s], Tasks: [%s], RPC name: %s ",
+                module_class,
+                module_class.tasks,
+                rpc_name,
+            )
+
+        return rpc_name
 
     @staticmethod
     def module_class_to_req_name(module_class: Type[ModuleBase]) -> str:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Quick follow-on to https://github.com/caikit/caikit/pull/511

Adds a few comments and a warning log in the service generation bits for the `training` endpoint when you have a multi-task model.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
