### PR TITLE
UUID asssertion on terminal 656

### DIFF
--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -320,9 +320,13 @@ class LocalModelTrainer(ModelTrainerBase):
 
         # Lock the global futures dict and add it to the dict
         with self._futures_lock:
-            assert (
-                model_future.id not in self._futures
-            ), f"UUID collision for model future {model_future.id}"
+            if current_future := self._futures.get(model_future.id):
+                error.value_check(
+                    "<COR35431427E>",
+                    current_future.get_info().status.is_terminal,
+                    "UUID collision for model future {}",
+                    model_future.id,
+                )
             self._futures[model_future.id] = model_future
 
         # Return the future

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -295,14 +295,15 @@ class LocalModelTrainer(ModelTrainerBase):
 
         # If there's an external ID, make sure it's not currently running before
         # launching the job
-        if external_training_id:
-            if current_future := self._futures.get(external_training_id):
-                error.value_check(
-                    "<COR79850561E>",
-                    current_future.get_info().status.is_terminal,
-                    "Cannot restart training {} that is currently running",
-                    external_training_id,
-                )
+        if external_training_id and (
+            current_future := self._futures.get(external_training_id)
+        ):
+            error.value_check(
+                "<COR79850561E>",
+                current_future.get_info().status.is_terminal,
+                "Cannot restart training {} that is currently running",
+                external_training_id,
+            )
 
         # Create the new future
         model_future = self.LocalModelFuture(

--- a/caikit/core/model_management/local_model_trainer.py
+++ b/caikit/core/model_management/local_model_trainer.py
@@ -293,6 +293,17 @@ class LocalModelTrainer(ModelTrainerBase):
             log.debug2("Subprocess wrapped models: %s", wrapped_models.keys())
             kwargs.update(wrapped_models)
 
+        # If there's an external ID, make sure it's not currently running before
+        # launching the job
+        if external_training_id:
+            if current_future := self._futures.get(external_training_id):
+                error.value_check(
+                    "<COR79850561E>",
+                    current_future.get_info().status.is_terminal,
+                    "Cannot restart training {} that is currently running",
+                    external_training_id,
+                )
+
         # Create the new future
         model_future = self.LocalModelFuture(
             self._instance_name,


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #656 

This PR handles the edge case where an external job manager attempts to retry a training job against a running instance of the `LocalModelTrainer` using the same ID as a previously failed run.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
