### PR TITLE
Fix Initialization bug in MultiModelInitializer

### DIFF
--- a/caikit/core/model_management/multi_model_initializer.py
+++ b/caikit/core/model_management/multi_model_initializer.py
@@ -86,7 +86,7 @@ class MultiModelInitializer(ModelInitializerBase):
         )
         error.value_check(
             "<COR54613971E>",
-            self._instance_name not in config_initializers,
+            self._instance_name not in initializer_priority,
             "Cannot include self in multi initializer priority",
         )
         model_manager = config.model_manager or caikit.core.MODEL_MANAGER

--- a/tests/core/model_management/test_multi_model_initializer.py
+++ b/tests/core/model_management/test_multi_model_initializer.py
@@ -24,6 +24,7 @@ import pytest
 import aconfig
 
 # Local
+from caikit.config import get_config
 from caikit.core.model_management.factories import model_initializer_factory
 from caikit.core.model_management.local_model_finder import LocalModelFinder
 from caikit.core.model_management.model_initializer_base import ModelInitializerBase
@@ -58,6 +59,10 @@ def construct_mm_initializer(multi_model_config, config_override={}):
     config_override = config_override or {
         "model_management": {
             "initializers": {
+                "default": {
+                    "type": "MULTI",
+                    "config": multi_model_config,
+                },
                 "local": {
                     "type": "LOCAL",
                 },
@@ -67,11 +72,9 @@ def construct_mm_initializer(multi_model_config, config_override={}):
     }
 
     with temp_config(config_override, "merge"):
-        model_config = {
-            "type": "MULTI",
-            "config": multi_model_config,
-        }
-        yield model_initializer_factory.construct(model_config, "instance_name")
+        yield model_initializer_factory.construct(
+            get_config().model_management.initializers.default, "default"
+        )
 
 
 ## Tests #######################################################################


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes a small bug which would break the MultiModelInitializer when loading from config. This also updates the test cases to hopefully avoid this issue in the future

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
