### PR TITLE
✨ add stream event types

### DIFF
--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -32,6 +32,7 @@ import ssl
 import tempfile
 import threading
 import time
+import traceback
 
 # Third Party
 from fastapi import FastAPI, HTTPException, Request, Response, status
@@ -512,6 +513,18 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     return
                 except HTTPException as err:
                     raise err
+                except (TypeError, ValueError) as err:
+                    log_dict = {
+                        "log_code": "<RUN76624264W>",
+                        "message": repr(err),
+                        "stack_trace": traceback.format_exc(),
+                    }
+                    log.warning(log_dict)
+                    error_code = 400
+                    error_content = {
+                        "details": repr(err),
+                        "code": error_code,
+                    }
                 except CaikitRuntimeException as err:
                     error_code = GRPC_CODE_TO_HTTP.get(err.status_code, 500)
                     error_content = {

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -506,10 +506,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                             **request_params,
                         )
                     ):
-                        yield {
-                            "event": StreamEventTypes.MESSAGE.value,
-                            "data": result.to_json(),
-                        }
+                        yield ServerSentEvent(
+                            data=result.to_json(), event=StreamEventTypes.MESSAGE.value
+                        )
                     return
                 except HTTPException as err:
                     raise err

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -498,13 +498,17 @@ class RuntimeHTTPServer(RuntimeServerBase):
                             **request_params,
                         )
                     ):
-                        yield result
+                        yield {
+                            "event": "message",
+                            "data": result.to_json(),
+                        }
                     return
                 except HTTPException as err:
                     raise err
                 except CaikitRuntimeException as err:
                     error_code = GRPC_CODE_TO_HTTP.get(err.status_code, 500)
                     error_content = {
+                        "event": "error",
                         "details": err.message,
                         "code": error_code,
                         "id": err.id,
@@ -512,6 +516,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     error_code = 500
                     error_content = {
+                        "event": "error",
                         "details": f"Unhandled exception: {str(err)}",
                         "code": error_code,
                         "id": None,

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -110,7 +110,7 @@ HEALTH_ENDPOINT = "/health"
 
 
 # Stream event types enum
-class StreamEventTypes(str, Enum):
+class StreamEventTypes(Enum):
     MESSAGE = "message"
     ERROR = "error"
 
@@ -507,7 +507,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
                         )
                     ):
                         yield {
-                            "event": StreamEventTypes.MESSAGE,
+                            "event": StreamEventTypes.MESSAGE.value,
                             "data": result.to_json(),
                         }
                     return
@@ -543,7 +543,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
 
                 # If an error occurs, yield an error response and terminate
                 yield ServerSentEvent(
-                    data=json.dumps(error_content), event=StreamEventTypes.ERROR
+                    data=json.dumps(error_content), event=StreamEventTypes.ERROR.value
                 )
 
             return EventSourceResponse(_generator())

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -515,7 +515,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 except CaikitRuntimeException as err:
                     error_code = GRPC_CODE_TO_HTTP.get(err.status_code, 500)
                     error_content = {
-                        "event": StreamEventTypes.ERROR,
                         "details": err.message,
                         "code": error_code,
                         "id": err.id,
@@ -523,7 +522,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     error_code = 500
                     error_content = {
-                        "event": StreamEventTypes.ERROR,
                         "details": f"Unhandled exception: {str(err)}",
                         "code": error_code,
                         "id": None,
@@ -531,7 +529,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     log.error("<RUN51881106E>", err, exc_info=True)
 
                 # If an error occurs, yield an error response and terminate
-                yield ServerSentEvent(data=json.dumps(error_content))
+                yield ServerSentEvent(
+                    data=json.dumps(error_content), event=StreamEventTypes.ERROR
+                )
 
             return EventSourceResponse(_generator())
 

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -78,7 +78,7 @@ class SampleModule(caikit.core.ModuleBase):
         """
         Args:
             sample_input (sample_lib.data_model.SampleInputType): the input
-            sampleerr_stream_input (bool): An optional parameter to error out the stream
+            err_stream (bool): An optional parameter to error out the stream
 
         Returns:
             caikit.core.data_model.DataStream[sample_lib.data_model.SampleOutputType]: The output

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -73,11 +73,12 @@ class SampleModule(caikit.core.ModuleBase):
 
     @SampleTask.taskmethod(output_streaming=True)
     def run_stream_out(
-        self, sample_input: SampleInputType
+        self, sample_input: SampleInputType, err_stream: bool = False
     ) -> DataStream[SampleOutputType]:
         """
         Args:
             sample_input (sample_lib.data_model.SampleInputType): the input
+            sampleerr_stream_input (bool): An optional parameter to error out the stream
 
         Returns:
             caikit.core.data_model.DataStream[sample_lib.data_model.SampleOutputType]: The output
@@ -87,7 +88,11 @@ class SampleModule(caikit.core.ModuleBase):
             SampleOutputType(f"Hello {sample_input.name} stream")
             for x in range(self.stream_size)
         ]
-        stream = DataStream.from_iterable(list_)
+        stream = (
+            DataStream.from_iterable(list_)
+            if not err_stream
+            else DataStream.from_iterable()
+        )
         return stream
 
     @SampleTask.taskmethod(input_streaming=True, output_streaming=True)

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -88,10 +88,14 @@ class SampleModule(caikit.core.ModuleBase):
             SampleOutputType(f"Hello {sample_input.name} stream")
             for x in range(self.stream_size)
         ]
+        # raise a value error when the stream is iterated, not before.
+        def raise_exception():
+            raise ValueError("raising a ValueError")
+
         stream = (
             DataStream.from_iterable(list_)
             if not err_stream
-            else DataStream.from_iterable()
+            else DataStream.from_iterable([1]).map(lambda x: raise_exception())
         )
         return stream
 

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -477,14 +477,23 @@ def test_inference_streaming_sample_module(sample_task_model_id, client):
         stream_content = stream.content.decode(stream.default_encoding)
         stream_responses = json.loads(
             "[{}]".format(
-                stream_content.replace("data: ", "")
+                stream_content.replace("event: ", '{"event":')
+                .replace("message", '"message"}')
+                .replace("data: ", "")
                 .replace("\r\n", "")
                 .replace("}{", "}, {")
             )
         )
-        assert len(stream_responses) == 10
+        assert len(stream_responses) == 20
         assert all(
-            resp.get("greeting") == "Hello world stream" for resp in stream_responses
+            resp.get("greeting") == "Hello world stream"
+            for resp in stream_responses
+            if "greeting" in resp
+        )
+        assert all(
+            resp.get("event") == "message"
+            for resp in stream_responses
+            if "event" in resp
         )
 
 

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -569,8 +569,7 @@ def test_inference_streaming_sample_module_actual_server_throws(
         assert len(stream_responses) == 2
         assert stream_responses[0].get("event") == StreamEventTypes.ERROR
         assert (
-            stream_responses[1].get("details")
-            == "Unhandled exception: raising a ValueError"
+            stream_responses[1].get("details") == "ValueError('raising a ValueError')"
         )
         assert stream_responses[1].get("code") == 400
 

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -480,8 +480,8 @@ def test_inference_streaming_sample_module(sample_task_model_id, client):
             "[{}]".format(
                 stream_content.replace("event: ", '{"event":')
                 .replace(
-                    StreamEventTypes.MESSAGE,
-                    '"' + f"{StreamEventTypes.MESSAGE}" + '"}',
+                    StreamEventTypes.MESSAGE.value,
+                    '"' + f"{StreamEventTypes.MESSAGE.value}" + '"}',
                 )
                 .replace("data: ", "")
                 .replace("\r\n", "")
@@ -495,7 +495,7 @@ def test_inference_streaming_sample_module(sample_task_model_id, client):
             if "greeting" in resp
         )
         assert all(
-            resp.get("event") == StreamEventTypes.MESSAGE
+            resp.get("event") == StreamEventTypes.MESSAGE.value
             for resp in stream_responses
             if "event" in resp
         )
@@ -517,8 +517,8 @@ def test_inference_streaming_sample_module_actual_server(
             "[{}]".format(
                 stream_content.replace("event: ", '{"event":')
                 .replace(
-                    StreamEventTypes.MESSAGE,
-                    '"' + f"{StreamEventTypes.MESSAGE}" + '"}',
+                    StreamEventTypes.MESSAGE.value,
+                    '"' + f"{StreamEventTypes.MESSAGE.value}" + '"}',
                 )
                 .replace("data: ", "")
                 .replace("\r\n", "")
@@ -532,7 +532,7 @@ def test_inference_streaming_sample_module_actual_server(
             if "greeting" in resp
         )
         assert all(
-            resp.get("event") == StreamEventTypes.MESSAGE
+            resp.get("event") == StreamEventTypes.MESSAGE.value
             for resp in stream_responses
             if "event" in resp
         )
@@ -558,8 +558,8 @@ def test_inference_streaming_sample_module_actual_server_throws(
             "[{}]".format(
                 stream_content.replace("event: ", '{"event":')
                 .replace(
-                    StreamEventTypes.ERROR,
-                    '"' + f"{StreamEventTypes.ERROR}" + '"}',
+                    StreamEventTypes.ERROR.value,
+                    '"' + f"{StreamEventTypes.ERROR.value}" + '"}',
                 )
                 .replace("data: ", "")
                 .replace("\r\n", "")
@@ -567,7 +567,7 @@ def test_inference_streaming_sample_module_actual_server_throws(
             )
         )
         assert len(stream_responses) == 2
-        assert stream_responses[0].get("event") == StreamEventTypes.ERROR
+        assert stream_responses[0].get("event") == StreamEventTypes.ERROR.value
         assert (
             stream_responses[1].get("details") == "ValueError('raising a ValueError')"
         )

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -36,6 +36,7 @@ import tls_test_tools
 # Local
 from caikit.core import MODEL_MANAGER, DataObjectBase, dataobject
 from caikit.runtime import http_server
+from caikit.runtime.http_server.http_server import StreamEventTypes
 from tests.conftest import temp_config
 from tests.runtime.conftest import (
     ModuleSubproc,
@@ -478,7 +479,10 @@ def test_inference_streaming_sample_module(sample_task_model_id, client):
         stream_responses = json.loads(
             "[{}]".format(
                 stream_content.replace("event: ", '{"event":')
-                .replace("message", '"message"}')
+                .replace(
+                    StreamEventTypes.MESSAGE,
+                    '"' + f"{StreamEventTypes.MESSAGE}" + '"}',
+                )
                 .replace("data: ", "")
                 .replace("\r\n", "")
                 .replace("}{", "}, {")
@@ -491,7 +495,7 @@ def test_inference_streaming_sample_module(sample_task_model_id, client):
             if "greeting" in resp
         )
         assert all(
-            resp.get("event") == "message"
+            resp.get("event") == StreamEventTypes.MESSAGE
             for resp in stream_responses
             if "event" in resp
         )
@@ -543,7 +547,8 @@ def test_inference_streaming_sample_module_actual_server(
         stream_content = stream.content.decode(stream.encoding)
         stream_responses = json.loads(
             "[{}]".format(
-                stream_content.replace("data: ", "")
+                stream_content.replace("event: ", '{"event":')
+                .replace("data: ", "")
                 .replace("\r\n", "")
                 .replace("}{", "}, {")
             )

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -501,11 +501,48 @@ def test_inference_streaming_sample_module(sample_task_model_id, client):
         )
 
 
-def test_inference_streaming_sample_module_actual_server_throws(
+def test_inference_streaming_sample_module_actual_server(
     sample_task_model_id, runtime_http_server
 ):
     """Simple check for testing a happy path unary-stream case
-    but pints the actual running server"""
+    but pings the actual running server"""
+
+    for i in range(10):
+        input = {"model_id": sample_task_model_id, "inputs": {"name": f"world{i}"}}
+        url = f"http://localhost:{runtime_http_server.port}/api/v1/task/server-streaming-sample"
+        stream = requests.post(url=url, json=input, verify=False)
+        assert stream.status_code == 200
+        stream_content = stream.content.decode(stream.encoding)
+        stream_responses = json.loads(
+            "[{}]".format(
+                stream_content.replace("event: ", '{"event":')
+                .replace(
+                    StreamEventTypes.MESSAGE,
+                    '"' + f"{StreamEventTypes.MESSAGE}" + '"}',
+                )
+                .replace("data: ", "")
+                .replace("\r\n", "")
+                .replace("}{", "}, {")
+            )
+        )
+        assert len(stream_responses) == 20
+        assert all(
+            resp.get("greeting") == f"Hello world{i} stream"
+            for resp in stream_responses
+            if "greeting" in resp
+        )
+        assert all(
+            resp.get("event") == StreamEventTypes.MESSAGE
+            for resp in stream_responses
+            if "event" in resp
+        )
+
+
+def test_inference_streaming_sample_module_actual_server_throws(
+    sample_task_model_id, runtime_http_server
+):
+    """Simple check for testing an exception in unary-stream case
+    that pings the actual running server"""
 
     for i in range(10):
         input = {
@@ -519,45 +556,23 @@ def test_inference_streaming_sample_module_actual_server_throws(
         stream_content = stream.content.decode(stream.encoding)
         stream_responses = json.loads(
             "[{}]".format(
-                stream_content.replace("data: ", "")
-                .replace("\r\n", "")
-                .replace("}{", "}, {")
-            )
-        )
-        assert len(stream_responses) == 10
-        assert all(
-            resp.get("greeting") == f"Hello world{i} stream"
-            for resp in stream_responses
-        )
-
-
-
-
-def test_inference_streaming_sample_module_actual_server(
-    sample_task_model_id, runtime_http_server
-):
-    """Simple check for testing a happy path unary-stream case
-    but pints the actual running server"""
-
-    for i in range(10):
-        input = {"model_id": sample_task_model_id, "inputs": {"name": f"world{i}"}}
-        url = f"http://localhost:{runtime_http_server.port}/api/v1/task/server-streaming-sample"
-        stream = requests.post(url=url, json=input, verify=False)
-        assert stream.status_code == 200
-        stream_content = stream.content.decode(stream.encoding)
-        stream_responses = json.loads(
-            "[{}]".format(
                 stream_content.replace("event: ", '{"event":')
+                .replace(
+                    StreamEventTypes.ERROR,
+                    '"' + f"{StreamEventTypes.ERROR}" + '"}',
+                )
                 .replace("data: ", "")
                 .replace("\r\n", "")
                 .replace("}{", "}, {")
             )
         )
-        assert len(stream_responses) == 10
-        assert all(
-            resp.get("greeting") == f"Hello world{i} stream"
-            for resp in stream_responses
+        assert len(stream_responses) == 2
+        assert stream_responses[0].get("event") == StreamEventTypes.ERROR
+        assert (
+            stream_responses[1].get("details")
+            == "Unhandled exception: raising a ValueError"
         )
+        assert stream_responses[1].get("code") == 400
 
 
 def test_no_model_id(client):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR makes 2 changes:

### Change 1
Right now in streaming APIs, we only sent in the `data` but not the type of event.
```
data: {
data:   "greeting": "Hello world stream"
data: }
```
Users could not determine whether an event was an error or a message.

This PR adds a `event` type to the messages, so that they look like:
```
event: message
data: {"greeting": "Hello world stream"}
```
or
```
event: error
data: {"details": "ValueError('raising a ValueError')", "code": 400}
```
### Change 2

This PR also makes the `http_server` catch `TypeError, ValueError` type errors, so that they are now tagged with `400`s instead of `500`s which was happening before and which was incorrect. Currently, in case of streaming, if the error happens while the stream is consumed, the error handling has to be done by the `http_server`, which doesn't have separate cases for type/value error.

**Special notes for your reviewer**:

(Also note the `to_json` part has been added to return the result in a single line, thanks Gabe)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
