### PR TITLE
Proactive load toggle 661

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -97,6 +97,11 @@ runtime:
     # the server
     wait_for_initial_model_loads: true
 
+    # If true, on each local_models_dir sync (include the initial one), any new
+    # models will start loading. If false, new models will be ignored and will
+    # only lazy load on inference.
+    load_new_local_models: true
+
     # If enabled, the models in local_models_dir will be periodically sync'ed
     # with the in-memory models. New models that are not in-memory that are
     # found in local_models_dir will be loaded and existing models that were


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #661 

This PR adds the `runtime.load_new_local_models` config option which can disable loading new models during synchronization with `local_models_dir`.

**Special notes for your reviewer**:

When loading new local models is disabled, the model info endpoints are not guaranteed to be consistent across replicas of `caikit.runtime` running behind a loadbalancer (e.g. k8s `Deployment` / `Service`) since loading only happens on inference calls which are distributed across the replicas.

**If applicable**:
- [x] this PR contains documentation (comment in `config.yml`)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
