### PR TITLE
:zap::bug: Add proper caching of streams in sources

### DIFF
--- a/caikit/runtime/service_generation/data_stream_source.py
+++ b/caikit/runtime/service_generation/data_stream_source.py
@@ -422,8 +422,9 @@ class DataStreamSourceBase(DataStream):
         super().__init__(self._generator)
 
     def _generator(self):
-        stream = self.to_data_stream()
-        return stream.generator_func(*stream.generator_args, **stream.generator_kwargs)
+        return self._stream.generator_func(
+            *self._stream.generator_args, **self._stream.generator_kwargs
+        )
 
     def __getstate__(self) -> bytes:
         """A DataStreamSource is pickled by serializing its source
@@ -449,6 +450,13 @@ class DataStreamSourceBase(DataStream):
         return {
             plugin.get_field_name(self.ELEMENT_TYPE): plugin for plugin in self.PLUGINS
         }
+
+    @cached_property
+    def _stream(self):
+        """The internal _stream is cached here so that the result of calling to_data_stream can be
+        re-read, rather than requiring to_data_stream to be invoked on every read through the
+        stream"""
+        return self.to_data_stream()
 
     # pylint: disable=too-many-return-statements
     def to_data_stream(self) -> DataStream:

--- a/tests/core/data_model/streams/test_data_stream.py
+++ b/tests/core/data_model/streams/test_data_stream.py
@@ -167,6 +167,26 @@ def test_data_stream_from_jsonl_is_pickleable(tmp_path):
     post_pickle_vals = list(pickled_stream)
 
     assert pre_pickle_vals == post_pickle_vals
+    # Interesting: Technically this is a stream of length 1 where the one element is [1,2,3,4,5,6]
+    validate_data_stream(pickled_stream, 1, list)
+
+
+def test_data_stream_from_json_is_pickleable(tmp_path):
+    tmpdir = str(tmp_path)
+
+    data = [1, 2, 3, 4, 5, 6]
+    filepath = os.path.join(tmpdir, "foo.json")
+    with open(filepath, "w") as f:
+        json.dump(data, f)
+
+    stream = DataStream.from_json_array(filepath)
+
+    pre_pickle_vals = list(stream)
+    pickled_stream = pickle.loads(pickle.dumps(stream))
+    post_pickle_vals = list(pickled_stream)
+
+    assert pre_pickle_vals == post_pickle_vals
+    validate_data_stream(pickled_stream, 6, int)
 
 
 def test_bad_json_stream(tmp_path):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

We came across two issues while testing custom plugins for DataStreamSources:
1. The `.to_data_stream` method is called on each read through the stream, which is really slow when your plugin implementation is reading from a remote resource, and unnecessary when your plugin already cached the remote data locally for stream re-entrancy.
2.  Calling `len` on unpickled DataStreamSources fails, because the base `DataStream` class sets a `_length` attribute that is not re-created on the DataStreamSourceBase's `__set_state__`

This PR caches both the `_length` property and the result of calling `to_data_stream` to fix both

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
