### PR TITLE
Model info loaded 653

### DIFF
--- a/caikit/interfaces/runtime/data_model/info.py
+++ b/caikit/interfaces/runtime/data_model/info.py
@@ -62,6 +62,7 @@ class ModelInfo(DataObjectBase):
     name: Annotated[str, FieldNumber(2)]
     size: Annotated[int, FieldNumber(3)]
     metadata: Annotated[Dict[str, str], FieldNumber(4)]
+    loaded: Annotated[bool, FieldNumber(7)]
 
     # Module Information
     module_id: Annotated[str, FieldNumber(5)]

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -118,6 +118,9 @@ class LoadedModel:  # pylint: disable=too-many-instance-attributes
         self.wait()
         return self._model
 
+    def loaded(self) -> bool:
+        return bool(self._model or self._caikit_model_future.done())
+
     def wait(self):
         if self._model is None:
             try:

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -107,6 +107,7 @@ class InfoServicer:
                     name=name,
                     size=loaded_module.size(),
                     metadata=model_instance.public_model_info,
+                    loaded=loaded_module.loaded(),
                     module_id=model_instance.MODULE_ID,
                     module_metadata=model_instance.module_metadata,
                 )

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -1035,6 +1035,8 @@ def test_all_model_info_ok_response(runtime_grpc_server, sample_task_model_id):
     for model in model_info_response.models:
         # Assert name and id exist
         assert model.name and model.module_id
+        # Assert loaded is set (could be True or False)
+        assert model.loaded is not None
         # Assert metadata module_name matches expected
         if model.name == sample_task_model_id:
             assert model.module_metadata.get("name") == "SampleModule"


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #653 

This PR adds a new `loaded` field to the output of each model info block behind the `InfoServicer`'s model info endpoint/rpc

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
