### PR TITLE
Consolidated dump 685

### DIFF
--- a/caikit/core/data_model/dataobject.py
+++ b/caikit/core/data_model/dataobject.py
@@ -253,6 +253,11 @@ def dataobject(*args, **kwargs) -> Callable[[_DataObjectBaseT], _DataObjectBaseT
     return decorator
 
 
+def get_generated_proto_classes():
+    """Provide get access to the auto-gen classes"""
+    return _AUTO_GEN_PROTO_CLASSES
+
+
 def render_dataobject_protos(interfaces_dir: str):
     """Write out protobufs files for all proto classes generated from dataobjects
     to the target interfaces directory

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -13,51 +13,66 @@
 # limitations under the License.
 
 # Standard
+from typing import Dict, List, Optional, Union
 import argparse
 import json
 import os
+import shutil
 import sys
 
+# Third Party
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pb2, descriptor_pool
+
 # First Party
+from py_to_proto import descriptor_to_file
+from py_to_proto.utils import safe_add_fd_to_pool
 import alog
 
 # Local
+from ..config.config import get_config
 from ..core.data_model import render_dataobject_protos
-from .service_factory import ServicePackageFactory
-from caikit.config.config import get_config
+from ..core.data_model.dataobject import _AUTO_GEN_PROTO_CLASSES
+from ..core.exceptions import error_handler
+from .service_factory import ServicePackage, ServicePackageFactory
 import caikit
 
 log = alog.use_channel("RUNTIME-DUMP-SVC")
+error = error_handler.get(log)
+
+## Public ######################################################################
 
 
-def dump_grpc_services(output_dir: str, write_modules_file):
-    """Utility for rendering the all generated interfaces to proto files"""
-    inf_enabled = get_config().runtime.service_generation.enable_inference
-    train_enabled = get_config().runtime.service_generation.enable_training
+def dump_grpc_services(
+    output_dir: str,
+    write_modules_file: bool,
+    consolidate: bool = False,
+):
+    """Utility for rendering the all generated interfaces to proto files
 
-    if inf_enabled:
-        inf_svc = ServicePackageFactory.get_service_package(
-            ServicePackageFactory.ServiceType.INFERENCE,
-            write_modules_file=write_modules_file,
+    Args:
+        output_dir (str): The directory where the generated services should be
+            placed
+        write_modules_file (bool): Whether or not to write out the compatibility
+            file for supported modules
+        consolidate (bool): Whether or not to consolidate the generated protos
+            by package
+    """
+    service_packages = _get_grpc_service_packages()
+    if not consolidate:
+        log.info(
+            "Dumping raw service and data model protos without package consolidation"
         )
-    if train_enabled:
-        train_svc = ServicePackageFactory.get_service_package(
-            ServicePackageFactory.ServiceType.TRAINING,
-        )
-        train_mgt_svc = ServicePackageFactory.get_service_package(
-            ServicePackageFactory.ServiceType.TRAINING_MANAGEMENT,
-        )
-    info_svc = ServicePackageFactory.get_service_package(
-        ServicePackageFactory.ServiceType.INFO,
-    )
-
-    render_dataobject_protos(output_dir)
-    if inf_enabled:
-        inf_svc.service.write_proto_file(output_dir)
-    if train_enabled:
-        train_svc.service.write_proto_file(output_dir)
-        train_mgt_svc.service.write_proto_file(output_dir)
-    info_svc.service.write_proto_file(output_dir)
+        render_dataobject_protos(output_dir)
+        for svc_pkg in service_packages:
+            svc_pkg.service.write_proto_file(output_dir)
+    else:
+        log.info("Dumping service and data model protos with package consolidation")
+        all_descriptors = [
+            proto_cls.DESCRIPTOR for proto_cls in _AUTO_GEN_PROTO_CLASSES
+        ] + [pkg.descriptor for pkg in service_packages]
+        fd_protos = _get_proto_file_descriptors(all_descriptors)
+        _dump_consolidated_protos(fd_protos, output_dir)
 
 
 def dump_http_services(output_dir: str):
@@ -100,19 +115,176 @@ def dump_http_services(output_dir: str):
             handle.write(json.dumps(response.json(), indent=2))
 
 
+## Implementation Details ######################################################
+
+
+def _try_find_file_by_name(
+    name: str,
+    pool: descriptor_pool.DescriptorPool,
+) -> Optional[_descriptor.FileDescriptor]:
+    """Attempt to find a file descriptor by name and return None if not found"""
+    try:
+        return pool.FindFileByName(name)
+    except KeyError:
+        return None
+
+
+def _recursive_safe_add_to_pool(
+    fd_proto: descriptor_pb2.FileDescriptorProto,
+    fd_protos_to_add: Dict[str, descriptor_pb2.FileDescriptorProto],
+    dpool: descriptor_pool.DescriptorPool,
+) -> _descriptor.FileDescriptor:
+    """Recursively add the given file descriptor and all of its dependencies to
+    the pool and handle double-add conflicts.
+    """
+    for dep_name in fd_proto.dependency:
+        if not _try_find_file_by_name(dep_name, dpool):
+            # Look in the pile of protos that need to be added
+            if pending_fd_proto := fd_protos_to_add.get(dep_name.rsplit(".", 1)[0]):
+                _recursive_safe_add_to_pool(pending_fd_proto, fd_protos_to_add, dpool)
+            # Look in the default pool
+            elif dflt_fd := _try_find_file_by_name(dep_name, descriptor_pool.Default()):
+                dep_fd_proto = descriptor_pb2.FileDescriptorProto()
+                dflt_fd.CopyToProto(dep_fd_proto)
+                _recursive_safe_add_to_pool(dep_fd_proto, fd_protos_to_add, dpool)
+            else:
+                error(
+                    "<COR25660790E>",
+                    ValueError(
+                        f"Can't add {fd_proto.name}: dependency {dep_name} not found"
+                    ),
+                )
+    safe_add_fd_to_pool(fd_proto, dpool)
+    return dpool.FindFileByName(fd_proto.name)
+
+
+def _get_proto_file_descriptors(
+    object_descriptors: List[
+        Union[
+            _descriptor.Descriptor,
+            _descriptor.EnumDescriptor,
+            _descriptor.ServiceDescriptor,
+        ]
+    ],
+) -> Dict[str, descriptor_pb2.FileDescriptorProto]:
+    """Get a dict mapping package names to consolidated DescriptorProto objects
+    holding all auto-generated messages and enums in the given package.
+    """
+
+    # Deduplicate object descriptors
+    dup_candidates = {}
+    for obj_desc in object_descriptors:
+        dup_candidates.setdefault(f"{type(obj_desc)}/{obj_desc.full_name}", {})[
+            id(obj_desc)
+        ] = obj_desc
+    dups = {obj_desc for obj_desc in dup_candidates.values() if len(obj_desc) > 1}
+    error.value_check(
+        "<COR01018988E>",
+        not dups,
+        "Found conflicting definitions of protobuf objects: %s",
+        [dup.name for dup in dups],
+    )
+    object_descriptors = sorted(
+        [list(obj_descs.values())[0] for obj_descs in dup_candidates.values()],
+        key=lambda obj_desc: obj_desc.name,
+    )
+
+    # Collect the auto-gen protos by package
+    file_descriptor_protos = {}
+    for obj_desc in object_descriptors:
+        file_descriptor_proto = file_descriptor_protos.setdefault(
+            obj_desc.file.package, descriptor_pb2.FileDescriptorProto()
+        )
+        obj_desc.file.CopyToProto(file_descriptor_proto)
+
+    # Update the file names to be package-level
+    for pkg_name, pkg_fd in file_descriptor_protos.items():
+        pkg_fd.name = f"{pkg_name}.proto"
+
+    # Update the dependencies for each package-level file descriptor proto
+    for pkg_name, pkg_fd in file_descriptor_protos.items():
+
+        # Figure out the remaining set of deps for this file as all external
+        # deps and all generated package-level files that aren't this one
+        pkg_deps = set()
+        for candidate_pkg_name in file_descriptor_protos:
+            if candidate_pkg_name != pkg_name and any(
+                dep.startswith(candidate_pkg_name) for dep in pkg_fd.dependency
+            ):
+                pkg_deps.add(candidate_pkg_name)
+
+        # Clear out existing object-level file deps
+        for existing_dep in list(pkg_fd.dependency):
+            if any(
+                existing_dep.startswith(candidate_pkg_name)
+                for candidate_pkg_name in file_descriptor_protos
+            ):
+                pkg_fd.dependency.remove(existing_dep)
+
+        # Add package-level dependency files
+        pkg_fd.dependency.extend(sorted([f"{pkg}.proto" for pkg in pkg_deps]))
+
+    return file_descriptor_protos
+
+
+def _dump_consolidated_protos(
+    fd_protos: Dict[str, descriptor_pb2.FileDescriptorProto],
+    interfaces_dir: str,
+):
+    """Dump all protobuf interfaces consolidated by package"""
+    temp_dpool = descriptor_pool.DescriptorPool()
+    for fd_proto in fd_protos.values():
+        fd = _recursive_safe_add_to_pool(fd_proto, fd_protos, temp_dpool)
+        target_file = os.path.join(interfaces_dir, fd.name)
+        with open(target_file, "w") as handle:
+            handle.write(descriptor_to_file(fd))
+
+
+def _get_grpc_service_packages(
+    write_modules_file: bool = False,
+) -> List[ServicePackage]:
+    """Get all enabled grpc service packages"""
+    inf_enabled = get_config().runtime.service_generation.enable_inference
+    train_enabled = get_config().runtime.service_generation.enable_training
+    svc_descriptors = []
+    if inf_enabled:
+        svc_descriptors.append(
+            ServicePackageFactory.get_service_package(
+                ServicePackageFactory.ServiceType.INFERENCE,
+                write_modules_file=write_modules_file,
+            )
+        )
+    if train_enabled:
+        svc_descriptors.append(
+            ServicePackageFactory.get_service_package(
+                ServicePackageFactory.ServiceType.TRAINING,
+            )
+        )
+        svc_descriptors.append(
+            ServicePackageFactory.get_service_package(
+                ServicePackageFactory.ServiceType.TRAINING_MANAGEMENT,
+            )
+        )
+    svc_descriptors.append(
+        ServicePackageFactory.get_service_package(
+            ServicePackageFactory.ServiceType.INFO,
+        )
+    )
+    return svc_descriptors
+
+
+## Main ########################################################################
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Dump grpc and http services for inference and train"
     )
-
-    # Add an argument for the output_dir
     parser.add_argument(
         "output_dir",
         type=str,
         help="Path to the output directory for service(s)' proto files",
     )
-
-    # Add an argument for write_modules_json
     parser.add_argument(
         "-j",
         "--write-modules-json",
@@ -120,17 +292,37 @@ def main():
         action="store_true",
         help="Wether the modules.json (of supported modules) should be output?",
     )
-
+    parser.add_argument(
+        "-c",
+        "--clean",
+        default=False,
+        action="store_true",
+        help="Clean out existing content in output dir",
+    )
+    parser.add_argument(
+        "-p",
+        "--consolidate-packages",
+        default=False,
+        action="store_true",
+        help="Consolidate protobufs by package",
+    )
     args = parser.parse_args()
-
-    out_dir = args.output_dir
-    write_modules_json = args.write_modules_json
 
     # Set up logging so users can set LOG_LEVEL etc
     caikit.core.toolkit.logging.configure()
 
+    # Make sure the output dir exists and optionally clean it out
+    out_dir = args.output_dir
+    if args.clean and os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+
     if get_config().runtime.grpc.enabled:
-        dump_grpc_services(out_dir, write_modules_json)
+        dump_grpc_services(
+            out_dir,
+            args.write_modules_json,
+            args.consolidate_packages,
+        )
     if get_config().runtime.http.enabled:
         dump_http_services(out_dir)
 

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -32,7 +32,7 @@ import alog
 # Local
 from ..config.config import get_config
 from ..core.data_model import render_dataobject_protos
-from ..core.data_model.dataobject import _AUTO_GEN_PROTO_CLASSES
+from ..core.data_model.dataobject import get_generated_proto_classes
 from ..core.exceptions import error_handler
 from .service_factory import ServicePackage, ServicePackageFactory
 import caikit
@@ -71,7 +71,7 @@ def dump_grpc_services(
         os.makedirs(output_dir, exist_ok=True)
         all_descriptors = [
             proto_cls.DESCRIPTOR
-            for proto_cls in _AUTO_GEN_PROTO_CLASSES
+            for proto_cls in get_generated_proto_classes()
             if proto_cls.DESCRIPTOR.file.pool is descriptor_pool.Default()
         ] + [pkg.descriptor for pkg in service_packages]
         fd_protos = _get_proto_file_descriptors(all_descriptors)

--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -179,7 +179,7 @@ def _get_proto_file_descriptors(
         dup_candidates.setdefault(f"{type(obj_desc)}/{obj_desc.full_name}", {})[
             id(obj_desc)
         ] = obj_desc
-    dups = {obj_desc for obj_desc in dup_candidates.values() if len(obj_desc) > 1}
+    dups = [obj_desc for obj_desc in dup_candidates.values() if len(obj_desc) > 1]
     error.value_check(
         "<COR01018988E>",
         not dups,

--- a/examples/sample_lib/README.md
+++ b/examples/sample_lib/README.md
@@ -50,17 +50,17 @@ The python client sends in requests to all 3 services that were mentioned above,
 
 ## Interact using terminal
 
-You can also use `grpcurl` (for gRPC requests) or `curl` (for http requests) to send in commands one-by-one to all the 3 services that were mentioned above. 
+You can also use `grpcurl` (for gRPC requests) or `curl` (for http requests) to send in commands one-by-one to all the 3 services that were mentioned above.
 
 Note: `http` does not currently support `training management` APIs.
 ### To train a model
 
 #### Using gRPC
 
-In order to train a model via gRPC, we will use `grpcurl` and point the import-path to `protos` dir, then call one of the Train rpc's available in the `SampleLibTrainingService` (see `protos/samplelibtrainingservice.proto` file generated above for all Train rpcs):
+In order to train a model via gRPC, we will use `grpcurl` and point the import-path to `protos` dir, then call one of the Train rpc's available in the `SampleLibTrainingService` (see `protos/caikit_sample_lib.proto` file generated above for all Train rpcs):
 
 ```shell
-grpcurl -plaintext -import-path protos/ -proto samplelibtrainingservice.proto -d '{"model_name": "my_model", "parameters": {"training_data": {"file": {"filename": "protos/sample.json"}}}}' localhost:8085 caikit_sample_lib.SampleLibTrainingService/SampleTaskSampleModuleTrain
+grpcurl -plaintext -import-path protos/ -proto caikit_sample_lib.proto -d '{"model_name": "my_model", "parameters": {"training_data": {"file": {"filename": "protos/sample.json"}}}}' localhost:8085 caikit_sample_lib.SampleLibTrainingService/SampleTaskSampleModuleTrain
 ```
 
 You should receive a response similar to the below:
@@ -85,7 +85,7 @@ Docs coming soon...
 With a `trainingId`, you can get a training status via gRPC. Replace the command below with your `trainingId`.
 
 ```shell
-grpcurl -plaintext -import-path protos/ -proto trainingmanagement.proto -d '{"training_id": "<training_id>"}' localhost:8085 caikit.runtime.training.TrainingManagement/GetTrainingStatus
+grpcurl -plaintext -import-path protos/ -proto caikit.runtime.training.proto -d '{"training_id": "<training_id>"}' localhost:8085 caikit.runtime.training.TrainingManagement/GetTrainingStatus
 ```
 
 You should get a response like this:
@@ -112,7 +112,7 @@ You are now ready to call inference via either gRPC or REST.
 
 You can also use the gRPC Server to call inference on this model by running:
 ```shell
-grpcurl -plaintext -import-path protos/ -proto samplelibservice.proto -d '{"sample_input": {"name": "world"}}' -H 'mm-model-id: my_model' localhost:8085 caikit_sample_lib.SampleLibService/SampleTaskPredict
+grpcurl -plaintext -import-path protos/ -proto caikit_sample_lib.proto -d '{"sample_input": {"name": "world"}}' -H 'mm-model-id: my_model' localhost:8085 caikit_sample_lib.SampleLibService/SampleTaskPredict
 ```
 
 You should receive a successful response back with a response body:
@@ -145,7 +145,7 @@ You should receive a 200 response back with a response body:
 
 ## Interact using a combination of pb2s and DataModels
 
-Install `protoc`, 
+Install `protoc`,
 
 ```shell
 pip3 install grpcio-tools

--- a/examples/sample_lib/start_runtime_with_sample_lib.py
+++ b/examples/sample_lib/start_runtime_with_sample_lib.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
             # dump protos
             shutil.rmtree("protos", ignore_errors=True)
             if get_config().runtime.grpc.enabled:
-                dump_grpc_services("protos", True)
+                dump_grpc_services("protos", True, True)
             if get_config().runtime.http.enabled:
                 dump_http_services("protos")
 

--- a/examples/sample_lib/start_runtime_with_sample_lib.py
+++ b/examples/sample_lib/start_runtime_with_sample_lib.py
@@ -39,10 +39,6 @@ if __name__ == "__main__":
                 os.path.join(Path(__file__).parent.parent.parent, "tests/fixtures"),
             )
 
-            # Import sample_lib to register modules for service dump
-            # Local
-            import sample_lib
-
             # Dump protos
             shutil.rmtree("protos", ignore_errors=True)
             if get_config().runtime.grpc.enabled:

--- a/examples/sample_lib/start_runtime_with_sample_lib.py
+++ b/examples/sample_lib/start_runtime_with_sample_lib.py
@@ -39,7 +39,11 @@ if __name__ == "__main__":
                 os.path.join(Path(__file__).parent.parent.parent, "tests/fixtures"),
             )
 
-            # dump protos
+            # Import sample_lib to register modules for service dump
+            # Local
+            import sample_lib
+
+            # Dump protos
             shutil.rmtree("protos", ignore_errors=True)
             if get_config().runtime.grpc.enabled:
                 dump_grpc_services("protos", True, True)

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -498,13 +498,13 @@ def _check_http_server_readiness(server, config_overrides: Dict[str, Dict]):
 ## TLS Helpers #####################################################################
 
 
-@dataobject
+@dataobject(package="caikit_data_model.test")
 class KeyPair(DataObjectBase):
     cert: str
     key: str
 
 
-@dataobject
+@dataobject(package="caikit_data_model.test")
 class TLSConfig(DataObjectBase):
     server: KeyPair
     client: KeyPair

--- a/tests/runtime/test_dump_services.py
+++ b/tests/runtime/test_dump_services.py
@@ -71,18 +71,23 @@ def test_dump_grpc_services_consolidated():
         #   do an exact check due to the global descriptor pool and other tests
         #   that modify it.
         dumped_files = os.listdir(workdir)
-        assert all(
-            fname in dumped_files
-            for fname in {
-                "caikit_runtime_SampleLib.proto",
-                "caikit_runtime_info.proto",
-                "caikit_runtime_training.proto",
-                "caikit_data_model_common.proto",
-                "caikit_data_model_common_runtime.proto",
-                "caikit_data_model_runtime.proto",
-                "caikit_data_model_sample_lib.proto",
-            }
-        )
+        exp_fnames = {
+            "caikit_runtime_SampleLib.proto",
+            "caikit_runtime_info.proto",
+            "caikit_runtime_training.proto",
+            "caikit_data_model_common.proto",
+            "caikit_data_model_common_runtime.proto",
+            "caikit_data_model_runtime.proto",
+            "caikit_data_model_sample_lib.proto",
+        }
+        assert all(fname in dumped_files for fname in exp_fnames)
+
+        # Spot check one of the files that we know will have specific contents
+        with open(os.path.join(workdir, "caikit_runtime_info.proto")) as handle:
+            content = handle.read()
+            assert "package caikit.runtime.info;" in content
+            assert "service InfoService" in content
+            assert "rpc GetRuntimeInfo" in content
 
 
 def test_dump_http_services_dir_exists():

--- a/tests/runtime/test_dump_services.py
+++ b/tests/runtime/test_dump_services.py
@@ -58,6 +58,30 @@ def test_dump_grpc_services_dir_does_not_exist():
         shutil.rmtree(fake_dir)
 
 
+@pytest.mark.skipif(
+    PROTOBUF_VERSION < 4 and ARM_ARCH, reason="protobuf 3 serialization bug"
+)
+def test_dump_grpc_services_consolidated():
+    with tempfile.TemporaryDirectory() as workdir:
+        dump_grpc_services(workdir, False, consolidate=True)
+        assert os.path.exists(workdir)
+        # Make sure the file names match the expected names for caikit plus
+        # sample_lib
+        # NOTE: This will break if any of these package names change which is
+        #   an indication that an API breaking change has happened!
+        assert set(os.listdir(workdir)) == {
+            "caikit.runtime.SampleLib.proto",
+            "caikit.runtime.info.proto",
+            "caikit.runtime.training.proto",
+            "caikit_data_model.common.proto",
+            "caikit_data_model.common.runtime.proto",
+            "caikit_data_model.runtime.proto",
+            "caikit_data_model.sample_lib.proto",
+            # NOTE: Added in conftest.py
+            "caikit_data_model.test.proto",
+        }
+
+
 def test_dump_http_services_dir_exists():
     with tempfile.TemporaryDirectory() as workdir:
         dump_http_services(workdir)

--- a/tests/runtime/test_dump_services.py
+++ b/tests/runtime/test_dump_services.py
@@ -67,19 +67,22 @@ def test_dump_grpc_services_consolidated():
         assert os.path.exists(workdir)
         # Make sure the file names match the expected names for caikit plus
         # sample_lib
-        # NOTE: This will break if any of these package names change which is
-        #   an indication that an API breaking change has happened!
-        assert set(os.listdir(workdir)) == {
-            "caikit_runtime_SampleLib.proto",
-            "caikit_runtime_info.proto",
-            "caikit_runtime_training.proto",
-            "caikit_data_model_common.proto",
-            "caikit_data_model_common_runtime.proto",
-            "caikit_data_model_runtime.proto",
-            "caikit_data_model_sample_lib.proto",
-            # NOTE: Added in conftest.py
-            "caikit_data_model_test.proto",
-        }
+        # NOTE: Dumping services dumps _all_ data model objects, so we cannot
+        #   do an exact check due to the global descriptor pool and other tests
+        #   that modify it.
+        dumped_files = os.listdir(workdir)
+        assert all(
+            fname in dumped_files
+            for fname in {
+                "caikit_runtime_SampleLib.proto",
+                "caikit_runtime_info.proto",
+                "caikit_runtime_training.proto",
+                "caikit_data_model_common.proto",
+                "caikit_data_model_common_runtime.proto",
+                "caikit_data_model_runtime.proto",
+                "caikit_data_model_sample_lib.proto",
+            }
+        )
 
 
 def test_dump_http_services_dir_exists():

--- a/tests/runtime/test_dump_services.py
+++ b/tests/runtime/test_dump_services.py
@@ -70,15 +70,15 @@ def test_dump_grpc_services_consolidated():
         # NOTE: This will break if any of these package names change which is
         #   an indication that an API breaking change has happened!
         assert set(os.listdir(workdir)) == {
-            "caikit.runtime.SampleLib.proto",
-            "caikit.runtime.info.proto",
-            "caikit.runtime.training.proto",
-            "caikit_data_model.common.proto",
-            "caikit_data_model.common.runtime.proto",
-            "caikit_data_model.runtime.proto",
-            "caikit_data_model.sample_lib.proto",
+            "caikit_runtime_SampleLib.proto",
+            "caikit_runtime_info.proto",
+            "caikit_runtime_training.proto",
+            "caikit_data_model_common.proto",
+            "caikit_data_model_common_runtime.proto",
+            "caikit_data_model_runtime.proto",
+            "caikit_data_model_sample_lib.proto",
             # NOTE: Added in conftest.py
-            "caikit_data_model.test.proto",
+            "caikit_data_model_test.proto",
         }
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #685 

This PR adds two new options to `caikit.runtime.dump_services`:

* `-c | --clean`: Clean out existing content in output dir
* `-p | --consolidate-packages`: Consolidate protobufs by package

The second is the primary point of this PR. It _drastically_ reduces the clutter in the dumped services directory and aligns more closely with standard protobuf practices to consolidate multiple objects into individual `.proto` files that are scoped by the `package`.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
