### PR TITLE
:goal_net: Handle caikit core exceptions in servicers

### DIFF
--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -31,6 +31,7 @@ import alog
 from caikit import get_config
 from caikit.core import ModuleBase, TaskBase
 from caikit.core.data_model import DataBase, DataStream
+from caikit.core.exceptions.caikit_core_exception import CaikitCoreException
 from caikit.core.signature_parsing import CaikitMethodSignature
 from caikit.runtime.metrics.rpc_meter import RPCMeter
 from caikit.runtime.model_management.model_manager import ModelManager
@@ -44,6 +45,7 @@ from caikit.runtime.utils.servicer_util import (
     build_proto_response,
     build_proto_stream,
     get_metadata,
+    raise_caikit_runtime_exception,
     validate_data_model,
 )
 from caikit.runtime.work_management.abortable_context import (
@@ -311,9 +313,10 @@ class GlobalPredictServicer:
                 grpc_request=request_name, code=e.status_code.name, model_id=model_id
             ).inc()
             raise e
-
         # Duplicate code in global_train_servicer
         # pylint: disable=duplicate-code
+        except CaikitCoreException as e:
+            raise_caikit_runtime_exception(exception=e)
         except (TypeError, ValueError) as e:
             log_dict = {
                 "log_code": "<RUN490439039W>",

--- a/caikit/runtime/servicers/global_train_servicer.py
+++ b/caikit/runtime/servicers/global_train_servicer.py
@@ -27,6 +27,7 @@ import alog
 # Local
 from caikit import get_config
 from caikit.core import MODEL_MANAGER, ModuleBase
+from caikit.core.exceptions.caikit_core_exception import CaikitCoreException
 from caikit.interfaces.common.data_model.stream_sources import S3Path
 from caikit.interfaces.runtime.data_model import TrainingJob
 from caikit.runtime.model_management.model_manager import ModelManager
@@ -36,6 +37,7 @@ from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 from caikit.runtime.utils.import_util import clean_lib_names, get_data_model
 from caikit.runtime.utils.servicer_util import (
     build_caikit_library_request_dict,
+    raise_caikit_runtime_exception,
     validate_data_model,
 )
 import caikit.core
@@ -147,6 +149,8 @@ class GlobalTrainServicer:
 
         # Duplicate code in global_predict_servicer
         # pylint: disable=duplicate-code
+        except CaikitCoreException as e:
+            raise_caikit_runtime_exception(exception=e)
         except (TypeError, ValueError) as e:
             log_dict = {
                 "log_code": "<RUN72924264W>",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

After rpc errors were interpreted as caikit core exceptions in https://github.com/caikit/caikit-nlp/pull/355, when the servicers get called, these always get interpreted as `500` e.g. `{"details": "(<CaikitCoreStatusCode.INVALID_ARGUMENT: 2>, 'input tokens (3222) plus prefix length (0) must be < 2048')", "code": 500, "id": "875b83810ee04c058357eb5124c7cea8"`

Since the mapping of status codes is already present in caikit, this can be handled here.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
