### PR TITLE
:bug: ensure correct shutdown handlers called

### DIFF
--- a/caikit/runtime/__main__.py
+++ b/caikit/runtime/__main__.py
@@ -1,6 +1,16 @@
-# Standard
-import signal
-
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # First Party
 import alog
 
@@ -13,25 +23,6 @@ log = alog.use_channel("RUNTIME-MAIN")
 def main():
     _grpc_server = None
     _http_server = None
-
-    def interrupt(signal_, _stack_frame):
-        log.info(
-            "<RUN87630120I>",
-            "Caikit Runtime received interrupt signal %s, shutting down",
-            signal_,
-        )
-        if _grpc_server:
-            _grpc_server.stop()
-        if _http_server:
-            _http_server.stop()
-
-    # NOTE: signal function can only be called from main thread of the main
-    # interpreter. If this function is called from a thread (like in tests)
-    # then signal handler cannot be used. Thus, we will only have real
-    # termination_handler when this is called from the __main__.
-
-    signal.signal(signal.SIGINT, interrupt)
-    signal.signal(signal.SIGTERM, interrupt)
 
     #####################
     # Start the servers

--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # Standard
 from concurrent import futures
 from typing import Optional, Union
@@ -244,6 +243,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
             grace_period_seconds (Union[float, int]): Grace period for service shutdown.
                 Defaults to application config
         """
+        log.info("Shutting down gRPC server")
         if grace_period_seconds is None:
             grace_period_seconds = (
                 self.config.runtime.grpc.server_shutdown_grace_period_seconds
@@ -296,7 +296,6 @@ class RuntimeGRPCServer(RuntimeServerBase):
 
 def main(blocking: bool = True):
     server = RuntimeGRPCServer()
-    server._intercept_interrupt_signal()
     server.start(blocking)
 
 

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -277,7 +277,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
             grace_period_seconds (Union[float, int]): Grace period for service shutdown.
                 Defaults to application config
         """
-        log.info(f"Shutting down http server {self._uvicorn_server_thread}")
+        log.info("Shutting down http server")
 
         if (
             self._uvicorn_server_thread is not None

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -170,7 +170,7 @@ class RuntimeServerBase(abc.ABC):  # pylint: disable=too-many-instance-attribute
         try:
             signal.signal(sig, nested_interrupt_builder(handler, signal.getsignal(sig)))
         except ValueError:
-            log.warning(
+            log.info(
                 "Unable to register signal handler. Server was started from a non-main thread."
             )
 

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -69,10 +69,9 @@ def http_session_scoped_open_port():
     return _open_port()
 
 
-def _open_port():
+def _open_port(start=8888):
     # TODO: This has obvious problems where the port returned for use by a test is not immediately
     # put into use, so parallel tests could attempt to use the same port.
-    start = 8888
     end = start + 1000
     host = "localhost"
     for port in range(start, end):

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -405,7 +405,9 @@ class ModuleSubproc:
             self.proc.kill()
 
     def __enter__(self):
-        self.proc = subprocess.Popen(self._cmd, env=self._env)
+        self.proc = subprocess.Popen(
+            self._cmd, env=self._env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         self._kill_timer.start()
         return self.proc
 

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -78,6 +78,7 @@ from tests.core.helpers import *
 from tests.fixtures import Fixtures
 from tests.runtime.conftest import (
     ModuleSubproc,
+    _open_port,
     register_trained_model,
     runtime_grpc_test_server,
 )
@@ -1354,8 +1355,8 @@ def test_grpc_sever_shutdown_with_model_poll(open_port):
 def test_all_signal_handlers_invoked(open_port):
     """Test that a SIGINT successfully shuts down all running servers"""
 
-    # whoops, need 2 ports. Cannot use `_open_port()` again because it'll return the same port
-    other_open_port = open_port + 37
+    # whoops, need 2 ports. Try to find another open one that isn't the one we already have
+    other_open_port = _open_port(start=open_port + 1)
 
     with tempfile.TemporaryDirectory() as workdir:
         server_proc = ModuleSubproc(

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -17,14 +17,11 @@
 # Standard
 from dataclasses import dataclass
 from unittest import mock
-from unittest.mock import patch
 import json
-import os
 import signal
 import tempfile
 import threading
 import time
-import uuid
 
 # Third Party
 from google.protobuf.descriptor_pool import DescriptorPool
@@ -35,6 +32,7 @@ from grpc_reflection.v1alpha.proto_reflection_descriptor_database import (
 )
 import grpc
 import pytest
+import requests
 import tls_test_tools
 
 # First Party
@@ -42,17 +40,20 @@ import alog
 
 # Local
 from caikit import get_config
-from caikit.core import MODEL_MANAGER
 from caikit.core.data_model.producer import ProducerId
 from caikit.interfaces.runtime.data_model import (
     RuntimeInfoRequest,
     RuntimeInfoResponse,
     TrainingInfoRequest,
     TrainingJob,
-    TrainingStatus,
     TrainingStatusResponse,
 )
-from caikit.runtime import get_inference_request, get_train_params, get_train_request
+from caikit.runtime import (
+    get_inference_request,
+    get_train_params,
+    get_train_request,
+    http_server,
+)
 from caikit.runtime.grpc_server import RuntimeGRPCServer
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.protobufs import (
@@ -1348,6 +1349,63 @@ def test_grpc_sever_shutdown_with_model_poll(open_port):
 
         # Make sure the process was not killed
         assert not server_proc.killed
+
+
+def test_all_signal_handlers_invoked(open_port):
+    """Test that a SIGINT successfully shuts down all running servers"""
+
+    # whoops, need 2 ports. Cannot use `_open_port()` again because it'll return the same port
+    other_open_port = open_port + 37
+
+    with tempfile.TemporaryDirectory() as workdir:
+        server_proc = ModuleSubproc(
+            "caikit.runtime",
+            kill_timeout=30.0,
+            RUNTIME_GRPC_PORT=str(open_port),
+            RUNTIME_HTTP_PORT=str(other_open_port),
+            RUNTIME_LOCAL_MODELS_DIR=workdir,
+            RUNTIME_LAZY_LOAD_LOCAL_MODELS="true",
+            RUNTIME_LAZY_LOAD_POLL_PERIOD_SECONDS="0.1",
+            RUNTIME_METRICS_ENABLED="false",
+            RUNTIME_GRPC_ENABLED="true",
+            RUNTIME_HTTP_ENABLED="true",
+        )
+        with server_proc as proc:
+            # Wait for the grpc server to be up:
+            _assert_connection(
+                grpc.insecure_channel(f"localhost:{open_port}"), max_failures=500
+            )
+            print("grpc server is up!")
+
+            # Then wait for the http server as well:
+            http_failures = 0
+            while http_failures < 500:
+                try:
+                    resp = requests.get(
+                        f"http://localhost:{other_open_port}{http_server.HEALTH_ENDPOINT}",
+                        timeout=0.1,
+                    )
+                    resp.raise_for_status()
+                    break
+                except (
+                    requests.HTTPError,
+                    requests.ConnectionError,
+                    requests.ConnectTimeout,
+                ) as e:
+                    print("http server still waiting:", e)
+                    http_failures += 1
+            print("http server up!")
+
+            # Signal the server to shut down
+            proc.send_signal(signal.SIGINT)
+
+        # Make sure the process was not killed
+        assert not server_proc.killed
+        # Check the logs (barf) to see if both grpc and http signal handlers called
+        # communicate returns (stdout, stderr) in bytes
+        logs = server_proc.proc.communicate()[1].decode("utf-8")
+        assert "Shutting down gRPC server" in logs
+        assert "Shutting down http server" in logs
 
 
 def test_construct_with_options(open_port, sample_train_service, sample_int_file):

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -1369,13 +1369,13 @@ def test_all_signal_handlers_invoked(open_port):
             RUNTIME_METRICS_ENABLED="false",
             RUNTIME_GRPC_ENABLED="true",
             RUNTIME_HTTP_ENABLED="true",
+            LOG_LEVEL="info",
         )
         with server_proc as proc:
             # Wait for the grpc server to be up:
             _assert_connection(
                 grpc.insecure_channel(f"localhost:{open_port}"), max_failures=500
             )
-            print("grpc server is up!")
 
             # Then wait for the http server as well:
             http_failures = 0
@@ -1391,10 +1391,10 @@ def test_all_signal_handlers_invoked(open_port):
                     requests.HTTPError,
                     requests.ConnectionError,
                     requests.ConnectTimeout,
-                ) as e:
-                    print("http server still waiting:", e)
+                ):
                     http_failures += 1
-            print("http server up!")
+                    # tiny sleep because a connection refused won't hit the full `0.1`s timeout
+                    time.sleep(0.001)
 
             # Signal the server to shut down
             proc.send_signal(signal.SIGINT)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This was a tangent I went on today. This PR both:
- allows multiple servers to cleanly register shutdown handlers for interruption
- Updates the http server hackery to ensure that previously registered signal handlers are actually invoked when uvicorn overrides all the signal handlers

**Special notes for your reviewer**:

This is a bit of a departure from how we were explicitly setting signal handlers in `main` methods before, but this allows us to easily handle uvicorn's insistence on overriding all signal handlers.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
