### PR TITLE
LimitHttpConcurrency

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -162,7 +162,13 @@ runtime:
         probe_timeout: 0.01
         # Additional uvicorn server configuration
         # CITE: https://github.com/encode/uvicorn/blob/master/uvicorn/config.py#L188
-        server_config: {}
+        server_config:
+            # By default, if not set here, the concurrency limit will be set to
+            # 2x the size of the server thread pool. If set to 0 or null, no
+            # limiting will be used. If set to a positive value, the explicit
+            # value will be used.
+            limit_concurrency: -1
+            # Other configuration values can be added with merged overrides
 
     # Configuration for the metrics server
     metrics:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds new logic to set the `limit_concurrency` config value for the HTTP server. The default behavior is to set it to 2x the server thread pool size. This is indicated by using a sentinel value of `-1` by default (any negative number). If set to `0`, no concurrency limiting will be applied. If set to a positive number, that number will be used directly.

**Special notes for your reviewer**:

This _could_ be considered a breaking change since it changes the default behavior to enable concurrency limiting

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
