### PR TITLE
FlakeyTestsRandomPorts: Use internal open-port function

### DIFF
--- a/caikit/runtime/grpc_server.py
+++ b/caikit/runtime/grpc_server.py
@@ -240,7 +240,7 @@ class RuntimeGRPCServer(RuntimeServerBase):
         if blocking:
             self.server.wait_for_termination(None)
 
-    def stop(self, grace_period_seconds: Union[float, int] = None):
+    def stop(self, grace_period_seconds: Optional[Union[float, int]] = None):
         """Stop the server, with an optional grace period.
 
         Args:

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -86,14 +86,16 @@ def _open_port(start=8888):
     # TODO: This has obvious problems where the port returned for use by a test is not immediately
     # put into use, so parallel tests could attempt to use the same port.
     end = start + 1000
-    host = "localhost"
     for port in range(start, end):
-        with socket.socket() as soc:
-            # soc.connect_ex returns 0 if connection is successful,
-            # indicating the port is in use
-            if soc.connect_ex((host, port)) != 0:
-                # So a non-zero code should mean the port is not currently in use
-                return port
+        if port_is_open(port):
+            return port
+
+
+def port_is_open(port: int) -> bool:
+    with socket.socket() as soc:
+        # soc.connect_ex returns 0 if connection is successful,
+        # indicating the port is in use
+        return soc.connect_ex(("localhost", port)) != 0
 
 
 @pytest.fixture(scope="session")

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -50,6 +50,11 @@ from tests.fixtures import Fixtures
 log = alog.use_channel("TEST-CONFTEST")
 
 
+def get_open_port():
+    """Non-fixture function to get an open port"""
+    return _open_port()
+
+
 @pytest.fixture
 def open_port():
     """Get an open port on localhost

--- a/tests/runtime/test_caikit_health_probe.py
+++ b/tests/runtime/test_caikit_health_probe.py
@@ -40,7 +40,11 @@ import alog
 # Local
 from caikit import get_config
 from tests.conftest import temp_config
-from tests.runtime.conftest import runtime_grpc_test_server, runtime_http_test_server
+from tests.runtime.conftest import (
+    get_open_port,
+    runtime_grpc_test_server,
+    runtime_http_test_server,
+)
 from tests.runtime.http_server.test_http_server import generate_tls_configs
 
 ## Helpers #####################################################################
@@ -153,8 +157,8 @@ def test_readiness_probe(test_config: ProbeTestConfig):
     """Test all of the different ways that the servers could be running"""
     with alog.ContextLog(log.info, "---LOG CONFIG: %s---", test_config):
         # Get ports for both servers
-        http_port = tls_test_tools.open_port()
-        grpc_port = tls_test_tools.open_port()
+        http_port = get_open_port()
+        grpc_port = get_open_port()
 
         # Set up SAN lists if not putting "localhost" in
         server_sans, client_sans = None, None

--- a/tests/runtime/test_caikit_health_probe.py
+++ b/tests/runtime/test_caikit_health_probe.py
@@ -25,13 +25,13 @@ from dataclasses import dataclass
 from enum import Enum
 from unittest import mock
 import os
+import random
 import shlex
 import subprocess
 import sys
 
 # Third Party
 import pytest
-import tls_test_tools
 
 # First Party
 from caikit_health_probe import __main__ as caikit_health_probe
@@ -41,7 +41,7 @@ import alog
 from caikit import get_config
 from tests.conftest import temp_config
 from tests.runtime.conftest import (
-    get_open_port,
+    port_is_open,
     runtime_grpc_test_server,
     runtime_http_test_server,
 )
@@ -157,8 +157,8 @@ def test_readiness_probe(test_config: ProbeTestConfig):
     """Test all of the different ways that the servers could be running"""
     with alog.ContextLog(log.info, "---LOG CONFIG: %s---", test_config):
         # Get ports for both servers
-        http_port = get_open_port()
-        grpc_port = get_open_port()
+        http_port = get_random_open_port()
+        grpc_port = get_random_open_port()
 
         # Set up SAN lists if not putting "localhost" in
         server_sans, client_sans = None, None

--- a/tests/runtime/test_caikit_health_probe.py
+++ b/tests/runtime/test_caikit_health_probe.py
@@ -41,7 +41,7 @@ import alog
 from caikit import get_config
 from tests.conftest import temp_config
 from tests.runtime.conftest import (
-    port_is_open,
+    get_open_port,
     runtime_grpc_test_server,
     runtime_http_test_server,
 )
@@ -106,13 +106,6 @@ class ProbeTestConfig:
     should_become_healthy: bool = True
 
 
-def get_random_open_port():
-    port = random.randint(9000, 50000)
-    while not port_is_open(port):
-        port = random.randint(9000, 50000)
-    return port
-
-
 ## Tests #######################################################################
 
 
@@ -156,7 +149,7 @@ def test_liveness_probe(proc_identifier, expected):
         # Start the process
         env = os.environ.copy()
         env.update(
-            RUNTIME_GRPC_PORT=str(get_random_open_port()),
+            RUNTIME_GRPC_PORT=str(get_open_port()),
             RUNTIME_GRPC_ENABLED="true",
             RUNTIME_HTTP_ENABLED="false",
             RUNTIME_METRICS_ENABLED="false",
@@ -222,8 +215,8 @@ def test_readiness_probe(test_config: ProbeTestConfig):
     """Test all of the different ways that the servers could be running"""
     with alog.ContextLog(log.info, "---LOG CONFIG: %s---", test_config):
         # Get ports for both servers
-        http_port = get_random_open_port()
-        grpc_port = get_random_open_port()
+        http_port = get_open_port()
+        grpc_port = get_open_port()
 
         # Set up SAN lists if not putting "localhost" in
         server_sans, client_sans = None, None

--- a/tests/runtime/test_grpc_server.py
+++ b/tests/runtime/test_grpc_server.py
@@ -82,7 +82,7 @@ from tests.runtime.conftest import (
     KeyPair,
     ModuleSubproc,
     TLSConfig,
-    _open_port,
+    get_open_port,
     register_trained_model,
     runtime_grpc_test_server,
 )
@@ -1409,7 +1409,7 @@ def test_all_signal_handlers_invoked(open_port):
     """Test that a SIGINT successfully shuts down all running servers"""
 
     # whoops, need 2 ports. Try to find another open one that isn't the one we already have
-    other_open_port = _open_port(start=open_port + 1)
+    other_open_port = get_open_port()
 
     with tempfile.TemporaryDirectory() as workdir:
         server_proc = ModuleSubproc(


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #646 

Second attempt to solve the flakey port collision tests!

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
