### PR TITLE
Remove modules.json from tests

### DIFF
--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -29,14 +29,14 @@ import caikit
 log = alog.use_channel("RUNTIME-DUMP-SVC")
 
 
-def dump_grpc_services(output_dir: str):
+def dump_grpc_services(output_dir: str, write_modules_file):
     """Utility for rendering the all generated interfaces to proto files"""
     inf_enabled = get_config().runtime.service_generation.enable_inference
     train_enabled = get_config().runtime.service_generation.enable_training
 
     if inf_enabled:
         inf_svc = ServicePackageFactory.get_service_package(
-            ServicePackageFactory.ServiceType.INFERENCE, write_modules_file=True
+            ServicePackageFactory.ServiceType.INFERENCE, write_modules_file=write_modules_file
         )
     if train_enabled:
         train_svc = ServicePackageFactory.get_service_package(
@@ -99,12 +99,15 @@ def dump_http_services(output_dir: str):
 
 
 if __name__ == "__main__":
-    assert len(sys.argv) == 2, f"Usage: {sys.argv[0]} <output_dir>"
+    assert (
+        len(sys.argv) == 2
+    ), f"Usage: {sys.argv[0]} <output_dir>, <write_modules_json>"
     out_dir = sys.argv[1]
+    write_modules_json = sys.argv[2]
     # Set up logging so users can set LOG_LEVEL etc
     caikit.core.toolkit.logging.configure()
 
     if get_config().runtime.grpc.enabled:
-        dump_grpc_services(out_dir)
+        dump_grpc_services(out_dir, write_modules_json)
     if get_config().runtime.http.enabled:
         dump_http_services(out_dir)

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Standard
+import argparse
 import json
 import os
 import sys
@@ -36,7 +37,8 @@ def dump_grpc_services(output_dir: str, write_modules_file):
 
     if inf_enabled:
         inf_svc = ServicePackageFactory.get_service_package(
-            ServicePackageFactory.ServiceType.INFERENCE, write_modules_file=write_modules_file
+            ServicePackageFactory.ServiceType.INFERENCE,
+            write_modules_file=write_modules_file,
         )
     if train_enabled:
         train_svc = ServicePackageFactory.get_service_package(
@@ -99,11 +101,33 @@ def dump_http_services(output_dir: str):
 
 
 if __name__ == "__main__":
-    assert (
-        len(sys.argv) == 2
-    ), f"Usage: {sys.argv[0]} <output_dir>, <write_modules_json>"
-    out_dir = sys.argv[1]
-    write_modules_json = sys.argv[2]
+    parser = argparse.ArgumentParser(
+        description="Dump grpc and http services for inference and train"
+    )
+
+    # Add an argument for the output_dir
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="protos",
+        type=str,
+        help="Path to the output directory for service(s)' proto files",
+    )
+
+    # Add an argument for write_modules_json
+    parser.add_argument(
+        "-j",
+        "--write-modules-json",
+        default=False,
+        action="store_true",
+        help="Wether the modules.json (of supported modules) should be output?",
+    )
+
+    args = parser.parse_args()
+
+    out_dir = args.output_dir
+    write_modules_json = args.write_modules_json
+
     # Set up logging so users can set LOG_LEVEL etc
     caikit.core.toolkit.logging.configure()
 

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -107,9 +107,7 @@ if __name__ == "__main__":
 
     # Add an argument for the output_dir
     parser.add_argument(
-        "-o",
-        "--output-dir",
-        default="protos",
+        "output_dir",
         type=str,
         help="Path to the output directory for service(s)' proto files",
     )

--- a/examples/sample_lib/start_runtime_with_sample_lib.py
+++ b/examples/sample_lib/start_runtime_with_sample_lib.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
             # dump protos
             shutil.rmtree("protos", ignore_errors=True)
             if get_config().runtime.grpc.enabled:
-                dump_grpc_services("protos")
+                dump_grpc_services("protos", True)
             if get_config().runtime.http.enabled:
                 dump_http_services("protos")
 

--- a/tests/runtime/test_dump_services.py
+++ b/tests/runtime/test_dump_services.py
@@ -29,7 +29,7 @@ log = alog.use_channel("TEST-DUMP-I")
 
 def test_dump_grpc_services_dir_exists():
     with tempfile.TemporaryDirectory() as workdir:
-        dump_grpc_services(workdir)
+        dump_grpc_services(workdir, False)
         assert os.path.exists(workdir)
 
         for file in os.listdir(workdir):
@@ -38,7 +38,7 @@ def test_dump_grpc_services_dir_exists():
 
 def test_dump_grpc_services_dir_does_not_exist():
     fake_dir = "fake_dir"
-    dump_grpc_services(fake_dir)
+    dump_grpc_services(fake_dir, False)
     assert os.path.exists(fake_dir)
 
     for file in os.listdir(fake_dir):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Currently, test_dump_services.py calls `dump_grpc_services` and this function always prints out a `modules.json` file. This PR makes this an argument, and don't print out a `modules.json` file in unit tests, only in `start_runtime_with_sample_lib.py` do we want this file printed out

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
