### PR TITLE
Add endpoint to get information about loaded models

### DIFF
--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -79,6 +79,17 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
             self._metadata = {}
         return self._metadata
 
+    def get_metadata(self) -> Dict[str, str]:
+        """Helper function to return public metadata about a Module. This is kept
+        separate from the metadata parameter to allow for fields to be excluded. This
+        function also requires a flat metadata structure without nested dictionaries
+
+        Returns:
+            Dict[str, str]: A dictionary of this module's public metadata
+        """
+
+        return {"name": self.MODULE_NAME, "version": self.MODULE_VERSION}
+
     def set_load_backend(self, load_backend):
         """Method used by the model manager to indicate the load backend that
         was used to load this module

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -80,16 +80,31 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
         return self._metadata
 
     @property
-    def module_metadata(self) -> Dict[str, Any]:
-        """Helper property to return public metadata about a Module. This function
-        is separate from `metdata` as this is specific for the root module. This
-        function also requires a flat metadata structure without nested dictionaries
+    def module_metadata(cls) -> Dict[str, Any]:
+        """Helper property to return metadata about a Module. This function
+        is separate from `metadata` as this is specific for the class module. This
+        function also requires a flat metadata structure without nested dictionaries.
+
+        NOTE: This should be a @classmethod but using @property/@classmethod together has
+        been deprecated
 
         Returns:
-            Dict[str, str]: A dictionary of this module's public metadata
+            Dict[str, str]: A dictionary of this ModuleBases's metadata
         """
 
-        return {"name": self.MODULE_NAME, "version": self.MODULE_VERSION}
+        return {"name": cls.MODULE_NAME, "version": cls.MODULE_VERSION}
+
+    @property
+    def public_model_info(cls) -> Dict[str, Any]:
+        """Helper property to return public metadata about a specific Model. This
+        function is separate from `metdata` as that contains the entire ModelConfig
+        which might not want to be shared/exposed.
+
+        Returns:
+            Dict[str, str]: A dictionary of this models's public metadata
+        """
+
+        return {}
 
     def set_load_backend(self, load_backend):
         """Method used by the model manager to indicate the load backend that

--- a/caikit/core/modules/base.py
+++ b/caikit/core/modules/base.py
@@ -79,9 +79,10 @@ class ModuleBase(metaclass=_ModuleBaseMeta):
             self._metadata = {}
         return self._metadata
 
-    def get_metadata(self) -> Dict[str, str]:
-        """Helper function to return public metadata about a Module. This is kept
-        separate from the metadata parameter to allow for fields to be excluded. This
+    @property
+    def module_metadata(self) -> Dict[str, Any]:
+        """Helper property to return public metadata about a Module. This function
+        is separate from `metdata` as this is specific for the root module. This
         function also requires a flat metadata structure without nested dictionaries
 
         Returns:

--- a/caikit/interfaces/runtime/data_model/__init__.py
+++ b/caikit/interfaces/runtime/data_model/__init__.py
@@ -14,7 +14,13 @@
 
 # Local
 from . import training_management
-from .info import RuntimeInfoRequest, RuntimeInfoResponse
+from .info import (
+    ModelInfo,
+    ModelInfoRequest,
+    ModelInfoResponse,
+    RuntimeInfoRequest,
+    RuntimeInfoResponse,
+)
 from .training_management import (
     ModelPointer,
     TrainingInfoRequest,

--- a/caikit/interfaces/runtime/data_model/info.py
+++ b/caikit/interfaces/runtime/data_model/info.py
@@ -16,7 +16,7 @@ This file contains interfaces to handle information requests
 """
 
 # Standard
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 # First Party
 from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
@@ -39,3 +39,28 @@ class RuntimeInfoRequest(DataObjectBase):
 class RuntimeInfoResponse(DataObjectBase):
     runtime_version: Annotated[Optional[str], FieldNumber(1)]
     python_packages: Annotated[Dict[str, str], FieldNumber(2)]
+
+
+@dataobject(RUNTIME_PACKAGE)
+class ModelInfoRequest(DataObjectBase):
+    """Empty request for runtime server information"""
+
+
+@dataobject(RUNTIME_PACKAGE)
+class ModelInfo(DataObjectBase):
+    """Empty request for runtime server information"""
+
+    # Model information
+    model_path: Annotated[str, FieldNumber(1)]
+    name: Annotated[str, FieldNumber(2)]
+    size: Annotated[int, FieldNumber(3)]
+
+    # Module Information
+    module_id: Annotated[str, FieldNumber(4)]
+    module_name: Annotated[str, FieldNumber(5)]
+    version: Annotated[str, FieldNumber(6)]
+
+
+@dataobject(RUNTIME_PACKAGE)
+class ModelInfoResponse(DataObjectBase):
+    models: Annotated[List[ModelInfo], FieldNumber(1)]

--- a/caikit/interfaces/runtime/data_model/info.py
+++ b/caikit/interfaces/runtime/data_model/info.py
@@ -45,6 +45,8 @@ class RuntimeInfoResponse(DataObjectBase):
 class ModelInfoRequest(DataObjectBase):
     """Empty request for runtime server information"""
 
+    model_ids: Annotated[Optional[List[str]], FieldNumber(1)]
+
 
 @dataobject(RUNTIME_PACKAGE)
 class ModelInfo(DataObjectBase):
@@ -57,8 +59,7 @@ class ModelInfo(DataObjectBase):
 
     # Module Information
     module_id: Annotated[str, FieldNumber(4)]
-    module_name: Annotated[str, FieldNumber(5)]
-    version: Annotated[str, FieldNumber(6)]
+    module_metadata: Annotated[Dict[str, str], FieldNumber(5)]
 
 
 @dataobject(RUNTIME_PACKAGE)

--- a/caikit/interfaces/runtime/data_model/info.py
+++ b/caikit/interfaces/runtime/data_model/info.py
@@ -48,7 +48,7 @@ class ModelInfoRequest(DataObjectBase):
 
 @dataobject(RUNTIME_PACKAGE)
 class ModelInfo(DataObjectBase):
-    """Empty request for runtime server information"""
+    """Information regarding a specific Model instance"""
 
     # Model information
     model_path: Annotated[str, FieldNumber(1)]
@@ -63,4 +63,6 @@ class ModelInfo(DataObjectBase):
 
 @dataobject(RUNTIME_PACKAGE)
 class ModelInfoResponse(DataObjectBase):
+    """Model Info response contains a list of ModelInfos"""
+
     models: Annotated[List[ModelInfo], FieldNumber(1)]

--- a/caikit/interfaces/runtime/data_model/info.py
+++ b/caikit/interfaces/runtime/data_model/info.py
@@ -56,10 +56,11 @@ class ModelInfo(DataObjectBase):
     model_path: Annotated[str, FieldNumber(1)]
     name: Annotated[str, FieldNumber(2)]
     size: Annotated[int, FieldNumber(3)]
+    metadata: Annotated[Dict[str, str], FieldNumber(4)]
 
     # Module Information
-    module_id: Annotated[str, FieldNumber(4)]
-    module_metadata: Annotated[Dict[str, str], FieldNumber(5)]
+    module_id: Annotated[str, FieldNumber(5)]
+    module_metadata: Annotated[Dict[str, str], FieldNumber(6)]
 
 
 @dataobject(RUNTIME_PACKAGE)

--- a/caikit/runtime/http_server/__init__.py
+++ b/caikit/runtime/http_server/__init__.py
@@ -13,5 +13,10 @@
 # limitations under the License.
 
 # Local
-from .http_server import HEALTH_ENDPOINT, RUNTIME_INFO_ENDPOINT, RuntimeHTTPServer
+from .http_server import (
+    HEALTH_ENDPOINT,
+    MODELS_INFO_ENDPOINT,
+    RUNTIME_INFO_ENDPOINT,
+    RuntimeHTTPServer,
+)
 from .pydantic_wrapper import dataobject_to_pydantic, pydantic_to_dataobject

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -113,6 +113,7 @@ HEALTH_ENDPOINT = "/health"
 
 # Endpoint to use for server info
 RUNTIME_INFO_ENDPOINT = "/info/version"
+MODELS_INFO_ENDPOINT = "/info/models"
 
 
 # Stream event types enum
@@ -197,6 +198,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
         # Add runtime info endpoint
         self.app.get(RUNTIME_INFO_ENDPOINT, response_class=JSONResponse)(
             self.info_servicer.get_version_dict
+        )
+        self.app.get(MODELS_INFO_ENDPOINT, response_class=JSONResponse)(
+            self.info_servicer.get_models_info
         )
 
         # Parse TLS configuration

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from typing import Annotated, Any, Dict, Iterable, List, Optional, Type, Union, get_args
+from typing import Any, Dict, Iterable, List, Optional, Type, Union, get_args
 import asyncio
 import inspect
 import io
@@ -46,7 +46,10 @@ import pydantic
 import uvicorn
 
 # First Party
-from py_to_proto.dataclass_to_proto import get_origin  # Imported here for 3.8 compat
+from py_to_proto.dataclass_to_proto import (  # Imported here for 3.8 compat
+    Annotated,
+    get_origin,
+)
 import aconfig
 import alog
 

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -773,7 +773,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
     ) -> Dict[str, Any]:
         """Create wrapper for get_models_info so model_ids can be marked as a query parameter"""
         try:
-            return self.info_servicer.get_models_info(model_ids)
+            return self.info_servicer.get_models_info_dict(model_ids)
         except HTTPException as err:
             raise err
         except CaikitRuntimeException as err:

--- a/caikit/runtime/service_factory.py
+++ b/caikit/runtime/service_factory.py
@@ -38,6 +38,8 @@ from caikit.core.data_model.dataobject import _AUTO_GEN_PROTO_CLASSES
 from caikit.core.exceptions import error_handler
 from caikit.core.task import TaskBase
 from caikit.interfaces.runtime.data_model import (
+    ModelInfoRequest,
+    ModelInfoResponse,
     RuntimeInfoRequest,
     RuntimeInfoResponse,
     TrainingInfoRequest,
@@ -76,6 +78,11 @@ INFO_SERVICE_SPEC = {
                 "name": "GetRuntimeInfo",
                 "input_type": RuntimeInfoRequest.get_proto_class().DESCRIPTOR.full_name,
                 "output_type": RuntimeInfoResponse.get_proto_class().DESCRIPTOR.full_name,
+            },
+            {
+                "name": "GetModelsInfo",
+                "input_type": ModelInfoRequest.get_proto_class().DESCRIPTOR.full_name,
+                "output_type": ModelInfoResponse.get_proto_class().DESCRIPTOR.full_name,
             },
         ]
     }

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -61,7 +61,7 @@ class InfoServicer:
         """
         return self._get_models_info(model_ids=request.model_ids).to_proto()
 
-    def get_models_info(
+    def get_models_info_dict(
         self, model_ids: Optional[List[str]]
     ) -> Dict[str, List[Dict[str, Any]]]:
         """Get information on models for the HTTP server
@@ -107,7 +107,7 @@ class InfoServicer:
                     name=name,
                     size=loaded_module.size(),
                     module_id=model_instance.MODULE_ID,
-                    module_metadata=model_instance.get_metadata(),
+                    module_metadata=model_instance.module_metadata,
                 )
             )
         return response

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -106,6 +106,7 @@ class InfoServicer:
                     model_path=loaded_module.path(),
                     name=name,
                     size=loaded_module.size(),
+                    metadata=model_instance.public_model_info,
                     module_id=model_instance.MODULE_ID,
                     module_metadata=model_instance.module_metadata,
                 )

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -19,7 +19,7 @@ library and services.
 # pylint: disable=E1101
 
 # Standard
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 # Third Party
 import importlib_metadata
@@ -29,7 +29,13 @@ import alog
 
 # Local
 from caikit.config import get_config
-from caikit.interfaces.runtime.data_model import RuntimeInfoResponse
+from caikit.interfaces.runtime.data_model import (
+    ModelInfo,
+    ModelInfoRequest,
+    ModelInfoResponse,
+    RuntimeInfoResponse,
+)
+from caikit.runtime.model_management.model_manager import ModelManager
 
 log = alog.use_channel("RI-SERVICR-I")
 
@@ -38,11 +44,64 @@ class InfoServicer:
     """This class contains the implementation for retrieving information about the
     library and services."""
 
+    def GetModelsInfo(
+        self, request: ModelInfoRequest, context  # pylint: disable=unused-argument
+    ) -> ModelInfoResponse:
+        """Get information on the loaded models for the GRPC server
+
+        Args:
+            request: ModelInfoRequest
+            context
+
+        Returns:
+            models_info: ModelInfoResponse
+                DataObject containing the model info
+        """
+        return self.get_models_info_impl().to_proto()
+
+    def get_models_info(self) -> Dict[str, List[Dict[str, Union[str, int]]]]:
+        """Get information on models for the HTTP server
+
+        Returns:
+            model_info_dict: Dict[str, List[Dict[str, str]]]
+                Dict representation of ModelInfoResponse
+        """
+        return self.get_models_info_impl().to_dict()
+
+    def get_models_info_impl(self) -> ModelInfoResponse:
+        """Helper function to get the list of models
+
+        Returns:
+            model_info: ModelInfoResponse
+                DataObject with model information
+        """
+        model_manager = ModelManager.get_instance()
+
+        # Get all loaded models
+        response = ModelInfoResponse(models=[])
+        for name, loaded_module in model_manager.loaded_models.items():
+            model_instance = loaded_module.model()
+            response.models.append(
+                ModelInfo(
+                    model_path=loaded_module.path(),
+                    name=name,
+                    size=loaded_module.size(),
+                    module_name=model_instance.MODULE_NAME,
+                    module_id=model_instance.MODULE_ID,
+                    version=model_instance.MODULE_VERSION,
+                )
+            )
+        return response
+
     def GetRuntimeInfo(
         self, request, context  # pylint: disable=unused-argument
     ) -> RuntimeInfoResponse:
         """Get information on versions of libraries and server for GRPC"""
         return self.get_runtime_info_impl().to_proto()
+
+    def get_version_dict(self) -> Dict[str, Union[str, Dict]]:
+        """Get information on versions of libraries and server for HTTP"""
+        return self.get_runtime_info_impl().to_dict()
 
     def get_runtime_info_impl(self) -> RuntimeInfoResponse:
         """Get information on versions of libraries and server from config"""
@@ -68,10 +127,6 @@ class InfoServicer:
             python_packages=python_packages,
             runtime_version=runtime_image,
         )
-
-    def get_version_dict(self) -> Dict[str, Union[str, Dict]]:
-        """Get information on versions of libraries and server for HTTP"""
-        return self.get_runtime_info_impl().to_dict()
 
     def try_lib_version(self, name) -> str:
         """Get version of python modules"""

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -57,7 +57,7 @@ class InfoServicer:
             models_info: ModelInfoResponse
                 DataObject containing the model info
         """
-        return self.get_models_info_impl().to_proto()
+        return self._get_models_info().to_proto()
 
     def get_models_info(self) -> Dict[str, List[Dict[str, Union[str, int]]]]:
         """Get information on models for the HTTP server
@@ -66,9 +66,9 @@ class InfoServicer:
             model_info_dict: Dict[str, List[Dict[str, str]]]
                 Dict representation of ModelInfoResponse
         """
-        return self.get_models_info_impl().to_dict()
+        return self._get_models_info().to_dict()
 
-    def get_models_info_impl(self) -> ModelInfoResponse:
+    def _get_models_info(self) -> ModelInfoResponse:
         """Helper function to get the list of models
 
         Returns:
@@ -97,13 +97,13 @@ class InfoServicer:
         self, request, context  # pylint: disable=unused-argument
     ) -> RuntimeInfoResponse:
         """Get information on versions of libraries and server for GRPC"""
-        return self.get_runtime_info_impl().to_proto()
+        return self._get_runtime_info().to_proto()
 
     def get_version_dict(self) -> Dict[str, Union[str, Dict]]:
         """Get information on versions of libraries and server for HTTP"""
-        return self.get_runtime_info_impl().to_dict()
+        return self._get_runtime_info().to_dict()
 
-    def get_runtime_info_impl(self) -> RuntimeInfoResponse:
+    def _get_runtime_info(self) -> RuntimeInfoResponse:
         """Get information on versions of libraries and server from config"""
         config_version_info = get_config().runtime.version_info or {}
         python_packages = {
@@ -118,7 +118,7 @@ class InfoServicer:
         for lib, dist_names in importlib_metadata.packages_distributions().items():
             if (
                 all_packages or (len(lib.split(".")) == 1 and lib.startswith("caikit"))
-            ) and (version := self.try_lib_version(dist_names[0])):
+            ) and (version := self._try_lib_version(dist_names[0])):
                 python_packages[lib] = version
 
         runtime_image = config_version_info.get("runtime_image")
@@ -128,7 +128,7 @@ class InfoServicer:
             runtime_version=runtime_image,
         )
 
-    def try_lib_version(self, name) -> str:
+    def _try_lib_version(self, name) -> str:
         """Get version of python modules"""
         try:
             return importlib_metadata.version(name)

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -824,6 +824,27 @@ def test_runtime_info_ok_custom_python_packages(runtime_http_server):
             assert "py_to_proto" not in json_response["python_packages"]
 
 
+def test_models_info_ok(runtime_http_server, sample_task_model_id):
+    """Make sure the runtime info returns version data"""
+    with TestClient(runtime_http_server.app) as client:
+        response = client.get(http_server.MODELS_INFO_ENDPOINT)
+        assert response.status_code == 200
+
+        json_response = json.loads(response.content.decode(response.default_encoding))
+        # Assert some models are loaded
+        assert len(json_response["models"]) > 0
+
+        found_sample_task = False
+        for model in json_response["models"]:
+            # Assert name and id exist
+            assert model["name"] and model["module_id"]
+            if model["name"] == sample_task_model_id:
+                assert model["module_name"] == "SampleModule"
+                found_sample_task = True
+
+        assert found_sample_task, "Unable to find sample_task model in models list"
+
+
 def test_http_server_shutdown_with_model_poll(open_port):
     """Test that a SIGINT successfully shuts down the running server"""
     with tempfile.TemporaryDirectory() as workdir:

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -824,7 +824,7 @@ def test_runtime_info_ok_custom_python_packages(runtime_http_server):
             assert "py_to_proto" not in json_response["python_packages"]
 
 
-def test_models_info_ok(client, sample_task_model_id):
+def test_all_models_info_ok(client, sample_task_model_id):
     """Make sure the runtime info returns version data"""
     response = client.get(http_server.MODELS_INFO_ENDPOINT)
     assert response.status_code == 200
@@ -838,10 +838,26 @@ def test_models_info_ok(client, sample_task_model_id):
         # Assert name and id exist
         assert model["name"] and model["module_id"]
         if model["name"] == sample_task_model_id:
-            assert model["module_name"] == "SampleModule"
+            assert model["module_metadata"]["name"] == "SampleModule"
             found_sample_task = True
 
     assert found_sample_task, "Unable to find sample_task model in models list"
+
+
+def test_single_models_info_ok(client, sample_task_model_id):
+    """Make sure the runtime info returns version data"""
+    response = client.get(
+        http_server.MODELS_INFO_ENDPOINT, params={"model_ids": sample_task_model_id}
+    )
+    assert response.status_code == 200
+
+    json_response = json.loads(response.content.decode(response.default_encoding))
+    # Assert some models are loaded
+    assert len(json_response["models"]) == 1
+
+    model = json_response["models"][0]
+    assert model["name"] == sample_task_model_id
+    assert model["module_metadata"]["name"] == "SampleModule"
 
 
 def test_http_server_shutdown_with_model_poll(open_port):

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -824,25 +824,24 @@ def test_runtime_info_ok_custom_python_packages(runtime_http_server):
             assert "py_to_proto" not in json_response["python_packages"]
 
 
-def test_models_info_ok(runtime_http_server, sample_task_model_id):
+def test_models_info_ok(client, sample_task_model_id):
     """Make sure the runtime info returns version data"""
-    with TestClient(runtime_http_server.app) as client:
-        response = client.get(http_server.MODELS_INFO_ENDPOINT)
-        assert response.status_code == 200
+    response = client.get(http_server.MODELS_INFO_ENDPOINT)
+    assert response.status_code == 200
 
-        json_response = json.loads(response.content.decode(response.default_encoding))
-        # Assert some models are loaded
-        assert len(json_response["models"]) > 0
+    json_response = json.loads(response.content.decode(response.default_encoding))
+    # Assert some models are loaded
+    assert len(json_response["models"]) > 0
 
-        found_sample_task = False
-        for model in json_response["models"]:
-            # Assert name and id exist
-            assert model["name"] and model["module_id"]
-            if model["name"] == sample_task_model_id:
-                assert model["module_name"] == "SampleModule"
-                found_sample_task = True
+    found_sample_task = False
+    for model in json_response["models"]:
+        # Assert name and id exist
+        assert model["name"] and model["module_id"]
+        if model["name"] == sample_task_model_id:
+            assert model["module_name"] == "SampleModule"
+            found_sample_task = True
 
-        assert found_sample_task, "Unable to find sample_task model in models list"
+    assert found_sample_task, "Unable to find sample_task model in models list"
 
 
 def test_http_server_shutdown_with_model_poll(open_port):

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -1015,7 +1015,7 @@ def test_runtime_info_ok_response_all_packages(runtime_grpc_server):
         assert "py_to_proto" in runtime_info_response.python_packages
 
 
-def test_model_info_ok_response(runtime_grpc_server, sample_task_model_id):
+def test_all_model_info_ok_response(runtime_grpc_server, sample_task_model_id):
     info_service: ServicePackage = ServicePackageFactory().get_service_package(
         ServicePackageFactory.ServiceType.INFO,
     )
@@ -1033,11 +1033,33 @@ def test_model_info_ok_response(runtime_grpc_server, sample_task_model_id):
     for model in model_info_response.models:
         # Assert name and id exist
         assert model.name and model.module_id
+        # Assert metadata module_name matches expected
         if model.name == sample_task_model_id:
-            assert model.module_name == "SampleModule"
+            assert model.module_metadata.get("name") == "SampleModule"
             found_sample_task = True
 
     assert found_sample_task, "Unable to find sample_task model in models list"
+
+
+def test_single_model_info_ok_response(runtime_grpc_server, sample_task_model_id):
+    info_service: ServicePackage = ServicePackageFactory().get_service_package(
+        ServicePackageFactory.ServiceType.INFO,
+    )
+
+    model_info_stub = info_service.stub_class(runtime_grpc_server.make_local_channel())
+
+    model_request = ModelInfoRequest(model_ids=[sample_task_model_id])
+    model_info_response: ModelInfoResponse = ModelInfoResponse.from_proto(
+        model_info_stub.GetModelsInfo(model_request.to_proto())
+    )
+
+    # Assert only one model was returned
+    assert len(model_info_response.models) == 1
+    model = model_info_response.models[0]
+    # Assert name and id exist
+    assert model.name and model.module_id
+    # Assert metadata module_name matches expected
+    assert model.module_metadata.get("name") == "SampleModule"
 
 
 #### Health Probe tests ####


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR allows for end-users to get information about the currently loaded models. This includes things like the model name, path, version, and size. The information is gathered from the `runtime.ModelManager.loaded_models` values.

**Special notes for your reviewer**:
This endpoint will be useful for the RemoteModel work and for any thin-client to discover models.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
