### PR TITLE
re-expose http server

### DIFF
--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -249,6 +249,7 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 overlapping_tls_config,
             )
             config_kwargs = {
+                "host": "0.0.0.0",
                 "port": self.port,
                 "log_level": None,
                 "log_config": None,


### PR DESCRIPTION
Refactors (#610) removed the host argument to the uvicorn config, causing the http server to only bind to 127.0.0.1.
