### PR TITLE
fix text-sentiment example http runtime client

### DIFF
--- a/examples/text-sentiment/client.py
+++ b/examples/text-sentiment/client.py
@@ -65,9 +65,9 @@ if __name__ == "__main__":
         port = 8080
         # Run inference for two sample prompts
         for text in ["I am not feeling well today!", "Today is a nice sunny day"]:
-            payload = {"inputs": text}
+            payload = {"inputs": text, "model_id": model_id}
             response = requests.post(
-                f"http://localhost:{port}/api/v1/{model_id}/task/hugging-face-sentiment",
+                f"http://localhost:{port}/api/v1/task/hugging-face-sentiment",
                 json=payload,
                 timeout=1,
             )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The text-sentiment example HTTP client uses the wrong HTTP path to query caikit, leading to a 404 not found error:
```
Text: I am not feeling well today!
RESPONSE from HTTP: {
    "detail": "Not Found"
}

Text: Today is a nice sunny day
RESPONSE from HTTP: {
    "detail": "Not Found"
}
```

This PR fixes the request so that the output becomes:
```
Text: I am not feeling well today!
RESPONSE from HTTP: {
    "classes": [
        {
            "class_name": "NEGATIVE",
            "confidence": 0.9997759461402893
        }
    ]
}

Text: Today is a nice sunny day
RESPONSE from HTTP: {
    "classes": [
        {
            "class_name": "POSITIVE",
            "confidence": 0.999869704246521
        }
    ]
}
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
