### PR TITLE
Set default Swagger UI Content-Type to multi-part form

### DIFF
--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -710,8 +710,8 @@ class RuntimeHTTPServer(RuntimeServerBase):
         return {
             "requestBody": {
                 "content": {
-                    "application/json": {"schema": parsed_schema},
                     "multipart/form-data": {"schema": multipart_schema},
+                    "application/json": {"schema": parsed_schema},
                 },
                 "required": True,
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR updates the default Swagger UI Content-Type from application/json to multi-part form. Multi-part form is significantly easier to use in the UI and in most cases more performant, especially when dealing with bytes or File data. This does not affect the generated openapi spec.

**Special notes for your reviewer**:
This is purely a UI preference change.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
