### PR TITLE
ModelFetchOutOfAsyncio

### DIFF
--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -503,9 +503,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                         self.global_predict_servicer.predict_model,
                         model_id=model_id,
                         request_name=rpc.request.name,
-                        inference_func_name=model.get_inference_signature(
-                            output_streaming=False, input_streaming=False, task=rpc.task
-                        ).method_name,
+                        input_streaming=False,
+                        output_streaming=False,
+                        task=rpc.task,
                         aborter=aborter,
                         **request_params,
                     )
@@ -577,9 +577,9 @@ class RuntimeHTTPServer(RuntimeServerBase):
                             self.global_predict_servicer.predict_model(
                                 model_id=model_id,
                                 request_name=rpc.request.name,
-                                inference_func_name=model.get_inference_signature(
-                                    output_streaming=True, input_streaming=False
-                                ).method_name,
+                                input_streaming=False,
+                                output_streaming=True,
+                                task=rpc.task,
                                 aborter=aborter,
                                 **request_params,
                             ),

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -487,9 +487,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 log.debug4(
                     "Sending request %s to model id %s", request_params, model_id
                 )
-                model = self.global_predict_servicer._model_manager.retrieve_model(
-                    model_id
-                )
 
                 aborter_context = (
                     HttpRequestAborter(context)
@@ -560,9 +557,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     model_id = self._get_model_id(request)
                     log.debug4(
                         "Sending request %s to model id %s", request_params, model_id
-                    )
-                    model = self.global_predict_servicer._model_manager.retrieve_model(
-                        model_id
                     )
 
                     aborter_context = (

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -16,7 +16,7 @@ from typing import Iterator
 from unittest.mock import MagicMock, patch
 
 # Local
-from caikit.core.data_model import ProducerId
+from caikit.core.data_model import DataStream, ProducerId
 from caikit.runtime.service_factory import get_inference_request
 from sample_lib.data_model.sample import GeoSpatialTask
 from sample_lib.modules import MultiTaskModule, SecondTask
@@ -132,6 +132,24 @@ def test_global_predict_works_for_unary_rpcs(
         caikit_rpc=sample_task_unary_rpc,
     )
     assert response == HAPPY_PATH_RESPONSE
+
+
+def test_global_predict_explicit_inference_function(
+    sample_inference_service,
+    sample_predict_servicer,
+    sample_task_model_id,
+    sample_task_unary_rpc,
+):
+    """Calling predict_model can explicitly select the inference function"""
+    predict_class = get_inference_request(SampleTask)
+    request_name = sample_task_unary_rpc.request.name
+    response = sample_predict_servicer.predict_model(
+        request_name=request_name,
+        model_id=sample_task_model_id,
+        inference_func_name="run_stream_out",
+        sample_input=HAPPY_PATH_INPUT_DM,
+    )
+    assert isinstance(response, DataStream)
 
 
 def test_global_predict_works_on_bidirectional_streaming_rpcs(


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the model lookup for inference signature into predict_model

The `retrieve_model` operation can potentially be expensive. With the `async` HTTP server, doing this outside of the `run_in_executor` call meant that the work to look up the model (and potentially wait for it to finish loading) was blocking the event loop. That work to fetch the model was _only_ being done so that the inference function could be deduced, so moving that logic inside of `predict_model` allows the lookup (and load) logic to not block the event loop.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
