### PR TITLE
ConfigurableHttpProbeTimeout: Make the http health probe configurable

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -139,6 +139,8 @@ runtime:
         route_prefix: api/v1
         # Maximum number of seconds to wait for graceful shutdown
         server_shutdown_grace_period_seconds: 5
+        # Timeout for health probe to receive a response
+        probe_timeout: 0.01
 
     # Configuration for the metrics server
     metrics:

--- a/caikit_health_probe/__main__.py
+++ b/caikit_health_probe/__main__.py
@@ -153,7 +153,7 @@ def _http_health_probe(
                 # NOTE: Not using the constant to avoid big imports
                 resp = session.get(
                     f"{protocol}://localhost:{port}/health",
-                    timeout=0.01,
+                    timeout=get_config().runtime.http.probe_timeout,
                     **kwargs,
                 )
             resp.raise_for_status()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the HTTP server's health probe timeout configurable via `RUNTIME_HTTP_PROBE_TIMEOUT`
