### PR TITLE
:technologist: Add start_index in response

### DIFF
--- a/caikit/interfaces/nlp/data_model/classification.py
+++ b/caikit/interfaces/nlp/data_model/classification.py
@@ -100,9 +100,7 @@ class TokenClassificationStreamResult(TokenClassificationResults):
     processed_index: Annotated[
         int, FieldNumber(2)
     ]  # Result index up to which text is processed
-    start_index: Annotated[
-        int, FieldNumber(3)
-    ]  # Result start index for processed text
+    start_index: Annotated[int, FieldNumber(3)]  # Result start index for processed text
 
 
 @dataobject(package=NLP_PACKAGE)
@@ -143,6 +141,4 @@ class ClassifiedGeneratedTextStreamResult(ClassifiedGeneratedTextResult):
     processed_index: Annotated[
         Optional[int], FieldNumber(7)
     ]  # Result index up to which text is processed
-    start_index: Annotated[
-        int, FieldNumber(7)
-    ]  # Result start index for processed text
+    start_index: Annotated[int, FieldNumber(7)]  # Result start index for processed text

--- a/caikit/interfaces/nlp/data_model/classification.py
+++ b/caikit/interfaces/nlp/data_model/classification.py
@@ -141,4 +141,4 @@ class ClassifiedGeneratedTextStreamResult(ClassifiedGeneratedTextResult):
     processed_index: Annotated[
         Optional[int], FieldNumber(7)
     ]  # Result index up to which text is processed
-    start_index: Annotated[int, FieldNumber(7)]  # Result start index for processed text
+    start_index: Annotated[int, FieldNumber(8)]  # Result start index for processed text

--- a/caikit/interfaces/nlp/data_model/classification.py
+++ b/caikit/interfaces/nlp/data_model/classification.py
@@ -100,6 +100,9 @@ class TokenClassificationStreamResult(TokenClassificationResults):
     processed_index: Annotated[
         int, FieldNumber(2)
     ]  # Result index up to which text is processed
+    start_index: Annotated[
+        int, FieldNumber(3)
+    ]  # Result start index for processed text
 
 
 @dataobject(package=NLP_PACKAGE)
@@ -140,3 +143,6 @@ class ClassifiedGeneratedTextStreamResult(ClassifiedGeneratedTextResult):
     processed_index: Annotated[
         Optional[int], FieldNumber(7)
     ]  # Result index up to which text is processed
+    start_index: Annotated[
+        int, FieldNumber(7)
+    ]  # Result start index for processed text

--- a/caikit/interfaces/nlp/data_model/text.py
+++ b/caikit/interfaces/nlp/data_model/text.py
@@ -55,6 +55,4 @@ class TokenizationStreamResult(TokenizationResults):
     processed_index: Annotated[
         int, FieldNumber(2)
     ]  # Result index up to which text is processed
-    start_index: Annotated[
-        int, FieldNumber(3)
-    ]  # Result start index for processed text
+    start_index: Annotated[int, FieldNumber(3)]  # Result start index for processed text

--- a/caikit/interfaces/nlp/data_model/text.py
+++ b/caikit/interfaces/nlp/data_model/text.py
@@ -55,3 +55,6 @@ class TokenizationStreamResult(TokenizationResults):
     processed_index: Annotated[
         int, FieldNumber(2)
     ]  # Result index up to which text is processed
+    start_index: Annotated[
+        int, FieldNumber(3)
+    ]  # Result start index for processed text


### PR DESCRIPTION
### Changes
- Add `start_index` as additional field to allow easy use of processed classification results instead of referencing it from "end" index with `processed_index`