### PR TITLE
Only call get_service_package for TRAINING when train is enabled

### DIFF
--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -30,23 +30,31 @@ log = alog.use_channel("RUNTIME-DUMP-SVC")
 
 
 def dump_grpc_services(output_dir: str):
-    """Utility for rendering the all generated interfaces to proto files"""
-    inf_svc = ServicePackageFactory.get_service_package(
-        ServicePackageFactory.ServiceType.INFERENCE, write_modules_file=True
-    )
-    train_svc = ServicePackageFactory.get_service_package(
-        ServicePackageFactory.ServiceType.TRAINING,
-    )
-    train_mgt_svc = ServicePackageFactory.get_service_package(
-        ServicePackageFactory.ServiceType.TRAINING_MANAGEMENT,
-    )
+    """Utility for rendering the all generated interfaces to proto files"""    
+    inf_enabled = get_config().runtime.service_generation.enable_inference
+    train_enabled = get_config().runtime.service_generation.enable_training
+
+    if inf_enabled:
+        inf_svc = ServicePackageFactory.get_service_package(
+            ServicePackageFactory.ServiceType.INFERENCE, write_modules_file=True
+        )
+    if train_enabled:
+        train_svc = ServicePackageFactory.get_service_package(
+            ServicePackageFactory.ServiceType.TRAINING,
+        )
+        train_mgt_svc = ServicePackageFactory.get_service_package(
+            ServicePackageFactory.ServiceType.TRAINING_MANAGEMENT,
+        )
     info_svc = ServicePackageFactory.get_service_package(
         ServicePackageFactory.ServiceType.INFO,
     )
+
     render_dataobject_protos(output_dir)
-    inf_svc.service.write_proto_file(output_dir)
-    train_svc.service.write_proto_file(output_dir)
-    train_mgt_svc.service.write_proto_file(output_dir)
+    if inf_enabled:
+        inf_svc.service.write_proto_file(output_dir)
+    if train_enabled:
+        train_svc.service.write_proto_file(output_dir)
+        train_mgt_svc.service.write_proto_file(output_dir)
     info_svc.service.write_proto_file(output_dir)
 
 

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -30,7 +30,7 @@ log = alog.use_channel("RUNTIME-DUMP-SVC")
 
 
 def dump_grpc_services(output_dir: str):
-    """Utility for rendering the all generated interfaces to proto files"""    
+    """Utility for rendering the all generated interfaces to proto files"""
     inf_enabled = get_config().runtime.service_generation.enable_inference
     train_enabled = get_config().runtime.service_generation.enable_training
 

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -103,6 +103,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
 
         # And intercept a training service, if we have one
         if self.enable_training and self.training_service:
+            log.info("<RUN20247827I>", "Enabling gRPC training service")
             global_train_servicer = GlobalTrainServicer(self.training_service)
             self.server = CaikitRuntimeServerWrapper(
                 server=self.server,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When training is NOT enabled, we should be able to call `python3 -m caikit.runtime.dump_services [output_dir]` without any error. Right now, the code calls `get_service_interfaces` for training service too even if training is not enabled. Error:

```
[app@2435cb980b26 ~]$ python3 -m caikit.runtime.dump_services output_protos
{"channel": "COM-LIB-INIT", "exception": null, "level": "info", "log_code": "<RUN11997772I>", "message": "Loading service module: watson_nlp", "num_indent": 0, "thread_id": 140167956726016, "timestamp": "2023-10-26T17:55:40.602909"}
Traceback (most recent call last):
  File "/usr/lib64/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.8/site-packages/caikit/runtime/dump_services.py", line 96, in <module>
    dump_grpc_services(out_dir)
  File "/usr/local/lib/python3.8/site-packages/caikit/runtime/dump_services.py", line 37, in dump_grpc_services
    train_svc = ServicePackageFactory.get_service_package(
  File "/usr/local/lib/python3.8/site-packages/caikit/runtime/service_factory.py", line 150, in get_service_package
    rpc.create_request_data_model(package_name)
  File "/usr/local/lib/python3.8/site-packages/caikit/runtime/service_generation/rpcs.py", line 126, in create_request_data_model
    inner_request_data_model = self._inner_request.create_data_model(package_name)
  File "/usr/local/lib/python3.8/site-packages/caikit/runtime/service_generation/rpcs.py", line 427, in create_data_model
    return make_dataobject(
  File "/usr/local/lib/python3.8/site-packages/caikit/core/data_model/dataobject.py", line 300, in make_dataobject
    return dataobject(**kwargs)(
  File "/usr/local/lib/python3.8/site-packages/caikit/core/data_model/dataobject.py", line 206, in decorator
    descriptor = _dataobject_to_proto(dataclass_=cls, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/caikit/core/data_model/dataobject.py", line 315, in _dataobject_to_proto
    return _DataobjectConverter(*args, **kwargs).descriptor
  File "/usr/local/lib/python3.8/site-packages/py_to_proto/dataclass_to_proto.py", line 118, in __init__
    super().__init__(
  File "/usr/local/lib/python3.8/site-packages/py_to_proto/converter_base.py", line 103, in __init__
    descriptor_proto = self._convert(entry=source_schema, name=name)
  File "/usr/local/lib/python3.8/site-packages/py_to_proto/converter_base.py", line 280, in _convert
    return self._convert_message(name, entry, message_fields)
  File "/usr/local/lib/python3.8/site-packages/py_to_proto/converter_base.py", line 482, in _convert_message
    nested_result = self._convert(entry=field_type, name=nested_name)
  File "/usr/local/lib/python3.8/site-packages/py_to_proto/converter_base.py", line 283, in _convert
    raise ValueError(f"Got unsupported entry type {entry}")
ValueError: Got unsupported entry type <class 'NoneType'>
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
