### PR TITLE
Add exception catching for everything in train.py

### DIFF
--- a/caikit/runtime/train.py
+++ b/caikit/runtime/train.py
@@ -158,7 +158,7 @@ def main() -> int:
         for library in args.library or []:
             log.info("<COR88091092I>", "Importing library %s", library)
             importlib.import_module(library)
-    except Exception as e:
+    except Exception:
         message = "Unable to import module {}".format(library)
         log.warning(
             {
@@ -193,7 +193,7 @@ def main() -> int:
             "Unable to find module {} to train",
             args.module,
         )
-    except (ValueError, Exception) as e:
+    except (ValueError, Exception):
         message = "Unable to find module {} to train".format(args.module)
         log.warning(
             {
@@ -262,7 +262,7 @@ def main() -> int:
                 "stack_trace": traceback.format_exc(),
             }
         )
-    except Exception as e:
+    except Exception:
         message = "Exception encountered when attempting to parse input parameters"
         log.warning(
             {
@@ -292,7 +292,7 @@ def main() -> int:
                     log.error(err)
                 write_termination_log("Training finished unsuccessfully")
                 return INTERNAL_ERROR_EXIT_CODE
-    except MemoryError as e:
+    except MemoryError:
         message = "OOM error during training"
         log.warning(
             {
@@ -303,7 +303,7 @@ def main() -> int:
         )
         write_termination_log(message)
         exit(INTERNAL_ERROR_EXIT_CODE)
-    except Exception as e:
+    except Exception:
         message = "Unhandled exception during training"
         log.warning(
             {

--- a/caikit/runtime/train.py
+++ b/caikit/runtime/train.py
@@ -155,7 +155,8 @@ def main() -> int:
                 "log_code": "<COR39662029E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(USER_ERROR_EXIT_CODE)
@@ -172,7 +173,8 @@ def main() -> int:
                 "log_code": "<COR17776539E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(USER_ERROR_EXIT_CODE)
@@ -269,7 +271,8 @@ def main() -> int:
                 "log_code": "<COR65474760E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
     except Exception:
         message = "Exception encountered when attempting to parse input parameters"
@@ -278,7 +281,8 @@ def main() -> int:
                 "log_code": "<COR17776549E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(USER_ERROR_EXIT_CODE)
@@ -308,7 +312,8 @@ def main() -> int:
                 "log_code": "<COR04280062E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(INTERNAL_ERROR_EXIT_CODE)
@@ -319,7 +324,8 @@ def main() -> int:
                 "log_code": "<COR04280062E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(INTERNAL_ERROR_EXIT_CODE)

--- a/caikit/runtime/train.py
+++ b/caikit/runtime/train.py
@@ -51,6 +51,7 @@ INTERNAL_ERROR_EXIT_CODE = 200
 
 class ArgumentParserError(Exception):
     """Custom exception class for ArgumentParser errors."""
+
     pass
 
 

--- a/caikit/runtime/train.py
+++ b/caikit/runtime/train.py
@@ -207,7 +207,8 @@ def main() -> int:
                 "log_code": "<COR17476539E>",
                 "message": message,
                 "stack_trace": traceback.format_exc,
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(USER_ERROR_EXIT_CODE)
@@ -256,7 +257,8 @@ def main() -> int:
                 "log_code": "<COR65834760E>",
                 "message": message,
                 "stack_trace": traceback.format_exc(),
-            }
+            },
+            exc_info=True,
         )
         write_termination_log(message)
         exit(USER_ERROR_EXIT_CODE)

--- a/caikit/runtime/train.py
+++ b/caikit/runtime/train.py
@@ -142,7 +142,7 @@ def main() -> int:
             train_kwargs["trainer"] = args.trainer
 
     except Exception as e:
-        message = "Exception raised during training. This may be a problem with your input: {e}"
+        message = f"Exception raised during training. This may be a problem with your input: {e}"
         log.warning(
             {
                 "log_code": "<COR39662029E>",
@@ -254,7 +254,7 @@ def main() -> int:
         write_termination_log(message)
         exit(USER_ERROR_EXIT_CODE)
     except ValueError as e:
-        message = "Invalid value for one or more input parameters: {e}"
+        message = f"Invalid value for one or more input parameters: {e}"
         log.warning(
             {
                 "log_code": "<COR65474760E>",

--- a/caikit/runtime/train.py
+++ b/caikit/runtime/train.py
@@ -24,6 +24,7 @@ import importlib
 import json
 import os
 import sys
+import traceback
 
 # Third Party
 from google.protobuf import json_format
@@ -44,10 +45,36 @@ from .utils.servicer_util import build_caikit_library_request_dict
 log = alog.use_channel("TRAIN")
 error = error_handler.get(log)
 
+USER_ERROR_EXIT_CODE = 1
+INTERNAL_ERROR_EXIT_CODE = 200
+
+
+class ArgumentParserError(Exception):
+    """Custom exception class for ArgumentParser errors."""
+    pass
+
+
+class TrainArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        """Error handler that raises an exception instead of exiting."""
+        raise ArgumentParserError(f"{self.prog}: error: {message}")
+
+
+def write_termination_log(text: str, log_file="/dev/termination-log"):
+    try:
+        f = open(log_file, "a")
+        f.write(text)
+        f.close()
+    except Exception as e:
+        log.warning(
+            "<COR96300323W>",
+            "Unable to write termination log due to error {}".format(e),
+        )
+
 
 def main() -> int:
     """Main entrypoint for running training jobs"""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = TrainArgumentParser(description=__doc__)
 
     # Required Args
     parser.add_argument(
@@ -95,44 +122,86 @@ def main() -> int:
         default=False,
         help="Include the training ID in the save path",
     )
+    parser.add_argument(
+        "--termination-log-file",
+        "-f",
+        action="store_true",
+        default="/dev/termination-log",
+        help="Location of where to write a termination error message",
+    )
 
-    args = parser.parse_args()
-    config_logging()
+    try:
+        args = parser.parse_args()
+        config_logging()
 
-    # Initialize top-level kwargs
-    train_kwargs = {
-        "save_path": args.save_path,
-        "save_with_id": args.save_with_id,
-        "model_name": args.model_name,
-    }
-    if args.trainer is not None:
-        train_kwargs["trainer"] = args.trainer
+        # Initialize top-level kwargs
+        train_kwargs = {
+            "save_path": args.save_path,
+            "save_with_id": args.save_with_id,
+            "model_name": args.model_name,
+        }
+        if args.trainer is not None:
+            train_kwargs["trainer"] = args.trainer
+
+    except Exception as e:
+        message = "Exception raised during training. This may be a problem with your input: {}".format(
+            e
+        )
+        log.warning(
+            {
+                "log_code": "<COR39662029E>",
+                "message": message,
+                "stacK_trace": traceback.format_exc(),
+            }
+        )
+        write_termination_log(message)
+        exit(USER_ERROR_EXIT_CODE)
 
     # Import libraries to register modules
-    for library in args.library or []:
-        log.info("<COR88091092I>", "Importing library %s", library)
-        importlib.import_module(library)
+    try:
+        for library in args.library or []:
+            log.info("<COR88091092I>", "Importing library %s", library)
+            importlib.import_module(library)
+    except Exception as e:
+        message = "Unable to import module {}".format(library)
+        log.error("<COR17776539E>", message)
+        write_termination_log(message)
+        exit(USER_ERROR_EXIT_CODE)
 
     # Try to import the root library of the provided module. It's ok if this
     # fails since the module may be a UID
-    mod_root_lib = args.module.split(".")[0]
     try:
+        mod_root_lib = args.module.split(".")[0]
         importlib.import_module(mod_root_lib)
-    except ImportError:
+    except (ImportError, ValueError):
         log.debug("Unable to import module root lib: %s", mod_root_lib)
 
     # Figure out the module to train
-    mod_reg = module_registry()
-    mod_pkg_to_mod = {
-        f"{mod.__module__}.{mod.__name__}": mod for mod in mod_reg.values()
-    }
-    module: Type[ModuleBase] = mod_reg.get(args.module, mod_pkg_to_mod.get(args.module))
-    error.value_check(
-        "<COR03876205E>",
-        module is not None,
-        "Unable to find module {} to train",
-        args.module,
-    )
+    try:
+        mod_reg = module_registry()
+        mod_pkg_to_mod = {
+            f"{mod.__module__}.{mod.__name__}": mod for mod in mod_reg.values()
+        }
+        module: Type[ModuleBase] = mod_reg.get(
+            args.module, mod_pkg_to_mod.get(args.module)
+        )
+        error.value_check(
+            "<COR03876205E>",
+            module is not None,
+            "Unable to find module {} to train",
+            args.module,
+        )
+    except Exception as e:
+        message = "Unable to import module {}".format(args.module)
+        log.warning(
+            {
+                "log_code": "<COR17776539E>",
+                "message": message,
+                "stack_trace": traceback.format_exc,
+            }
+        )
+        write_termination_log(message)
+        exit(USER_ERROR_EXIT_CODE)
 
     # Read training kwargs
     try:
@@ -142,56 +211,110 @@ def main() -> int:
         else:
             training_kwargs = json.loads(args.training_kwargs)
     except json.decoder.JSONDecodeError:
-        log.error(
-            "<COR65834760E>",
-            "--training-kwargs must be valid json or point to a valid json file",
+        message = "training-kwargs must be valid json or point to a valid json file"
+        log.warning(
+            {
+                "log_code": "<COR65834760E>",
+                "message": message,
+                "stack_trace": traceback.format_exc(),
+            }
         )
-        raise
+        write_termination_log(message)
+        exit(USER_ERROR_EXIT_CODE)
+    except Exception as e:
+        message = "Exception encountered when attempting to parse input parameters"
+        log.warning(
+            {
+                "log_code": "<COR17776549E>",
+                "message": message,
+                "stack_trace": traceback.format_exc(),
+            }
+        )
+        write_termination_log(message)
+        exit(USER_ERROR_EXIT_CODE)
 
-    # Convert datatypes to match the training API
-    training_service = ServicePackageFactory.get_service_package(
-        ServicePackageFactory.ServiceType.TRAINING,
-    )
-    train_rpcs = [
-        rpc
-        for rpc in training_service.caikit_rpcs.values()
-        if rpc.module_list == [module]
-    ]
-    error.value_check(
-        "<COR11978965E>",
-        len(train_rpcs) == 1,
-        "Unable to find a unique train signature",
-    )
-    package_name = get_service_package_name(ServicePackageFactory.ServiceType.TRAINING)
-    train_rpc_req = (
-        train_rpcs[0].create_request_data_model(package_name).get_proto_class()
-    )
-    request_proto = json_format.Parse(
-        json.dumps({"parameters": training_kwargs}),
-        train_rpc_req(),
-    )
-    req_kwargs = build_caikit_library_request_dict(
-        request_proto.parameters, module.TRAIN_SIGNATURE
-    )
-    train_kwargs.update(req_kwargs)
-    log.debug3("All train kwargs: %s", train_kwargs)
+    try:
+        # Convert datatypes to match the training API
+        training_service = ServicePackageFactory.get_service_package(
+            ServicePackageFactory.ServiceType.TRAINING,
+        )
+        train_rpcs = [
+            rpc
+            for rpc in training_service.caikit_rpcs.values()
+            if rpc.module_list == [module]
+        ]
+        error.value_check(
+            "<COR11978965E>",
+            len(train_rpcs) == 1,
+            "Unable to find a unique train signature",
+        )
+        package_name = get_service_package_name(
+            ServicePackageFactory.ServiceType.TRAINING
+        )
+        train_rpc_req = (
+            train_rpcs[0].create_request_data_model(package_name).get_proto_class()
+        )
+        request_proto = json_format.Parse(
+            json.dumps({"parameters": training_kwargs}),
+            train_rpc_req(),
+        )
+        req_kwargs = build_caikit_library_request_dict(
+            request_proto.parameters, module.TRAIN_SIGNATURE
+        )
+        train_kwargs.update(req_kwargs)
+        log.debug3("All train kwargs: %s", train_kwargs)
+    except Exception as e:
+        message = "Exception encountered when attempting to parse input parameters"
+        log.warning(
+            {
+                "log_code": "<COR17376549E>",
+                "message": message,
+                "stack_trace": traceback.format_exc(),
+            }
+        )
+        write_termination_log(message)
+        exit(USER_ERROR_EXIT_CODE)
 
-    # Run the training
-    with alog.ContextTimer(
-        log.info,
-        "Finished training %s in: ",
-        args.model_name,
-    ):
-        future = train(module, wait=True, **train_kwargs)
-        info = future.get_info()
-        if info.status == TrainingStatus.COMPLETED:
-            log.info("Training finished successfully")
-            return 0
-        else:
-            log.error("Training finished unsuccessfully")
-            for err in info.errors or []:
-                log.error(err)
-            return 1
+    try:
+        # Run the training
+        with alog.ContextTimer(
+            log.info,
+            "Finished training %s in: ",
+            args.model_name,
+        ):
+            future = train(module, wait=True, **train_kwargs)
+            info = future.get_info()
+            if info.status == TrainingStatus.COMPLETED:
+                log.info("Training finished successfully")
+                return 0
+            else:
+                log.error("Training finished unsuccessfully")
+                for err in info.errors or []:
+                    log.error(err)
+                write_termination_log("Training finished unsuccessfully")
+                return INTERNAL_ERROR_EXIT_CODE
+    except MemoryError as e:
+        message = "OOM error during training"
+        log.warning(
+            {
+                "log_code": "<COR04280062E>",
+                "message": message,
+                "stack_trace": traceback.format_exc(),
+            }
+        )
+        write_termination_log(message)
+        exit(INTERNAL_ERROR_EXIT_CODE)
+    except Exception as e:
+        message = "Unhandled exception during training"
+        log.warning(
+            {
+                "log_code": "<COR04280062E>",
+                "message": message,
+                "stack_trace": traceback.format_exc(),
+            }
+        )
+        write_termination_log(message)
+        exit(INTERNAL_ERROR_EXIT_CODE)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_train.py
+++ b/tests/runtime/test_train.py
@@ -235,7 +235,10 @@ def test_failed_training():
         "--training-kwargs",
         json.dumps(training_kwargs),
     ):
-        assert main() == train.INTERNAL_ERROR_EXIT_CODE
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == train.INTERNAL_ERROR_EXIT_CODE
 
 
 def test_bad_module():
@@ -319,4 +322,7 @@ def test_non_existent_save_path():
         "--training-kwargs",
         json.dumps(SAMPLE_TRAIN_KWARGS),
     ):
-        assert main() == train.INTERNAL_ERROR_EXIT_CODE
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == train.INTERNAL_ERROR_EXIT_CODE


### PR DESCRIPTION
Because train.py is being launched via the command line, we need to convert all thrown exceptions to exit codes. When running in a k8s container environment, the error message must also be written to the termination log.