### PR TITLE
Unload model race

### DIFF
--- a/caikit/runtime/servicers/model_runtime_servicer.py
+++ b/caikit/runtime/servicers/model_runtime_servicer.py
@@ -66,11 +66,12 @@ class ModelRuntimeServicerImpl(model_runtime_pb2_grpc.ModelRuntimeServicer):
                     request.modelType,
                     aborter=aborter,
                 )
-                model_size = work.do()
+                loaded_model = work.do()
             else:
-                model_size = self.model_manager.load_model(
+                loaded_model = self.model_manager.load_model(
                     request.modelId, request.modelPath, request.modelType
                 )
+            model_size = loaded_model.size()
 
             log.info(
                 {

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -110,7 +110,7 @@ def test_load_model_ok_response():
         model_id=model_id,
         local_model_path=Fixtures.get_good_model_path(),
         model_type=Fixtures.get_good_model_type(),
-    )
+    ).size()
     assert model_size > 0
 
 
@@ -127,7 +127,7 @@ def test_load_model_no_size_update():
         model_id=model_id,
         local_model_path=Fixtures.get_good_model_path(),
         model_type=Fixtures.get_good_model_type(),
-    )
+    ).size()
     assert model_size > 0
     loaded_model = MODEL_MANAGER.loaded_models[model_id]
     assert loaded_model.size() == model_size
@@ -668,7 +668,7 @@ def test_load_model():
 
             model_size = MODEL_MANAGER.load_model(
                 model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE
-            )
+            ).size()
             assert expected_model_size == model_size
             mock_loader.load_model.assert_called_once()
             call_args = mock_loader.load_model.call_args
@@ -832,12 +832,12 @@ def test_reload_partially_loaded():
             mock_loader.load_model.return_value = loaded_model
             model_size = MODEL_MANAGER.load_model(
                 model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE, wait=False
-            )
+            ).size()
             assert model_size == special_model_size
             assert (
                 MODEL_MANAGER.load_model(
                     model_id, ANY_MODEL_PATH, ANY_MODEL_TYPE, wait=False
-                )
+                ).size()
                 == special_model_size
             )
 

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -561,6 +561,7 @@ def test_model_unload_race(good_model_path):
 
                 # Retrieve the model and make sure there's no error
                 assert manager.retrieve_model(model_id)
+                assert model_id not in manager.loaded_models
 
 
 def test_load_local_model_deleted_dir():

--- a/tests/runtime/servicers/test_model_runtime_servicer_impl.py
+++ b/tests/runtime/servicers/test_model_runtime_servicer_impl.py
@@ -57,7 +57,7 @@ class TestModelRuntimeServicerImpl(unittest.TestCase):
             ]
         )
         mock_manager = MagicMock()
-        mock_manager.load_model.return_value = 1
+        mock_manager.load_model.size.return_value = 1
 
         with patch.object(self.servicer, "model_manager", mock_manager):
             response = self.servicer.loadModel(request, context)
@@ -75,7 +75,7 @@ class TestModelRuntimeServicerImpl(unittest.TestCase):
             get_config().inference_plugin.model_mesh.max_model_concurrency
         )
         mock_manager = MagicMock()
-        mock_manager.load_model.return_value = 1
+        mock_manager.load_model.size.return_value = 1
 
         with patch.object(self.servicer, "model_manager", mock_manager):
             response = self.servicer.loadModel(request, context)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses a race condition that was showing up due to another bug where models in the `local_models_dir` that were nested inside subdirectories were auto-unloaded when the sync cron fired. Because of how often models were being unloaded, it was reasonably common that a model would be unloaded _after_ being added to the global `self.loaded_models` map, but _before_ the `retrieve_model` call finished, causing [the re-lookup](https://github.com/caikit/caikit/blob/main/caikit/runtime/model_management/model_manager.py#L413) to raise a `KeyError`.

The fix in this PR is to not re-index into `self.loaded_models`. This does still expose the possible race condition where a request might appear as though a model were still loaded, even after it were removed from the map, but that would only manifest for a single request and subsequent requests would fail to find the model.

**Special notes for your reviewer**:

* The bug that revealed this race was fixed in the [previous PR](https://github.com/caikit/caikit/pull/578)
* The change to the return value of `caikit.runtime.model_management.ModelManager.load_model` is NOT considered an API breaking change. The public API of `caikit.runtime` is only the server APIs and the extensible interfaces, so even though it's a public function on the class, it's not API breaking to the overall `caikit.runtime` API.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
