### PR TITLE
first version showing how otel compliant tracing can be enabled

### DIFF
--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -191,6 +191,8 @@ runtime:
         endpoint: "localhost:4317"
         protocol: grpc
         service_name: caikit.runtime
+        # Flush the trace on exit
+        flush_on_exit: true
         # TLS config for the otel server. If CA is falsy, insecure. If client
         # key and cert provided with CA, mTLS, otherwise TLS.
         tls:

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -187,7 +187,8 @@ runtime:
     # Configuration for the trace push client
     trace:
         enabled: false
-        endpoint: "localhost:14250"
+        # For HTTP default, use "http(s)://localhost:4318/v1/traces"
+        endpoint: "localhost:4317"
         protocol: grpc
         service_name: caikit.runtime
         # TLS config for the otel server. If CA is falsy, insecure. If client

--- a/caikit/config/config.yml
+++ b/caikit/config/config.yml
@@ -184,6 +184,19 @@ runtime:
         enabled: true
         port: 8086
 
+    # Configuration for the trace push client
+    trace:
+        enabled: false
+        endpoint: "localhost:14250"
+        protocol: grpc
+        service_name: caikit.runtime
+        # TLS config for the otel server. If CA is falsy, insecure. If client
+        # key and cert provided with CA, mTLS, otherwise TLS.
+        tls:
+            ca: ""
+            client_key: ""
+            client_cert: ""
+
     # Whether or not to abort work on client cancellation
     use_abortable_threads: true
 

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -76,7 +76,6 @@ from caikit.runtime.names import (
     MODEL_MANAGEMENT_SERVICE_SPEC,
     MODELS_INFO_ENDPOINT,
     OPTIONAL_INPUTS_KEY,
-    REQUEST_ID_HEADER_KEY,
     REQUIRED_INPUTS_KEY,
     RUNTIME_INFO_ENDPOINT,
     STATUS_CODE_TO_HTTP,
@@ -651,11 +650,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     HttpRequestAborter(context) if self.interrupter else nullcontext()
                 )
 
-                # Get the request ID for this request either from the context or
-                # with an internal uuid
-                request_id = self._get_request_id(context)
-                log.debug("Predict request: %s", request_id)
-
                 with aborter_context as aborter:
                     # TODO: use `async_wrap_*`?
                     call = partial(
@@ -667,7 +661,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                         task=rpc.task,
                         aborter=aborter,
                         context=context,
-                        request_id=request_id,
                         **request_params,
                     )
                     result = await loop.run_in_executor(self.thread_pool, call)
@@ -730,11 +723,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                         else nullcontext()
                     )
 
-                    # Get the request ID for this request either from the context or
-                    # with an internal uuid
-                    request_id = self._get_request_id(context)
-                    log.debug("Predict request: %s", request_id)
-
                     with aborter_context as aborter:
                         log.debug("In stream generator for %s", rpc.name)
                         async for result in async_wrap_iter(
@@ -746,7 +734,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                                 task=rpc.task,
                                 aborter=aborter,
                                 context=context,
-                                request_id=request_id,
                                 **request_params,
                             ),
                             pool=self.thread_pool,
@@ -929,13 +916,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
         )
 
         return request_message
-
-    @staticmethod
-    def _get_request_id(context: Request) -> str:
-        """Get a request ID from the headers and fall back to an internal id"""
-        if (request_id := context.headers.get(REQUEST_ID_HEADER_KEY)) is not None:
-            return request_id
-        return str(uuid.uuid4())
 
     @staticmethod
     def _get_response_dataobject(rpc: CaikitRPCBase) -> Type[DataBase]:

--- a/caikit/runtime/names.py
+++ b/caikit/runtime/names.py
@@ -287,9 +287,6 @@ MODEL_MANAGEMENT_SERVICE_SPEC = {
 # Invocation metadata key for the model ID, provided by Model Mesh
 MODEL_MESH_MODEL_ID_KEY = "mm-model-id"
 
-# Input request ID metadata/header key
-REQUEST_ID_HEADER_KEY = "request-id"
-
 ## HTTP Server
 
 # Endpoint to use for health checks

--- a/caikit/runtime/names.py
+++ b/caikit/runtime/names.py
@@ -287,6 +287,8 @@ MODEL_MANAGEMENT_SERVICE_SPEC = {
 # Invocation metadata key for the model ID, provided by Model Mesh
 MODEL_MESH_MODEL_ID_KEY = "mm-model-id"
 
+# Input request ID metadata/header key
+REQUEST_ID_HEADER_KEY = "request-id"
 
 ## HTTP Server
 

--- a/caikit/runtime/server_base.py
+++ b/caikit/runtime/server_base.py
@@ -28,6 +28,7 @@ import alog
 # Local
 from caikit.config import get_config
 from caikit.core.exceptions import error_handler
+from caikit.runtime import trace
 from caikit.runtime.model_management.model_manager import ModelManager
 from caikit.runtime.service_factory import ServicePackage, ServicePackageFactory
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
@@ -77,6 +78,9 @@ class RuntimeServerBase(abc.ABC):  # pylint: disable=too-many-instance-attribute
 
         # Configure using the log level and formatter type specified in config.
         caikit.core.toolkit.logging.configure()
+
+        # Configure tracing
+        trace.configure()
 
         # We should always be able to stand up an inference service
         self.enable_inference = self.config.runtime.service_generation.enable_inference

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -135,7 +135,6 @@ class GlobalPredictServicer:
             library,
             lib_version,
         )
-        super()
 
     def Predict(
         self,

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -289,7 +289,7 @@ class GlobalPredictServicer:
                 The object (unary) or objects (output stream) produced by the
                 inference request
         """
-
+        trace.set_tracer(context, self._tracer)
         trace_context = trace.get_trace_context(context)
         trace_span_name = f"{__name__}.GlobalPredictServicer.predict_model"
         with self._handle_predict_exceptions(

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -212,8 +212,7 @@ class GlobalPredictServicer:
                 request_id := get_metadata(
                     context, REQUEST_ID_HEADER_KEY, required=False
                 )
-                is None
-            ):
+            ) is None:
                 request_id = str(uuid.uuid4())
                 log.debug("Using internally generated request ID: %s", request_id)
 

--- a/caikit/runtime/servicers/global_predict_servicer.py
+++ b/caikit/runtime/servicers/global_predict_servicer.py
@@ -27,32 +27,6 @@ from prometheus_client import Counter, Summary
 # First Party
 import alog
 
-#OTEL Tracing SDK and pkgs
-########################
-
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    BatchSpanProcessor,
-    ConsoleSpanExporter,
-)
-
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
-
-provider = TracerProvider()
-otelendpoint=os.environ.get('OTEL_ENDPOINT')
-processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=otelendpoint,insecure=True))
-provider.add_span_processor(processor)
-
-# Sets the global default tracer provider
-trace.set_tracer_provider(provider)
-
-# Creates a tracer from the global tracer provider
-tracer = trace.get_tracer("caikit.runtime.servicers.global_predict_service")
-
-########################
-
 # Local
 from caikit import get_config
 from caikit.core import MODEL_MANAGER, ModuleBase, TaskBase
@@ -188,13 +162,6 @@ class GlobalPredictServicer:
         model_id = get_metadata(context, MODEL_MESH_MODEL_ID_KEY)
         request_name = caikit_rpc.request.name
 
-
-
-        #metadata sent by client request, this can be used to pass the context from the parent request, Gabe to help figuring this out
-  	metadict_context_from_client_request = dict(context.invocation_metadata())
-  	print("METADICT_CONTEXT_FROM_CLINENT_REQUEST")
-  	print(dir(metadict_context_from_client_request))
-
         with self._handle_predict_exceptions(model_id, request_name), alog.ContextLog(
             log.debug, "GlobalPredictServicer.Predict:%s", request_name
         ):
@@ -305,14 +272,7 @@ class GlobalPredictServicer:
                 inference request
         """
 
-
-        #ctx can be derived from kwargs, ctx can be added to otel trace/span, [ Gabe to further look into it ]
-        ctx=kwargs
-
-
-        with self._handle_predict_exceptions(model_id, request_name), tracer.start_as_current_span("caikit.runtime.servicers/global_predict_servicer.predict_model",context=ctx) as span:
-        #with self._handle_predict_exceptions(model_id, request_name):
-
+        with self._handle_predict_exceptions(model_id, request_name):
             model = model or self._model_manager.retrieve_model(model_id)
             self._verify_model_task(model)
             if input_streaming is not None and output_streaming is not None:
@@ -356,25 +316,6 @@ class GlobalPredictServicer:
             ).inc()
             if get_config().runtime.metering.enabled:
                 self.rpc_meter.update_metrics(str(type(model)))
-
-            #Span Attributes for OTEL trace/span added as the below
-            span.set_attribute("calling", "caikit.runtime.servicers/global_predict_servicer.predict_model")
-            model = self._model_manager.retrieve_model(model_id)
-            span.set_attribute("model_id", model_id)
-            span.set_attribute("request_name", request_name)
-            span.set_attribute("inference_func_name", inference_func_name)
-            span.set_attribute("task", task)
-
-            #Span Attributes specific to embedding response-type attributes
-            tmpA=getattr(response, '_producer_id')
-            span.set_attribute("producer_id name",tmpA.name)
-
-            tmpA=getattr(response, '_infer_which_oneof')
-            span.set_attribute("full_name",tmpA)
-
-            tmpA=getattr(response, '_input_token_count')
-            span.set_attribute("input token count",tmpA)
-
 
             return response
 

--- a/caikit/runtime/trace.py
+++ b/caikit/runtime/trace.py
@@ -84,10 +84,6 @@ def configure():
     # Populate the global module handle
     _TRACE_MODULE = trace
 
-    # Configure the trace provider
-    resource = Resource(attributes={SERVICE_NAME: trace_cfg.service_name})
-    provider = TracerProvider(resource=resource)
-
     # Set up the exporter
     exporter_kwargs = {"endpoint": trace_cfg.endpoint}
     if trace_cfg.tls.ca:
@@ -116,7 +112,11 @@ def configure():
             exporter_kwargs["insecure"] = True
     exporter = OTLPSpanExporter(**exporter_kwargs)
 
-    # Set up the trace provider
+    # Configure the trace provider
+    resource = Resource(attributes={SERVICE_NAME: trace_cfg.service_name})
+    provider = TracerProvider(
+        resource=resource, shutdown_on_exit=trace_cfg.flush_on_exit
+    )
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
 

--- a/caikit/runtime/trace.py
+++ b/caikit/runtime/trace.py
@@ -101,8 +101,11 @@ def configure():
                 **creds_kwargs
             )
         else:
-            if trace_cfg.tls.client_key and trace_cfg.tls.client_cert:
-                log.warning("mTLS not supported for trace with HTTP")
+            error.value_check(
+                "<RUN46942098E>",
+                not (trace_cfg.tls.client_key and trace_cfg.tls.client_cert),
+                "mTLS not supported for trace with HTTP",
+            )
             log.debug("Configuring http trace with TLS")
             error.file_check("<RUN80171155E>", trace_cfg.tls.ca)
             exporter_kwargs["certificate_file"] = trace_cfg.tls.ca

--- a/caikit/runtime/trace.py
+++ b/caikit/runtime/trace.py
@@ -1,0 +1,130 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The trace module holds utilities for tracing runtime requests.
+"""
+# Standard
+import base64
+import os
+
+# Third Party
+import grpc
+
+# First Party
+import alog
+
+# Local
+from ..config import get_config
+from ..core.exceptions import error_handler
+
+log = alog.use_channel("TRACE")
+error = error_handler.get(log)
+
+
+# Global handle to the trace module that will be populated in configure()
+_TRACE_MODULE = None
+
+
+def configure():
+    """Configure all tracing based on config and installed packages"""
+
+    # Short circuit if not enabled
+    trace_cfg = get_config().runtime.trace
+    if not trace_cfg.enabled:
+        log.info("Trace disabled")
+        return
+
+    # Figure out which protocol is being used
+    error.value_check("<RUN85736759E>", trace_cfg.protocol in ["grpc", "http"])
+    grpc_protocol = trace_cfg.protocol == "grpc"
+
+    # Attempt to import the necessary packages
+    try:
+        # Third Party
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        # Import the right span exporter
+        if grpc_protocol:
+            # Third Party
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+        else:
+            # Third Party
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+
+    except ImportError as err:
+        log.warning(
+            "<RUN41027815W>",
+            "Cannot enable trace. You may need to `pip install caikt[runtime-trace]`: %s",
+            err,
+        )
+        return
+
+    # Populate the global module handle
+    global _TRACE_MODULE
+    _TRACE_MODULE = trace
+
+    # Configure the trace provider
+    resource = Resource(attributes={SERVICE_NAME: trace_cfg.service_name})
+    provider = TracerProvider(resource=resource)
+
+    # Set up the exporter
+    exporter_kwargs = {"endpoint": trace_cfg.endpoint}
+    if trace_cfg.tls.ca:
+        if grpc_protocol:
+            creds_kwargs = {"root_certificates": _load_tls_secret(trace_cfg.tls.ca)}
+            if trace_cfg.tls.client_key and trace_cfg.tls.client_cert:
+                log.debug("Configuring grpc trace with mTLS")
+                creds_kwargs["private_key"] = _load_tls_secret(trace_cfg.tls.client_key)
+                creds_kwargs["certificate_chain"] = _load_tls_secret(
+                    trace_cfg.tls.client_cert
+                )
+            else:
+                log.debug("Configuring grpc trace with TLS")
+            exporter_kwargs["credentials"] = grpc.ssl_channel_credentials(
+                **creds_kwargs
+            )
+        else:
+            if trace_cfg.tls.client_key and trace_cfg.tls.client_cert:
+                log.warning("mTLS not supported for trace with HTTP")
+            log.debug("Configuring http trace with TLS")
+            error.file_check("<RUN80171155E>", trace_cfg.tls.ca)
+            exporter_kwargs["certificate_file"] = trace_cfg.tls.ca
+    else:
+        log.debug("Configuring trace with insecure transport")
+        if grpc_protocol:
+            exporter_kwargs["insecure"] = True
+    exporter = OTLPSpanExporter(**exporter_kwargs)
+
+    # Set up the trace provider
+    trace.set_tracer_provider(BatchSpanProcessor(exporter))
+
+
+## Implementation Details ######################################################
+
+
+def _load_tls_secret(tls_config_val: str) -> bytes:
+    """If the config value points at a file, load it, otherwise assume it's an
+    inline string
+    """
+    if os.path.exists(tls_config_val):
+        with open(tls_config_val, "rb") as handle:
+            return handle.read()
+    return tls_config_val.encode("utf-8")

--- a/caikit/runtime/trace.py
+++ b/caikit/runtime/trace.py
@@ -15,7 +15,7 @@
 The trace module holds utilities for tracing runtime requests.
 """
 # Standard
-from typing import Union
+from typing import TYPE_CHECKING, Union
 import os
 
 # Third Party
@@ -34,6 +34,11 @@ error = error_handler.get(log)
 
 # Global handle to the trace module that will be populated in configure()
 _TRACE_MODULE = None
+
+
+if TYPE_CHECKING:
+    # Third Party
+    from opentelemetry.trace import Tracer
 
 
 def configure():

--- a/otel_tracing_requirements.txt
+++ b/otel_tracing_requirements.txt
@@ -1,7 +1,0 @@
-opentelemetry-api
-opentelemetry-sdk
-opentelemetry-exporter-otlp-proto-http 
-opentelemetry-instrumentation-flask 
-opentelemetry-instrumentation-requests
-opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-exporter-otlp = "^1.15.0"

--- a/otel_tracing_requirements.txt
+++ b/otel_tracing_requirements.txt
@@ -1,0 +1,7 @@
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http 
+opentelemetry-instrumentation-flask 
+opentelemetry-instrumentation-requests
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-exporter-otlp = "^1.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ interfaces-ts-pyspark = [
 
 # NOTE: This is "all" from the user perspective, not the dev perspective
 all = [
-    "caikit[runtime-grpc, runtime-http, runtime-client, interfaces-vision, interfaces-ts]",
+    "caikit[runtime-grpc, runtime-http, runtime-client, runtime-trace, interfaces-vision, interfaces-ts]",
 ]
 
 ## Dev Extra Sets ##

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ runtime-client = [
     "requests>=2.28.2,<3",
 ]
 
+# Needed to enable Open Telemetry tracing
+runtime-trace = [
+    "opentelemetry-sdk>=1.24.0,<2",
+    "opentelemetry-exporter-otlp>=1.24.0,<2",
+]
+
 interfaces-vision = [
     "pillow>=6.2.1,<11.0"
 ]

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -7,6 +7,7 @@ import alog
 
 # Local
 from caikit.runtime.model_management.model_manager import ModelManager
+from caikit.runtime.names import MODEL_MESH_MODEL_ID_KEY
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 
 log = alog.use_channel("TEST-FIXTURE")
@@ -39,7 +40,7 @@ class Fixtures:
             raise e
 
     @staticmethod
-    def build_context(model_id="test-any-model-id"):
+    def build_context(model_id="test-any-model-id", **metadata):
         """Build a gRPC context object containing the specified model ID
 
         Args:
@@ -54,11 +55,13 @@ class Fixtures:
         class TestContext:
             def __init__(self, model_id):
                 self.model_id = model_id
+                self.metadata = metadata
+                self.metadata[MODEL_MESH_MODEL_ID_KEY] = self.model_id
                 self.callbacks = []
                 self.canceled = False
 
             def invocation_metadata(self):
-                return [("mm-model-id", self.model_id)]
+                return list(self.metadata.items())
 
             def add_callback(self, some_function, *args, **kwargs):
                 self.callbacks.append(

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -2,6 +2,9 @@
 import os
 import shutil
 
+# Third Party
+import grpc
+
 # First Party
 import alog
 
@@ -52,13 +55,50 @@ class Fixtures:
 
         # Create a dummy class for mimicking ServicerContext invocation
         # metadata storage
-        class TestContext:
+        class TestContext(grpc.ServicerContext):
             def __init__(self, model_id):
                 self.model_id = model_id
                 self.metadata = metadata
                 self.metadata[MODEL_MESH_MODEL_ID_KEY] = self.model_id
                 self.callbacks = []
                 self.canceled = False
+
+            # Define the abstract methods to do nothing
+            def abort(self, *_, **__):
+                pass
+
+            def abort_with_status(self, *_, **__):
+                pass
+
+            def auth_context(self, *_, **__):
+                pass
+
+            def is_active(self, *_, **__):
+                pass
+
+            def peer(self, *_, **__):
+                pass
+
+            def peer_identities(self, *_, **__):
+                pass
+
+            def peer_identity_key(self, *_, **__):
+                pass
+
+            def send_initial_metadata(self, *_, **__):
+                pass
+
+            def set_code(self, *_, **__):
+                pass
+
+            def set_details(self, *_, **__):
+                pass
+
+            def set_trailing_metadata(self, *_, **__):
+                pass
+
+            def time_remaining(self, *_, **__):
+                pass
 
             def invocation_metadata(self):
                 return list(self.metadata.items())

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -38,7 +38,6 @@ from caikit.core.data_model import TrainingStatus
 from caikit.core.model_management.multi_model_finder import MultiModelFinder
 from caikit.runtime import http_server
 from caikit.runtime.http_server.http_server import StreamEventTypes
-from caikit.runtime.names import REQUEST_ID_HEADER_KEY
 from caikit.runtime.server_base import ServerThreadPool
 from tests.conftest import get_mutable_config_copy, reset_globals, temp_config
 from tests.core.helpers import MockBackend
@@ -928,12 +927,7 @@ def test_inference_trace(sample_task_model_id, open_port):
                     "inputs": {"name": "world"},
                     "model_id": sample_task_model_id,
                 }
-                request_id = "my-request"
-                response = client.post(
-                    f"/api/v1/task/sample",
-                    json=json_input,
-                    headers={REQUEST_ID_HEADER_KEY: request_id},
-                )
+                response = client.post(f"/api/v1/task/sample", json=json_input)
                 json_response = response.json()
                 assert response.status_code == 200, json_response
                 assert json_response["greeting"] == "Hello world"
@@ -946,7 +940,7 @@ def test_inference_trace(sample_task_model_id, open_port):
                         "context"
                     )
                 )
-                assert span_context.get("request_id") == request_id
+                assert span_context.get("model_id") == sample_task_model_id
 
 
 ## Info Tests ##################################################################

--- a/tests/runtime/http_server/test_http_server.py
+++ b/tests/runtime/http_server/test_http_server.py
@@ -912,35 +912,47 @@ def test_http_inference_streaming_notifies_backends_of_context(
 def test_inference_trace(sample_task_model_id, open_port):
     """Test that tracing is called when enabled"""
 
-    span_mock = mock.MagicMock()
+    class SpanMock:
+        def __init__(self):
+            self.attrs = {}
+
+        def set_attribute(self, key, val):
+            self.attrs[key] = val
+
+    span_mock = SpanMock()
     span_context_mock = mock.MagicMock()
     tracer_mock = mock.MagicMock()
     get_tracer_mock = mock.MagicMock()
+    get_trace_context = mock.MagicMock()
     tracer_mock.start_as_current_span.return_value = span_context_mock
     span_context_mock.__enter__.return_value = span_mock
     get_tracer_mock.return_value = tracer_mock
+    dummy_context = {"dummy": "context"}
+    get_trace_context.return_value = dummy_context
 
     with mock.patch("caikit.runtime.trace.get_tracer", get_tracer_mock):
-        with runtime_http_test_server(open_port) as server:
-            with client_context(server) as client:
-                json_input = {
-                    "inputs": {"name": "world"},
-                    "model_id": sample_task_model_id,
-                }
-                response = client.post(f"/api/v1/task/sample", json=json_input)
-                json_response = response.json()
-                assert response.status_code == 200, json_response
-                assert json_response["greeting"] == "Hello world"
+        with mock.patch("caikit.runtime.trace.get_trace_context", get_trace_context):
+            with runtime_http_test_server(open_port) as server:
+                with client_context(server) as client:
+                    json_input = {
+                        "inputs": {"name": "world"},
+                        "model_id": sample_task_model_id,
+                    }
+                    response = client.post(f"/api/v1/task/sample", json=json_input)
+                    json_response = response.json()
+                    assert response.status_code == 200, json_response
+                    assert json_response["greeting"] == "Hello world"
 
-                # Make sure tracing called
-                get_tracer_mock.assert_called_once()
-                tracer_mock.start_as_current_span.assert_called_once()
-                assert (
-                    span_context := tracer_mock.start_as_current_span.call_args.kwargs.get(
-                        "context"
+                    # Make sure tracing called
+                    get_tracer_mock.assert_called_once()
+                    tracer_mock.start_as_current_span.call_count == 2
+                    assert (
+                        tracer_mock.start_as_current_span.mock_calls[0].kwargs.get(
+                            "context"
+                        )
+                        is dummy_context
                     )
-                )
-                assert span_context.get("model_id") == sample_task_model_id
+                    assert span_mock.attrs.get("model_id") == sample_task_model_id
 
 
 ## Info Tests ##################################################################

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -556,8 +556,8 @@ def test_global_predict_tracing(
                 span_context_mock.__enter__.call_count == 2
 
                 # Validate some of the key attributes
-                span_mock.attrs.get("model_id") == sample_task_model_id
-                span_mock.attrs.get("task") == SampleTask
+                assert span_mock.attrs.get("model_id") == sample_task_model_id
+                assert span_mock.attrs.get("task") == SampleTask.__name__
 
                 # Make sure the context got decorated with the tracer
                 assert hasattr(context, trace._CONTEXT_TRACER_ATTR)

--- a/tests/runtime/servicers/test_global_predict_servicer_impl.py
+++ b/tests/runtime/servicers/test_global_predict_servicer_impl.py
@@ -41,7 +41,6 @@ import pytest
 from caikit.core import MODEL_MANAGER
 from caikit.interfaces.common.data_model import File
 from caikit.runtime import trace
-from caikit.runtime.names import REQUEST_ID_HEADER_KEY
 from caikit.runtime.servicers.global_predict_servicer import GlobalPredictServicer
 from caikit.runtime.types.aborted_exception import AbortedException
 from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
@@ -534,8 +533,7 @@ def test_global_predict_tracing(
         with patch("caikit.runtime.trace.get_trace_context", get_trace_context):
             with make_sample_predict_servicer(sample_inference_service) as servicer:
                 predict_class = get_inference_request(SampleTask)
-                request_id = "my-request"
-                metadata = {REQUEST_ID_HEADER_KEY: request_id}
+                metadata = {}
                 context = Fixtures.build_context(sample_task_model_id, **metadata)
                 response = servicer.Predict(
                     predict_class(sample_input=HAPPY_PATH_INPUT_DM).to_proto(),

--- a/tests/runtime/test_trace.py
+++ b/tests/runtime/test_trace.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for the trace module
+"""
+
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from typing import Optional
+from unittest import mock
+import ssl
+import sys
+import threading
+import time
+
+# Third Party
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse
+import grpc
+import pytest
+import uvicorn
+
+# Local
+from caikit.runtime import trace
+from tests.conftest import temp_config
+from tests.runtime.conftest import generate_tls_configs, open_port
+
+## Mock Collectors #############################################################
+
+
+class MockCollectorHttpServer:
+    """Mock http server implementing collection"""
+
+    def __init__(
+        self,
+        port: int,
+        cert: Optional[str] = None,
+        key: Optional[str] = None,
+        client_ca: Optional[str] = None,
+    ):
+        self.requests = []
+        self.app = FastAPI()
+
+        @self.app.post("/v1/traces")
+        def traces(request: Request):
+            self.requests.append(request)
+            return PlainTextResponse("OK")
+
+        tls_kwargs = {}
+        if cert and key:
+            tls_kwargs["ssl_keyfile"] = key
+            tls_kwargs["ssl_certfile"] = cert
+            if client_ca:
+                tls_kwargs["ssl_ca_certs"] = client_ca
+                tls_kwargs["ssl_cert_required"] = ssl.CERT_REQUIRED
+        self.server = uvicorn.Server(uvicorn.Config(self.app, port=port, **tls_kwargs))
+        self.server_thread = threading.Thread(target=self.server.run)
+
+    def start(self):
+        self.server_thread.start()
+        while not self.server.started:
+            time.sleep(1e-3)
+
+    def stop(self):
+        self.server.should_exit = True
+        self.server_thread.join()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *_, **__):
+        self.stop()
+
+
+@contextmanager
+def collector_grpc(
+    port: int,
+    cert: Optional[str] = None,
+    key: Optional[str] = None,
+    client_ca: Optional[str] = None,
+):
+    """Define and instantiate a collector grpc server
+
+    NOTE: The classes themselves are defined inline so that the imports are
+        scoped to the test
+    """
+
+    # Third Party
+    from opentelemetry.proto.collector.trace.v1 import (
+        trace_service_pb2,
+        trace_service_pb2_grpc,
+    )
+
+    class MockServicer(trace_service_pb2_grpc.TraceServiceServicer):
+        def __init__(self):
+            self.requests = []
+
+        def Export(self, request, *_, **__):
+            self.requests.append(request)
+            return trace_service_pb2.ExportTraceServiceResponse()
+
+    # Set up the servicer and server
+    servicer = MockServicer()
+    server = grpc.server(ThreadPoolExecutor(max_workers=1))
+    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(servicer, server)
+
+    # Bind to the port and start up
+    server_hname = f"[::]:{port}"
+    if cert and key:
+        tls_pair = [(key.encode("utf-8"), cert.encode("utf-8"))]
+        if client_ca:
+            creds = grpc.ssl_server_credentials(
+                tls_pair,
+                root_certificates=client_ca.encode("utf-8"),
+                require_client_auth=True,
+            )
+        else:
+            creds = grpc.ssl_server_credentials(tls_pair)
+        server.add_secure_port(server_hname, creds)
+    else:
+        server.add_insecure_port(server_hname)
+    server.start()
+
+    # Yield the servicer for checking requests
+    try:
+        yield servicer
+    finally:
+        server.stop(0)
+
+
+def maybe_inline(inline: bool, tls_file: str):
+    if not inline:
+        return tls_file
+    with open(tls_file, "r") as handle:
+        return handle.read()
+
+
+## Fixtures ####################################################################
+
+
+@pytest.fixture
+def reset_trace_imports():
+    """This fixture will cause all inline imports to be scoped to the duration
+    of the test and it will cause the trace module to revert to "unconfigured"
+    after tests complete.
+    """
+    sys_mod_copy = sys.modules.copy()
+    otel_modules = {mod for mod in sys_mod_copy if mod.startswith("opentelemetry")}
+    for mod in otel_modules:
+        del sys_mod_copy[mod]
+    with mock.patch.object(sys, "modules", sys_mod_copy):
+        with mock.patch.object(trace, "_TRACE_MODULE", None):
+            yield
+
+
+@contextmanager
+def trace_config(**kwargs):
+    with temp_config({"runtime": {"trace": kwargs}}, "merge"):
+        yield
+
+
+@pytest.fixture
+def trace_enabled_http():
+    with trace_config(
+        enabled=True, protocol="http", endpoint="http://localhost:1234/v1/traces"
+    ):
+        yield
+
+
+@pytest.fixture
+def trace_enabled_grpc():
+    with trace_config(enabled=True, protocol="grpc"):
+        yield
+
+
+@pytest.fixture
+def trace_disabled():
+    with temp_config({"runtime": {"trace": {"enabled": False}}}, "merge"):
+        yield
+
+
+@pytest.fixture
+def collector_grpc_insecure(open_port):
+    with collector_grpc(open_port) as servicer_mock:
+        with trace_config(endpoint=f"localhost:{open_port}"):
+            yield servicer_mock
+
+
+@pytest.fixture
+def collector_http_insecure(open_port):
+    with MockCollectorHttpServer(open_port) as server_mock:
+        with trace_config(endpoint=f"http://localhost:{open_port}/v1/traces"):
+            yield server_mock
+
+
+@pytest.fixture
+def reset_otel_trace_globals():
+    """https://github.com/open-telemetry/opentelemetry-python/blob/main/tests/opentelemetry-test-utils/src/opentelemetry/test/globals_test.py#L25"""
+    # Third Party
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.util._once import Once
+
+    with mock.patch.object(otel_trace, "_TRACER_PROVIDER_SET_ONCE", Once()):
+        with mock.patch.object(otel_trace, "_TRACER_PROVIDER", None):
+            yield
+
+
+## Helpers #####################################################################
+
+
+def exercise_tracer_api(tracer):
+    """Shared helper to exercise the full scope of the Tracer that we expect to
+    support
+    """
+    with tracer.start_as_current_span("foobar") as span:
+        span.set_attribute("foo", "bar")
+        span.set_attributes({"baz": "bat", "biz": 123})
+        span.add_event("something", {"key": ["val"]})
+
+        # NOTE: Just in case anyone finds this later. The `context` arg of
+        #   start_span needs to be an opentelemetry.context.Context (which is a
+        #   dict) NOT a SpanContext (which is not a dict), so you cannot call
+        #   start_span(...) with context=span.get_span_context()!
+        nested_span1 = tracer.start_span("nested1", links=[span])
+        nested_span2 = tracer.start_span("nested2", links=[span])
+        nested_span1.add_link(nested_span2.get_span_context())
+
+
+def verify_exported(mock_server):
+    """Verify that output was exported to the mock server"""
+    # Third Party
+    from opentelemetry.trace import get_tracer_provider
+
+    get_tracer_provider().force_flush()
+    assert mock_server.requests
+
+
+## Tests #######################################################################
+
+
+def test_trace_unconfigured(reset_trace_imports, trace_disabled):
+    """Test that without calling configure, all of the expected tracing
+    operations are no-ops
+    """
+    exercise_tracer_api(trace.get_tracer("test/tracer"))
+    assert "opentelemetry" not in sys.modules
+
+
+def test_trace_disabled(reset_trace_imports, trace_disabled):
+    """Test that with configure called, but trace disabled, all of the expected
+    tracing operations are no-ops
+    """
+    trace.configure()
+    exercise_tracer_api(trace.get_tracer("test/tracer"))
+    assert "opentelemetry" not in sys.modules
+
+
+def test_trace_configured_grpc(
+    reset_otel_trace_globals, trace_enabled_grpc, collector_grpc_insecure
+):
+    """Test that with tracing enabled using the grpc protocol, all of the
+    expected tracing operations are correctly configured and run
+    """
+    with trace_config(flush_on_exit=False):
+        trace.configure()
+    exercise_tracer_api(trace.get_tracer("test/tracer"))
+    assert "opentelemetry" in sys.modules
+    verify_exported(collector_grpc_insecure)
+
+
+def test_trace_configured_http(
+    reset_otel_trace_globals, trace_enabled_http, collector_http_insecure
+):
+    """Test that with tracing enabled using the http protocol, all of the
+    expected tracing operations are correctly configured and run
+    """
+    with trace_config(flush_on_exit=False):
+        trace.configure()
+    exercise_tracer_api(trace.get_tracer("test/tracer"))
+    assert "opentelemetry" in sys.modules
+    verify_exported(collector_http_insecure)
+
+
+@pytest.mark.parametrize(
+    ["mtls", "inline"],
+    [
+        (False, False),
+        (False, True),
+        (True, False),
+        (True, True),
+    ],
+)
+def test_trace_grpc_tls(
+    reset_otel_trace_globals, trace_enabled_grpc, open_port, mtls, inline
+):
+    """Test that tracing can be enabled all flavors of (m)TLS"""
+    with generate_tls_configs(
+        open_port,
+        tls=True,
+        mtls=mtls,
+        inline=True,
+    ) as tls_configs:
+        mtls_kwargs = (
+            {
+                "client_ca": maybe_inline(True, tls_configs.use_in_test.ca_cert),
+            }
+            if mtls
+            else {}
+        )
+        with collector_grpc(
+            open_port,
+            cert=tls_configs.runtime.tls.server.cert,
+            key=tls_configs.runtime.tls.server.key,
+            **mtls_kwargs,
+        ) as servicer:
+            tls_trace_cfg = {
+                "ca": maybe_inline(inline, tls_configs.use_in_test.ca_cert)
+            }
+            if mtls:
+                tls_trace_cfg["client_cert"] = maybe_inline(
+                    inline, tls_configs.use_in_test.client_cert
+                )
+                tls_trace_cfg["client_key"] = maybe_inline(
+                    inline, tls_configs.use_in_test.client_key
+                )
+            with trace_config(
+                tls=tls_trace_cfg,
+                flush_on_exit=False,
+                endpoint=f"localhost:{open_port}",
+            ):
+                trace.configure()
+            exercise_tracer_api(trace.get_tracer("test/tracer"))
+            verify_exported(servicer)


### PR DESCRIPTION
**Scope of Change**:
caikit/runtime/servicers/global_predict_servicer.py inserted with global tracer and span with attributes

**Changes requires otel sdk and other dependent pkgs to be installed**:
- [ ] this PR has been tested by locally standing up embedding model server and also deployed stand-alone jaeger to visualise traces/spans with applied attributes

CC @gabe-l-hart @gkumbhat 
