### PR TITLE
Add alog protocol support

### DIFF
--- a/caikit/core/exceptions/error_handler.py
+++ b/caikit/core/exceptions/error_handler.py
@@ -19,9 +19,12 @@
 # Standard
 from collections.abc import Iterable
 from types import GeneratorType
-from typing import TYPE_CHECKING, Dict, NoReturn, Optional, Type
+from typing import TYPE_CHECKING, Dict, NoReturn, Optional, Type, Union
 import os
 import typing
+
+# First Party
+from alog.protocols import LoggerProtocol
 
 # Local
 from caikit.config import get_config
@@ -38,7 +41,7 @@ if TYPE_CHECKING:
 _error_handlers: Dict[str, "ErrorHandler"] = {}
 
 
-def get(log_chan: "Logger"):
+def get(log_chan: Union["Logger", LoggerProtocol]):
     """Get an error handler associated with a given alog log channel.  The same error handler will
     be returned if this function is called repeatedly with the same log channel.
 
@@ -61,7 +64,7 @@ class ErrorHandler:
     the `.log_raise` method.
     """
 
-    def __init__(self, log_chan: "Logger"):
+    def __init__(self, log_chan: Union["Logger", LoggerProtocol]):
         """Create a new error handler that provides reusable error checking and automatic logging.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers=[
 ]
 dependencies = [
     "alchemy-config>=1.1.1,<2.0.0",
-    "alchemy-logging>=1.0.4,<2.0.0",
+    "alchemy-logging>=1.3.2,<2.0.0",
     "anytree>=2.7.0,<3.0",
     "docstring-parser>=0.14.1,<0.17.0",
     "grpcio>=1.35.0,<2.0,!=1.55.0",


### PR DESCRIPTION
**What this PR does / why we need it**:
closes https://github.com/caikit/caikit/issues/695

Update typing for `error_handler` to include [`LoggerProtocol`](https://github.com/IBM/alchemy-logging/blob/2bc2d8127ac878c55d5faa6c65c8fba31c4f1cf9/src/python/alog/protocols.py#L135). 

`LoggerProtocol` represents the interface for the stdlib `logger` class. `ALogLoggerProtocol`, which inherits from `LoggerProtocol`, will also be an acceptable argument to `error_handler.get()` and `ErrorHandler`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
