### PR TITLE
Fix GRPC server over Unix socket

### DIFF
--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -153,7 +153,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
 
         # Listen on a unix socket as well for model mesh.
         if self.config.runtime.grpc.unix_socket_path and os.path.exists(
-            self.config.runtime.grpc.unix_socket_path
+            os.path.dirname(self.config.runtime.grpc.unix_socket_path)
         ):
             try:
                 self.server.add_insecure_port(

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -1283,6 +1283,25 @@ def test_construct_with_options(open_port, sample_train_service, sample_int_file
             assert context.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
 
 
+def test_grpc_server_startup(open_port, sample_train_service, sample_int_file):
+    """Make sure that the server can be booted with config options"""
+    socket_dir = tempfile.TemporaryDirectory()
+    with temp_config(
+        {"runtime": {"grpc": {"unix_socket_path": socket_dir.name + "/grpc.sock"}}},
+        "merge",
+    ):
+        server = RuntimeGRPCServer()
+        with server:
+            stub = model_runtime_pb2_grpc.ModelRuntimeStub(
+                grpc.insecure_channel(f"unix://{socket_dir.name}/grpc.sock")
+            )
+            runtime_status_request = model_runtime_pb2.RuntimeStatusRequest()
+            actual_response = stub.runtimeStatus(runtime_status_request)
+            assert (
+                actual_response.status == model_runtime_pb2.RuntimeStatusResponse.READY
+            )
+
+
 # Test implementation details #########################
 @dataclass
 class KeyPair:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR updates the GRPCServer unix socket implementation to actually allow listening over unix sockets. Prior to this the server would always skip adding the unix socket even if the target directory existed.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
