### PR TITLE
Datetime task params 670

### DIFF
--- a/caikit/core/data_model/base.py
+++ b/caikit/core/data_model/base.py
@@ -511,6 +511,13 @@ class DataBase(metaclass=_DataBaseMetaClass):
         defined in the interface definitions.  If not, an exception will be thrown at runtime.
     """
 
+    # Class constant used to identify protobuf types that are handled with
+    # special logic in the to/from proto conversions
+    PROTO_CONVERSION_SPECIAL_TYPES = [
+        timestamp.TIMESTAMP_PROTOBUF_NAME,
+        json_dict.STRUCT_PROTOBUF_NAME,
+    ]
+
     @dataclass
     class OneofFieldVal:
         """Helper struct that backends can use to return information about

--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -16,6 +16,7 @@ This module holds the Pydantic wrapping required by the REST server,
 capable of converting to and from Pydantic models to our DataObjects.
 """
 # Standard
+from datetime import date, datetime, time, timedelta
 from typing import Dict, List, Type, Union, get_args, get_type_hints
 import base64
 import enum
@@ -144,7 +145,18 @@ def _get_pydantic_type(field_type: type) -> type:
         return float
     if field_type == bytes:
         return Annotated[bytes, BeforeValidator(_from_base64)]
-    if field_type in (int, float, bool, str, dict, type(None)):
+    if field_type in (
+        int,
+        float,
+        bool,
+        str,
+        dict,
+        type(None),
+        date,
+        datetime,
+        time,
+        timedelta,
+    ):
         return field_type
     if isinstance(field_type, type) and issubclass(field_type, enum.Enum):
         return field_type

--- a/tests/runtime/http_server/test_pydantic_wrapper.py
+++ b/tests/runtime/http_server/test_pydantic_wrapper.py
@@ -16,6 +16,7 @@ Tests for the pydantic wrapping for REST server
 """
 # Standard
 from typing import Dict, List, Union, get_args
+import datetime
 import enum
 
 # Third Party
@@ -138,6 +139,10 @@ def test_pydantic_to_dataobject_datastream_file():
         (List[Annotated[str, "blah"]], List[str]),
         (Dict[str, int], Dict[str, int]),
         (Dict[Annotated[str, "blah"], int], Dict[str, int]),
+        (datetime.datetime, datetime.datetime),
+        (datetime.date, datetime.date),
+        (datetime.time, datetime.time),
+        (datetime.timedelta, datetime.timedelta),
     ],
 )
 def test_get_pydantic_type(input, output):


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #670 

This PR allows the out-of-the-box protobuf classes for `Timestamp` and `Struct` to be used in `task` signatures and served via `caikit.runtime`. Previously, the logic in `servicer_util` would have rejected them because of their lack of a corresponding data model class, but these two are handled as special cases in `DataBase`, so that check is not correct.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
