### PR TITLE
:zap: Share thread pool across servers

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -111,6 +111,9 @@ runtime:
     # Number of threads to make available for load jobs (null => all)
     load_threads: null
 
+    # Number of threads for both the http and grpc server to share for servicing requests
+    server_thread_pool_size: 100
+
     # TLS configs
     tls:
         server:
@@ -123,8 +126,6 @@ runtime:
     grpc:
         enabled: true
         port: 8085
-        # Number of workers with which we will run the gRPC server
-        server_thread_pool_size: 5
         # gRPC Server shutdown grace period
         # the server shuts down immediately when stopped,
         # and all RPCs active at the end of the grace period are aborted

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -69,9 +69,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
 
         # Initialize basic server
         self.server = grpc.server(
-            futures.ThreadPoolExecutor(
-                max_workers=self.config.runtime.grpc.server_thread_pool_size
-            ),
+            thread_pool=self.thread_pool,
             interceptors=(PROMETHEUS_METRICS_INTERCEPTOR,),
             options=(self.config.runtime.grpc.options or {}).items(),
         )
@@ -231,9 +229,9 @@ class RuntimeGRPCServer(RuntimeServerBase):
 
         log.info(
             "<RUN10001001I>",
-            "Caikit Runtime is serving on port: %s with thread pool size: %s",
+            "Caikit Runtime is serving grpc on port: %s with thread pool size: %s",
             self.port,
-            self.config.runtime.grpc.server_thread_pool_size,
+            self.thread_pool._max_workers,
         )
 
         if blocking:

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Base class with common functionality across all caikit servers"""
-
 # Standard
+from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 import abc
 import signal
@@ -27,12 +27,38 @@ import alog
 
 # Local
 from caikit.config import get_config
+from caikit.core.exceptions import error_handler
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import caikit
 
 log = alog.use_channel("SERVR-BASE")
+error = error_handler.get(log)
+
+
+class ServerThreadPool:
+    """Simple wrapper for all servers to share a single thread pool"""
+
+    @staticmethod
+    def _build_pool() -> ThreadPoolExecutor:
+        config = caikit.get_config()
+        # Leave in backwards compatibility for the old runtime.grpc.server_thread_pool_size
+        # parameter, which many users may have deployed with.
+        if pool_size := config.runtime.grpc.get("server_thread_pool_size", None):
+            log.info("Using legacy runtime.grpc.server_thread_pool_size configuration")
+        else:
+            pool_size = config.runtime.server_thread_pool_size
+
+        error.type_check("<RUN92632238E>", int, pool_size=pool_size)
+
+        pool = ThreadPoolExecutor(
+            max_workers=pool_size, thread_name_prefix="caikit_runtime"
+        )
+
+        return pool
+
+    pool = _build_pool()
 
 
 class RuntimeServerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
@@ -82,6 +108,8 @@ class RuntimeServerBase(abc.ABC):  # pylint: disable=too-many-instance-attribute
         ] = ServicePackageFactory.get_service_package(
             ServicePackageFactory.ServiceType.INFO,
         )
+
+        self.thread_pool: ThreadPoolExecutor = ServerThreadPool.pool
 
     @classmethod
     def _start_metrics_server(cls) -> None:

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -1075,3 +1075,9 @@ def test_train_other_task(client, runtime_http_server):
     json_response = json.loads(response.content.decode(response.default_encoding))
     assert response.status_code == 200, json_response
     assert json_response["farewell"] == "goodbye: world 64 times"
+
+
+def test_http_and_grpc_server_share_threadpool(
+    runtime_http_server, runtime_grpc_server
+):
+    assert runtime_grpc_server.thread_pool is runtime_http_server.thread_pool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR both:
- Explicitly sets a thread pool to use for `loop.run_in_executor` calls in the http server that map sync model code to async event loops. This is required to give users the flexibility to specify large thread pools for IO bound models (e.g. remote shims)
- Shares a single thread pool across all servers, so that an http and grpc server running in the same process would share the same access to threads

The new `runtime.server_thread_pool_size` config option sets the size of this pool, but if the older `runtime.grpc.server_thread_pool_size` is set, it will take precedence.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
