### PR TITLE
Add Finder/Initializer options to Runtime Model Manager load

### DIFF
--- a/caikit/runtime/model_management/model_loader.py
+++ b/caikit/runtime/model_management/model_loader.py
@@ -103,8 +103,8 @@ class ModelLoader:
         model_path: str,
         model_id: str,
         model_type: str,
-        finder: Union[None, str, ModelFinderBase],
-        initializer: Union[None, str, ModelInitializerBase],
+        finder: Optional[Union[str, ModelFinderBase]] = None,
+        initializer: Optional[Union[str, ModelInitializerBase]] = None,
     ) -> LoadedModel:
         try:
             log.info("<RUN89711114I>", "Loading model '%s'", model_id)

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -15,7 +15,7 @@
 from collections import Counter as DictCounter
 from functools import partial
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 import atexit
 import gc
 import os
@@ -33,6 +33,7 @@ import alog
 from caikit import get_config
 from caikit.core import ModuleBase
 from caikit.core.exceptions import error_handler
+from caikit.core.model_management import ModelFinderBase, ModelInitializerBase
 from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.model_management.model_loader import ModelLoader
 from caikit.runtime.model_management.model_sizer import ModelSizer
@@ -173,6 +174,8 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
         model_type: str,
         wait: bool = True,
         retries: Optional[int] = None,
+        finder: Optional[Union[str, ModelFinderBase]] = None,
+        initializer: Optional[Union[str, ModelInitializerBase]] = None,
     ) -> LoadedModel:
         """Load a model using model_path (in Cloud Object Storage) & give it a model ID
         Args:
@@ -208,6 +211,8 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
                             model_type,
                             fail_callback=partial(self.unload_model, model_id),
                             retries=retries,
+                            finder=finder,
+                            initializer=initializer,
                         )
                     except Exception as ex:
                         self.__increment_load_model_exception_count_metric(model_type)

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -1081,7 +1081,7 @@ class NoModelFinder(ModelFinderBase):
     def __init__(self, config: Config, instance_name: str):
         super().__init__(config, instance_name)
 
-    def find_model(self, model_path: str, **kwargs) -> ModuleConfig | None:
+    def find_model(self, model_path: str, **kwargs) -> ModuleConfig:
         raise FileNotFoundError(f"Unable to find model {model_path}")
 
 
@@ -1103,7 +1103,7 @@ def test_load_model_custom_finder():
 class CustomParamInitializer(LocalModelInitializer):
     name = "CUSTOMPARAM"
 
-    def init(self, model_config: ModuleConfig, **kwargs) -> ModuleBase | None:
+    def init(self, model_config: ModuleConfig, **kwargs) -> ModuleBase:
         module = super().init(model_config, **kwargs)
         module.custom_param = True
         return module


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds two optional parameters `finder` and `initializer` to the `RuntimeModelManager.load_model` function. This allows end users to customize which finder/initializer is being used similarly to the core `MODEL_MANAGER.load` function.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
