### PR TITLE
Uvicorn config 609

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -153,6 +153,9 @@ runtime:
         server_shutdown_grace_period_seconds: 5
         # Timeout for health probe to receive a response
         probe_timeout: 0.01
+        # Additional uvicorn server configuration
+        # CITE: https://github.com/encode/uvicorn/blob/master/uvicorn/config.py#L188
+        server_config: {}
 
     # Configuration for the metrics server
     metrics:


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #609 

This PR makes it possible to set arbitrary `uvicorn` server config overrides as long as they don't overlap with the ones that `caikit` manages explicitly.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
