### PR TITLE
:pushpin: Disallow grpcio 1.64.0 for abstract method regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "alchemy-logging>=1.3.2,<2.0.0",
     "anytree>=2.7.0,<3.0",
     "docstring-parser>=0.14.1,<0.17.0",
-    "grpcio>=1.35.0,<2.0,!=1.55.0",
+    "grpcio>=1.35.0,<2.0,!=1.55.0,!=1.64.0",
     "ijson>=3.1.4,<3.3.0",
     "importlib-metadata>=6.8.0,<8.0.0",
     "munch>=2.5.0,<5.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

For: https://github.com/grpc/grpc/issues/36683 - after applications using `caikit` got bumped to the latest version of grpcio (1.64.0) due to the flexible version range, errors were seen/builds were broken

This assumes that `1.64.0` will be the only problematic version and any next release will contain a fix for the issue

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
