### PR TITLE
Add Abstractions for Runtime ModelManagement classes

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -55,6 +55,10 @@ model_management:
         default:
             type: CORE
             config: {}
+    sizers:
+        default:
+            type: MODEL_MESH
+            config: {}
 
 log:
     # Default level for all python loggers

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -51,6 +51,10 @@ model_management:
                 # List of module backend configurations in priority order
                 backend_priority:
                     - type: LOCAL
+    loaders:
+        default:
+            type: CORE
+            config: {}
 
 log:
     # Default level for all python loggers

--- a/caikit/runtime/model_management/core_model_loader.py
+++ b/caikit/runtime/model_management/core_model_loader.py
@@ -50,7 +50,7 @@ class CoreModelLoader(ModelLoaderBase):
         """Start loading a model from disk and associate the ID/size with it"""
         log.info("<RUN89711114I>", "Loading model '%s'", model_id)
 
-        # Only pass finder/initializer if they have values
+        # Only pass finder/initializer if they have values so that defaults are used otherwise
         load_kwargs = {}
         if finder:
             load_kwargs["finder"] = finder

--- a/caikit/runtime/model_management/core_model_loader.py
+++ b/caikit/runtime/model_management/core_model_loader.py
@@ -12,28 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Standard
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
-from typing import Callable, Optional, Union
-import abc
+from typing import Optional, Union
 
 # Third Party
-from grpc import StatusCode
 from prometheus_client import Summary
 
 # First Party
 import alog
-import aconfig
 
 # Local
-from caikit.core.toolkit.factory import FactoryConstructible
-from caikit.config import get_config
 from caikit.core import MODEL_MANAGER, ModuleBase
 from caikit.core.model_management import ModelFinderBase, ModelInitializerBase
-from caikit.runtime.model_management.batcher import Batcher
-from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.model_management.model_loader_base import ModelLoaderBase
-from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("MODEL-LOADER")
 
@@ -43,11 +33,12 @@ CAIKIT_CORE_LOAD_DURATION_SUMMARY = Summary(
     ["model_type"],
 )
 
+
 class CoreModelLoader(ModelLoaderBase):
     """The CoreModelLoader loads a model using the caikit core.ModelManager"""
 
     name = "CORE"
-    
+
     def load_module_instance(
         self,
         model_path: str,
@@ -56,9 +47,7 @@ class CoreModelLoader(ModelLoaderBase):
         finder: Optional[Union[str, ModelFinderBase]] = None,
         initializer: Optional[Union[str, ModelInitializerBase]] = None,
     ) -> ModuleBase:
-        """Start loading a model from disk and associate the ID/size with it
-
-        """
+        """Start loading a model from disk and associate the ID/size with it"""
         log.info("<RUN89711114I>", "Loading model '%s'", model_id)
 
         # Only pass finder/initializer if they have values
@@ -73,4 +62,3 @@ class CoreModelLoader(ModelLoaderBase):
             model = MODEL_MANAGER.load(model_path, **load_kwargs)
 
         return model
-

--- a/caikit/runtime/model_management/core_model_loader.py
+++ b/caikit/runtime/model_management/core_model_loader.py
@@ -1,0 +1,76 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from typing import Callable, Optional, Union
+import abc
+
+# Third Party
+from grpc import StatusCode
+from prometheus_client import Summary
+
+# First Party
+import alog
+import aconfig
+
+# Local
+from caikit.core.toolkit.factory import FactoryConstructible
+from caikit.config import get_config
+from caikit.core import MODEL_MANAGER, ModuleBase
+from caikit.core.model_management import ModelFinderBase, ModelInitializerBase
+from caikit.runtime.model_management.batcher import Batcher
+from caikit.runtime.model_management.loaded_model import LoadedModel
+from caikit.runtime.model_management.model_loader_base import ModelLoaderBase
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+
+log = alog.use_channel("MODEL-LOADER")
+
+CAIKIT_CORE_LOAD_DURATION_SUMMARY = Summary(
+    "caikit_core_load_model_duration_seconds",
+    "Summary of the duration (in seconds) of caikit.core.load(model)",
+    ["model_type"],
+)
+
+class CoreModelLoader(ModelLoaderBase):
+    """The CoreModelLoader loads a model using the caikit core.ModelManager"""
+
+    name = "CORE"
+    
+    def load_module_instance(
+        self,
+        model_path: str,
+        model_id: str,
+        model_type: str,
+        finder: Optional[Union[str, ModelFinderBase]] = None,
+        initializer: Optional[Union[str, ModelInitializerBase]] = None,
+    ) -> ModuleBase:
+        """Start loading a model from disk and associate the ID/size with it
+
+        """
+        log.info("<RUN89711114I>", "Loading model '%s'", model_id)
+
+        # Only pass finder/initializer if they have values
+        load_kwargs = {}
+        if finder:
+            load_kwargs["finder"] = finder
+        if initializer:
+            load_kwargs["initializer"] = initializer
+
+        # Load using the caikit.core
+        with CAIKIT_CORE_LOAD_DURATION_SUMMARY.labels(model_type=model_type).time():
+            model = MODEL_MANAGER.load(model_path, **load_kwargs)
+
+        return model
+

--- a/caikit/runtime/model_management/core_model_loader.py
+++ b/caikit/runtime/model_management/core_model_loader.py
@@ -59,6 +59,4 @@ class CoreModelLoader(ModelLoaderBase):
 
         # Load using the caikit.core
         with CAIKIT_CORE_LOAD_DURATION_SUMMARY.labels(model_type=model_type).time():
-            model = MODEL_MANAGER.load(model_path, **load_kwargs)
-
-        return model
+            return MODEL_MANAGER.load(model_path, **load_kwargs)

--- a/caikit/runtime/model_management/directory_model_sizer.py
+++ b/caikit/runtime/model_management/directory_model_sizer.py
@@ -1,0 +1,83 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+from pathlib import Path
+from typing import Dict
+import os
+
+# Third Party
+import grpc
+
+# First Party
+import alog
+import aconfig
+
+# Local
+from caikit import get_config
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+from caikit.runtime.model_management.model_sizer_base import ModelSizerBase
+
+log = alog.use_channel("DIRECTORY-SIZER")
+
+
+class DirectoryModelSizer(ModelSizerBase):
+    """DirectoryModelSizer. This class calculates a models size based on the 
+    size of the files in the model directory"""
+    name = "DIRECTORY"
+    
+    
+    def __init__(self, config: aconfig.Config, instance_name: str):
+        super().__init__(config, instance_name)
+        # Cache of archive sizes: directory model path -> archive size in bytes
+        self.model_directory_size: Dict[str, int] = {}
+
+    
+    def get_model_size(self, model_id, local_model_path, model_type) -> int:
+        """
+        Returns the estimated memory footprint of a model
+        Args:
+            model_id: The model identifier, used for informative logging
+            cos_model_path: The path to the model archive in S3 storage
+            model_type: The type of model, used to adjust the memory estimate
+        Returns:
+            The estimated size in bytes of memory that would be used by loading this model
+        """
+        # Cache model's size
+        if local_model_path not in self.model_directory_size:
+            self.model_directory_size[local_model_path] = self.__get_directory_size(
+                model_id, local_model_path
+            )
+
+        return self.model_directory_size[local_model_path]
+
+    def __get_directory_size(self, model_id, local_model_path) -> int:
+        try:
+            if os.path.isdir(local_model_path):
+                # Walk the directory to size all files
+                return sum(
+                    file.stat().st_size
+                    for file in Path(local_model_path).rglob("*")
+                    if file.is_file()
+                )
+
+            # Probably just an archive file
+            return os.path.getsize(local_model_path)
+        except FileNotFoundError as ex:
+            message = (
+                f"Failed to estimate size of model '{model_id}',"
+                f"file '{local_model_path}' not found"
+            )
+            log.error("<RUN62168924E>", message)
+            raise CaikitRuntimeException(grpc.StatusCode.NOT_FOUND, message) from ex

--- a/caikit/runtime/model_management/directory_model_sizer.py
+++ b/caikit/runtime/model_management/directory_model_sizer.py
@@ -21,29 +21,27 @@ import os
 import grpc
 
 # First Party
-import alog
 import aconfig
+import alog
 
 # Local
-from caikit import get_config
-from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.model_management.model_sizer_base import ModelSizerBase
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("DIRECTORY-SIZER")
 
 
 class DirectoryModelSizer(ModelSizerBase):
-    """DirectoryModelSizer. This class calculates a models size based on the 
+    """DirectoryModelSizer. This class calculates a models size based on the
     size of the files in the model directory"""
+
     name = "DIRECTORY"
-    
-    
+
     def __init__(self, config: aconfig.Config, instance_name: str):
         super().__init__(config, instance_name)
         # Cache of archive sizes: directory model path -> archive size in bytes
         self.model_directory_size: Dict[str, int] = {}
 
-    
     def get_model_size(self, model_id, local_model_path, model_type) -> int:
         """
         Returns the estimated memory footprint of a model

--- a/caikit/runtime/model_management/factories.py
+++ b/caikit/runtime/model_management/factories.py
@@ -1,0 +1,25 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Global factories for model management
+"""
+
+# Local
+from caikit.core.toolkit.factory import ImportableFactory
+from caikit.runtime.model_management.core_model_loader import CoreModelLoader
+
+# Model Loader factory. A loader is responsible for constructing 
+# a LoadedModel instance
+model_loader_factory = ImportableFactory("ModelLoader")
+model_loader_factory.register(CoreModelLoader)

--- a/caikit/runtime/model_management/factories.py
+++ b/caikit/runtime/model_management/factories.py
@@ -18,8 +18,16 @@ Global factories for model management
 # Local
 from caikit.core.toolkit.factory import ImportableFactory
 from caikit.runtime.model_management.core_model_loader import CoreModelLoader
+from caikit.runtime.model_management.directory_model_sizer import DirectoryModelSizer
+from caikit.runtime.model_management.mm_model_sizer import ModelMeshModelSizer
 
-# Model Loader factory. A loader is responsible for constructing 
+# Model Loader factory. A loader is responsible for constructing
 # a LoadedModel instance
 model_loader_factory = ImportableFactory("ModelLoader")
 model_loader_factory.register(CoreModelLoader)
+
+# Model Sizer factory. A sizer is responsible for estimating
+# the size of a model
+model_sizer_factory = ImportableFactory("ModelSizer")
+model_sizer_factory.register(DirectoryModelSizer)
+model_sizer_factory.register(ModelMeshModelSizer)

--- a/caikit/runtime/model_management/mm_model_sizer.py
+++ b/caikit/runtime/model_management/mm_model_sizer.py
@@ -12,32 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Standard
-from pathlib import Path
-from typing import Dict
-import os
-
-# Third Party
-import grpc
-
 # First Party
 import alog
-import aconfig
 
 # Local
 from caikit import get_config
-from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.model_management.directory_model_sizer import DirectoryModelSizer
 
-log = alog.use_channel("DIRECTORY-SIZER")
+log = alog.use_channel("MM-SIZER")
 
 
 class ModelMeshModelSizer(DirectoryModelSizer):
-    """ModelMeshModelSizer. This class calculates a models size based on the 
-    size of the files in the model directory plus a modelmesh modifier"""
+    """ModelMeshModelSizer. This class estimates a models size based on
+    the contents of the directory multiplied by a model specific
+    constant"""
+
     name = "MODEL_MESH"
 
-        
     def get_model_size(self, model_id, local_model_path, model_type) -> int:
         """
         Returns the estimated memory footprint of a model
@@ -48,7 +39,7 @@ class ModelMeshModelSizer(DirectoryModelSizer):
         Returns:
             The estimated size in bytes of memory that would be used by loading this model
         """
-        
+
         if (
             model_type
             in get_config().inference_plugin.model_mesh.model_size_multipliers
@@ -75,4 +66,6 @@ class ModelMeshModelSizer(DirectoryModelSizer):
                 model_id,
                 multiplier,
             )
-        return int(super().get_model_size(model_id, local_model_path, model_type) * multiplier)
+        return int(
+            super().get_model_size(model_id, local_model_path, model_type) * multiplier
+        )

--- a/caikit/runtime/model_management/model_loader_base.py
+++ b/caikit/runtime/model_management/model_loader_base.py
@@ -15,6 +15,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Callable, Optional, Union
+import abc
 
 # Third Party
 from grpc import StatusCode
@@ -22,8 +23,10 @@ from prometheus_client import Summary
 
 # First Party
 import alog
+import aconfig
 
 # Local
+from caikit.core.toolkit.factory import FactoryConstructible
 from caikit.config import get_config
 from caikit.core import MODEL_MANAGER, ModuleBase
 from caikit.core.model_management import ModelFinderBase, ModelInitializerBase
@@ -33,27 +36,46 @@ from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("MODEL-LOADER")
 
-CAIKIT_CORE_LOAD_DURATION_SUMMARY = Summary(
-    "caikit_core_load_model_duration_seconds",
-    "Summary of the duration (in seconds) of caikit.core.load(model)",
-    ["model_type"],
-)
+class ModelLoaderBase(FactoryConstructible):
+    """Model Loader Base class which describes how models are loaded."""
 
-
-class ModelLoader:
-    """Model Loader class. The singleton class contains the core implementation details
-    for loading models in from S3."""
-
-    __instance = None
-
-    def __init__(self):
-        # Re-instantiating this is a programming error
-        assert self.__class__.__instance is None, "This class is a singleton!"
-        ModelLoader.__instance = self
-        self._load_thread_pool = ThreadPoolExecutor(get_config().runtime.load_threads)
+    __load_thread_pool = None
+    
+    def __init__(self, config: aconfig.Config, instance_name: str):
+        """A FactoryConstructible object must be constructed with a config
+        object that it uses to pull in all configuration
+        """
+        if ModelLoaderBase.__load_thread_pool is None:
+            ModelLoaderBase.__load_thread_pool = ThreadPoolExecutor(
+                get_config().runtime.load_threads
+            )
+       
         # Instead of storing config-based batching information here, we call
         # get_config() when needed to support dynamic config changes for
         # batching
+
+    @abc.abstractmethod
+    def load_module_instance(
+        self,
+        model_path: str,
+        model_id: str,
+        model_type: str,
+        finder: Optional[Union[str, ModelFinderBase]] = None,
+        initializer: Optional[Union[str, ModelInitializerBase]] = None,
+    ) -> ModuleBase:
+        """Load an instance of a Caikit Model
+
+        Args:
+            model_path (str): The model path to load from
+            model_id (str): The model's id 
+            model_type (str): The type of model being load
+            finder (Optional[Union[str, ModelFinderBase]], optional): The ModelFinder to use for loading. Defaults to None.
+            initializer (Optional[Union[str, ModelInitializerBase]], optional): The ModelInitializer to use for loading. Defaults to None.
+
+        Returns:
+            ModuleBase: a loaded model
+        """
+
 
     def load_model(
         self,
@@ -77,7 +99,7 @@ class ModelLoader:
         Returns:
             model (LoadedModel) : The model that was loaded
         """
-        # Set up the basics of the model's metadata
+                # Set up the basics of the model's metadata
         model_builder = (
             LoadedModel.Builder()
             .id(model_id)
@@ -91,41 +113,41 @@ class ModelLoader:
         args = (local_model_path, model_id, model_type, finder, initializer)
         log.debug2("Loading model %s async", model_id)
         future_factory = partial(
-            self._load_thread_pool.submit, self._load_module, *args
+            self.__load_thread_pool.submit, self._wrapped_load_model, *args
         )
         model_builder.model_future_factory(future_factory)
 
         # Return the built model with the future handle
         return model_builder.build()
 
-    def _load_module(
+    def _wrapped_load_model(
         self,
         model_path: str,
         model_id: str,
         model_type: str,
         finder: Optional[Union[str, ModelFinderBase]] = None,
         initializer: Optional[Union[str, ModelInitializerBase]] = None,
-    ) -> LoadedModel:
+    ) -> Union[Batcher, ModuleBase]:
         try:
             log.info("<RUN89711114I>", "Loading model '%s'", model_id)
 
-            # Only pass finder/initializer if they have values
-            load_kwargs = {}
-            if finder:
-                load_kwargs["finder"] = finder
-            if initializer:
-                load_kwargs["initializer"] = initializer
 
-            # Load using the caikit.core
-            with CAIKIT_CORE_LOAD_DURATION_SUMMARY.labels(model_type=model_type).time():
-                model = MODEL_MANAGER.load(model_path, **load_kwargs)
-
+            model = self.load_module_instance(model_path, model_id, model_type, finder, initializer)
+            
             # If this model needs batching, configure a Batcher to wrap it
             model = self._wrap_in_batcher_if_configured(
                 model,
                 model_type,
                 model_id,
             )
+        except CaikitRuntimeException as cre:
+            log_dict = {
+                "log_code": "<RUN98613924E>",
+                "message": f"load failed to load model: {model_path} with error: {repr(cre)}",
+                "model_id": model_id,
+            }
+            log.error(log_dict)
+            raise cre
         except FileNotFoundError as fnfe:
             log_dict = {
                 "log_code": "<RUN98613924E>",
@@ -164,14 +186,7 @@ class ModelLoader:
         log.info("<RUN89713784I>", "Singleton cache: '%s'", str(cache_info))
 
         return model
-
-    @classmethod
-    def get_instance(cls) -> "ModelLoader":
-        """This method returns the instance of Model Manager"""
-        if not cls.__instance:
-            cls.__instance = ModelLoader()
-        return cls.__instance
-
+    
     def _wrap_in_batcher_if_configured(
         self,
         caikit_core_model: ModuleBase,

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -42,6 +42,11 @@ from caikit.runtime.model_management.factories import (
 from caikit.runtime.model_management.loaded_model import LoadedModel
 from caikit.runtime.model_management.model_loader_base import ModelLoaderBase
 from caikit.runtime.model_management.model_sizer_base import ModelSizerBase
+from caikit.runtime.names import (
+    DEFAULT_LOADER_NAME,
+    DEFAULT_SIZER_NAME,
+    LOCAL_MODEL_TYPE,
+)
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("MODEL-MANAGR")
@@ -65,9 +70,6 @@ LOAD_MODEL_DURATION_SUMMARY = Summary(
     "Summary of the duration (in seconds) of loadModel RPCs",
     ["model_type"],
 )
-LOCAL_MODEL_TYPE = "LOCAL"
-DEFAULT_LOADER_NAME = "default"
-DEFAULT_SIZER_NAME = "default"
 
 
 class ModelManager:  # pylint: disable=too-many-instance-attributes
@@ -78,8 +80,6 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
     __instance = None
 
     __model_size_gauge_lock = threading.Lock()
-
-    _LOCAL_MODEL_TYPE = "standalone-model"
 
     ## Construction ##
 
@@ -461,7 +461,7 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
             loaded_model = self.load_model(
                 model_id=model_id,
                 local_model_path=local_model_path,
-                model_type=self._LOCAL_MODEL_TYPE,
+                model_type=LOCAL_MODEL_TYPE,
                 wait=True,
                 retries=get_config().runtime.lazy_load_retries,
             )
@@ -538,7 +538,7 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
             return self.load_model(
                 model_id=model_id,
                 local_model_path=model_dir,
-                model_type=self._LOCAL_MODEL_TYPE,
+                model_type=LOCAL_MODEL_TYPE,
                 **kwargs,
             )
 
@@ -643,7 +643,7 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
             self.load_model(
                 model_id,
                 model_path,
-                self._LOCAL_MODEL_TYPE,
+                LOCAL_MODEL_TYPE,
                 wait=False,
                 retries=get_config().runtime.lazy_load_retries,
             )

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -35,10 +35,13 @@ from caikit import get_config
 from caikit.core import ModuleBase
 from caikit.core.exceptions import error_handler
 from caikit.core.model_management import ModelFinderBase, ModelInitializerBase
-from caikit.runtime.model_management.factories import model_loader_factory
-from caikit.runtime.model_management.model_loader_base import ModelLoaderBase
+from caikit.runtime.model_management.factories import (
+    model_loader_factory,
+    model_sizer_factory,
+)
 from caikit.runtime.model_management.loaded_model import LoadedModel
-from caikit.runtime.model_management.model_sizer import ModelSizer
+from caikit.runtime.model_management.model_loader_base import ModelLoaderBase
+from caikit.runtime.model_management.model_sizer_base import ModelSizerBase
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("MODEL-MANAGR")
@@ -106,7 +109,17 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
         self.model_loader: ModelLoaderBase = model_loader_factory.construct(
             loader_config, DEFAULT_LOADER_NAME
         )
-        self.model_sizer = ModelSizer.get_instance()
+        sizer_config = get_config().model_management.sizers.get(DEFAULT_LOADER_NAME, {})
+        error.value_check(
+            "<COR54257389E>",
+            isinstance(sizer_config, dict),
+            "Unknown {}: {}",
+            "sizer",
+            DEFAULT_LOADER_NAME,
+        )
+        self.model_sizer: ModelSizerBase = model_sizer_factory.construct(
+            sizer_config, DEFAULT_LOADER_NAME
+        )
 
         # In-memory mapping of model_id to LoadedModel instance
         self.loaded_models: Dict[str, LoadedModel] = {}

--- a/caikit/runtime/model_management/model_manager.py
+++ b/caikit/runtime/model_management/model_manager.py
@@ -67,6 +67,7 @@ LOAD_MODEL_DURATION_SUMMARY = Summary(
 )
 LOCAL_MODEL_TYPE = "LOCAL"
 DEFAULT_LOADER_NAME = "default"
+DEFAULT_SIZER_NAME = "default"
 
 
 class ModelManager:  # pylint: disable=too-many-instance-attributes
@@ -115,7 +116,7 @@ class ModelManager:  # pylint: disable=too-many-instance-attributes
             isinstance(sizer_config, dict),
             "Unknown {}: {}",
             "sizer",
-            DEFAULT_LOADER_NAME,
+            DEFAULT_SIZER_NAME,
         )
         self.model_sizer: ModelSizerBase = model_sizer_factory.construct(
             sizer_config, DEFAULT_LOADER_NAME

--- a/caikit/runtime/model_management/model_sizer_base.py
+++ b/caikit/runtime/model_management/model_sizer_base.py
@@ -13,30 +13,24 @@
 # limitations under the License.
 
 # Standard
-from pathlib import Path
-from typing import Dict
-import os
 import abc
-
-# Third Party
-import grpc
 
 # First Party
 import alog
 
 # Local
-from caikit import get_config
-from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.core.toolkit.factory import FactoryConstructible
 
 log = alog.use_channel("MODEL-SIZER")
 
 
 class ModelSizerBase(FactoryConstructible):
-    """Model Sizer Base class. This class contains the """
+    """Model Sizer Base class. This class contains the"""
 
     @abc.abstractmethod
-    def get_model_size(self, model_id: str, local_model_path: str, model_type: str) -> int:
+    def get_model_size(
+        self, model_id: str, local_model_path: str, model_type: str
+    ) -> int:
         """
         Returns the estimated memory footprint of a model
         Args:
@@ -46,4 +40,3 @@ class ModelSizerBase(FactoryConstructible):
         Returns:
             The estimated size in bytes of memory that would be used by loading this model
         """
-       

--- a/caikit/runtime/model_management/model_sizer_base.py
+++ b/caikit/runtime/model_management/model_sizer_base.py
@@ -1,0 +1,49 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+from pathlib import Path
+from typing import Dict
+import os
+import abc
+
+# Third Party
+import grpc
+
+# First Party
+import alog
+
+# Local
+from caikit import get_config
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
+from caikit.core.toolkit.factory import FactoryConstructible
+
+log = alog.use_channel("MODEL-SIZER")
+
+
+class ModelSizerBase(FactoryConstructible):
+    """Model Sizer Base class. This class contains the """
+
+    @abc.abstractmethod
+    def get_model_size(self, model_id: str, local_model_path: str, model_type: str) -> int:
+        """
+        Returns the estimated memory footprint of a model
+        Args:
+            model_id: The model identifier, used for informative logging
+            cos_model_path: The path to the model archive in S3 storage
+            model_type: The type of model, used to adjust the memory estimate
+        Returns:
+            The estimated size in bytes of memory that would be used by loading this model
+        """
+       

--- a/caikit/runtime/names.py
+++ b/caikit/runtime/names.py
@@ -49,6 +49,11 @@ from caikit.interfaces.runtime.data_model import (
 log = alog.use_channel("RNTM-NAMES")
 
 
+################################# Model Management Names #######################
+LOCAL_MODEL_TYPE = "standalone-model"
+DEFAULT_LOADER_NAME = "default"
+DEFAULT_SIZER_NAME = "default"
+
 ################################# Service Names ################################
 
 

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -52,9 +52,13 @@ def temp_model_loader():
 def model_loader():
     yield construct_model_loader()
 
+
 def construct_model_loader():
-    model_loader: CoreModelLoader = model_loader_factory.construct(get_config().model_management.loaders.default,"default")
+    model_loader: CoreModelLoader = model_loader_factory.construct(
+        get_config().model_management.loaders.default, "default"
+    )
     return model_loader
+
 
 def make_model_future(model_instance):
     fake_future = Future()
@@ -163,10 +167,11 @@ def test_nonzip_extract_fails(model_loader):
     assert "config.yml" in context.value.message
 
 
-#def test_no_double_instantiation_of_thread_pools():
-#    """Make sure trying to re-instantiate this singleton raises"""
-#    with construct_model_loader() as loader1, construct_model_loader() as loader2:
-#        assert loader1__load_thread_pool == loader2.__load_thread_pool
+def test_no_double_instantiation_of_thread_pools():
+    """Make sure trying to re-instantiate this singleton raises"""
+    loader1 = construct_model_loader()
+    loader2 = construct_model_loader()
+    assert loader1._load_thread_pool == loader2._load_thread_pool
 
 
 def test_with_batching(model_loader):
@@ -373,7 +378,9 @@ def test_load_model_loaded_status(model_loader):
         release_event.wait()
         return model_mock
 
-    with mock.patch.object(model_loader, "load_module_instance", _load_module_instance_mock):
+    with mock.patch.object(
+        model_loader, "load_module_instance", _load_module_instance_mock
+    ):
         loaded_model = model_loader.load_model(
             model_id=model_id,
             local_model_path=Fixtures.get_good_model_path(),

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -171,7 +171,7 @@ def test_no_double_instantiation_of_thread_pools():
     """Make sure trying to re-instantiate this singleton raises"""
     loader1 = construct_model_loader()
     loader2 = construct_model_loader()
-    assert loader1._load_thread_pool == loader2._load_thread_pool
+    assert loader1._load_thread_pool is loader2._load_thread_pool
 
 
 def test_with_batching(model_loader):

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -27,8 +27,10 @@ from caikit.config import get_config
 from caikit.core import ModuleConfig
 from caikit.core.module_backends import backend_types
 from caikit.core.modules import base, module
+from caikit.core.toolkit.factory import FactoryConstructible
 from caikit.runtime.model_management.batcher import Batcher
-from caikit.runtime.model_management.model_loader import ModelLoader
+from caikit.runtime.model_management.core_model_loader import CoreModelLoader
+from caikit.runtime.model_management.factories import model_loader_factory
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from sample_lib.data_model import SampleInputType, SampleOutputType
 from sample_lib.modules.sample_task import SampleModule
@@ -43,16 +45,16 @@ import caikit.core
 @contextmanager
 def temp_model_loader():
     """Temporarily reset the ModelLoader singleton"""
-    real_singleton = ModelLoader.get_instance()
-    ModelLoader._ModelLoader__instance = None
-    yield ModelLoader.get_instance()
-    ModelLoader._ModelLoader__instance = real_singleton
+    yield construct_model_loader()
 
 
 @pytest.fixture
 def model_loader():
-    return ModelLoader.get_instance()
+    yield construct_model_loader()
 
+def construct_model_loader():
+    model_loader: CoreModelLoader = model_loader_factory.construct(get_config().model_management.loaders.default,"default")
+    return model_loader
 
 def make_model_future(model_instance):
     fake_future = Future()
@@ -161,10 +163,10 @@ def test_nonzip_extract_fails(model_loader):
     assert "config.yml" in context.value.message
 
 
-def test_no_double_instantiation():
-    """Make sure trying to re-instantiate this singleton raises"""
-    with pytest.raises(Exception):
-        ModelLoader()
+#def test_no_double_instantiation_of_thread_pools():
+#    """Make sure trying to re-instantiate this singleton raises"""
+#    with construct_model_loader() as loader1, construct_model_loader() as loader2:
+#        assert loader1__load_thread_pool == loader2.__load_thread_pool
 
 
 def test_with_batching(model_loader):
@@ -319,11 +321,11 @@ def test_load_model_succeed_after_retry(model_loader):
     """
     failures = 2
     fail_wrapper = TempFailWrapper(
-        model_loader._load_module,
+        model_loader.load_module_instance,
         num_failures=failures,
         exc=CaikitRuntimeException(grpc.StatusCode.INTERNAL, "Yikes!"),
     )
-    with mock.patch.object(model_loader, "_load_module", fail_wrapper):
+    with mock.patch.object(model_loader, "load_module_instance", fail_wrapper):
         model_id = random_test_id()
         loaded_model = model_loader.load_model(
             model_id=model_id,
@@ -342,11 +344,11 @@ def test_load_model_fail_callback_once(model_loader):
     """
     failures = 3
     fail_wrapper = TempFailWrapper(
-        model_loader._load_module,
+        model_loader.load_module_instance,
         num_failures=failures,
         exc=CaikitRuntimeException(grpc.StatusCode.INTERNAL, "Yikes!"),
     )
-    with mock.patch.object(model_loader, "_load_module", fail_wrapper):
+    with mock.patch.object(model_loader, "load_module_instance", fail_wrapper):
         model_id = random_test_id()
         fail_cb = mock.MagicMock()
         loaded_model = model_loader.load_model(
@@ -367,11 +369,11 @@ def test_load_model_loaded_status(model_loader):
     release_event = threading.Event()
     model_mock = mock.MagicMock()
 
-    def _load_module_mock(*_, **__):
+    def _load_module_instance_mock(*_, **__):
         release_event.wait()
         return model_mock
 
-    with mock.patch.object(model_loader, "_load_module", _load_module_mock):
+    with mock.patch.object(model_loader, "load_module_instance", _load_module_instance_mock):
         loaded_model = model_loader.load_model(
             model_id=model_id,
             local_model_path=Fixtures.get_good_model_path(),

--- a/tests/runtime/model_management/test_model_manager.py
+++ b/tests/runtime/model_management/test_model_manager.py
@@ -46,7 +46,7 @@ from tests.conftest import TempFailWrapper, random_test_id, temp_config
 from tests.core.helpers import TestFinder
 from tests.fixtures import Fixtures
 from tests.runtime.conftest import deploy_good_model_files
-import caikit.runtime.model_management.model_loader
+import caikit.runtime.model_management.model_loader_base
 
 get_dynamic_module("caikit.core")
 ANY_MODEL_TYPE = "test-any-model-type"
@@ -72,7 +72,7 @@ def temp_local_models_dir(workdir, model_manager=MODEL_MANAGER):
 def non_singleton_model_managers(num_mgrs=1, *args, **kwargs):
     with temp_config(*args, **kwargs):
         with patch(
-            "caikit.runtime.model_management.model_loader.MODEL_MANAGER",
+            "caikit.runtime.model_management.core_model_loader.MODEL_MANAGER",
             new_callable=CoreModelManager,
         ):
             instances = []
@@ -1269,13 +1269,13 @@ def test_periodic_sync_handles_temporary_errors():
         ) as managers:
             manager = managers[0]
             flakey_loader = TempFailWrapper(
-                manager.model_loader._load_module,
+                manager.model_loader.load_module_instance,
                 num_failures=1,
                 exc=CaikitRuntimeException(grpc.StatusCode.INTERNAL, "Dang"),
             )
             with patch.object(
                 manager.model_loader,
-                "_load_module",
+                "load_module_instance",
                 flakey_loader,
             ):
                 assert manager._lazy_sync_timer is not None
@@ -1307,13 +1307,13 @@ def test_lazy_load_handles_temporary_errors():
         ) as managers:
             manager = managers[0]
             flakey_loader = TempFailWrapper(
-                manager.model_loader._load_module,
+                manager.model_loader.load_module_instance,
                 num_failures=1,
                 exc=CaikitRuntimeException(grpc.StatusCode.INTERNAL, "Dang"),
             )
             with patch.object(
                 manager.model_loader,
-                "_load_module",
+                "load_module_instance",
                 flakey_loader,
             ):
                 assert manager._lazy_sync_timer is None

--- a/tests/runtime/model_management/test_model_sizer.py
+++ b/tests/runtime/model_management/test_model_sizer.py
@@ -22,7 +22,8 @@ import grpc
 
 # Local
 from caikit import get_config
-from caikit.runtime.model_management.model_sizer import ModelSizer
+from caikit.runtime.model_management.factories import model_sizer_factory
+from caikit.runtime.model_management.model_sizer_base import ModelSizerBase
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from tests.conftest import random_test_id, temp_config
 from tests.fixtures import Fixtures
@@ -37,7 +38,9 @@ class TestModelSizer(unittest.TestCase):
 
     def setUp(self):
         """This method runs before each test begins to run"""
-        self.model_sizer = ModelSizer.get_instance()
+        self.model_sizer = model_sizer_factory.construct(
+            get_config().model_management.sizers.default, "default"
+        )
 
     @staticmethod
     def _add_file(path, charsize) -> int:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR converts the `ModelLoader` and `ModelSizer` classes into abstract base classes with their own factories. This mimics the core model management classes like `ModelFinder`. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
