### PR TITLE
Add support for ReturnOptions, GeneratedTokens and InputTokens

### DIFF
--- a/caikit/interfaces/nlp/data_model/classification.py
+++ b/caikit/interfaces/nlp/data_model/classification.py
@@ -148,8 +148,8 @@ class ClassifiedGeneratedTextResult(DataObjectBase):
     warnings: Annotated[
         Optional[List[InputWarning]], FieldNumber(9)
     ]  # Warning to user in the event of input errors
-    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(30)]
-    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(40)]
+    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(11)]
+    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(12)]
 
 
 @dataobject(package=NLP_PACKAGE)

--- a/caikit/interfaces/nlp/data_model/classification.py
+++ b/caikit/interfaces/nlp/data_model/classification.py
@@ -148,8 +148,8 @@ class ClassifiedGeneratedTextResult(DataObjectBase):
     warnings: Annotated[
         Optional[List[InputWarning]], FieldNumber(9)
     ]  # Warning to user in the event of input errors
-    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(11)]
-    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(12)]
+    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(10)]
+    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(11)]
 
 
 @dataobject(package=NLP_PACKAGE)

--- a/caikit/interfaces/nlp/data_model/classification.py
+++ b/caikit/interfaces/nlp/data_model/classification.py
@@ -27,7 +27,7 @@ import alog
 # Local
 from ....core import DataObjectBase, dataobject
 from .package import NLP_PACKAGE
-from .text_generation import FinishReason
+from .text_generation import FinishReason, GeneratedToken
 
 log = alog.use_channel("DATAM")
 
@@ -148,6 +148,8 @@ class ClassifiedGeneratedTextResult(DataObjectBase):
     warnings: Annotated[
         Optional[List[InputWarning]], FieldNumber(9)
     ]  # Warning to user in the event of input errors
+    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(30)]
+    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(40)]
 
 
 @dataobject(package=NLP_PACKAGE)

--- a/caikit/interfaces/nlp/data_model/text_generation.py
+++ b/caikit/interfaces/nlp/data_model/text_generation.py
@@ -45,6 +45,12 @@ class FinishReason(Enum):
 
 
 @dataobject(package=NLP_PACKAGE)
+class GeneratedToken(DataObjectBase):
+    text: Annotated[str, FieldNumber(1)]
+    logprob: Annotated[Optional[float], FieldNumber(3)]
+
+
+@dataobject(package=NLP_PACKAGE)
 class GeneratedTextResult(DataObjectBase):
     generated_text: Annotated[str, FieldNumber(1)]
     generated_tokens: Annotated[int, FieldNumber(2)]
@@ -52,12 +58,8 @@ class GeneratedTextResult(DataObjectBase):
     producer_id: Annotated[ProducerId, FieldNumber(4)]
     input_token_count: Annotated[int, FieldNumber(5)]
     seed: Annotated[Optional[np.uint64], FieldNumber(6)]
-
-
-@dataobject(package=NLP_PACKAGE)
-class GeneratedToken(DataObjectBase):
-    text: Annotated[str, FieldNumber(1)]
-    logprob: Annotated[Optional[float], FieldNumber(3)]
+    tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(7)]
+    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(8)]
 
 
 @dataobject(package=NLP_PACKAGE)
@@ -74,3 +76,4 @@ class GeneratedTextStreamResult(DataObjectBase):
     tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(2)]
     details: Annotated[Optional[TokenStreamDetails], FieldNumber(3)]
     producer_id: Annotated[ProducerId, FieldNumber(4)]
+    input_tokens: Annotated[Optional[List[GeneratedToken]], FieldNumber(5)]


### PR DESCRIPTION
Add support for ReturnOptions, GeneratedTokens and InputTokens

As part of caikit there are some parameters that are hard-coded to default values in code.
In the TGIS implementation, users can set these options and get the appropriate response. 
The parameters in questions are part of the `ResponseOptions` proto found [here](https://github.com/IBM/text-generation-inference/blob/main/proto/generation.proto). 

This PR updates the data-model so that the return from inference server can be part of the result if the appropriate parameter is set in caikit FastAPI endpoint.