### PR TITLE
Changes metadata field to accept all types

### DIFF
--- a/caikit/interfaces/runtime/data_model/info.py
+++ b/caikit/interfaces/runtime/data_model/info.py
@@ -25,6 +25,7 @@ import alog
 
 # Local
 from caikit.core.data_model import PACKAGE_COMMON, DataObjectBase, dataobject
+from caikit.core.data_model.json_dict import JsonDict
 
 log = alog.use_channel("RUNTIMEOPS")
 
@@ -61,7 +62,7 @@ class ModelInfo(DataObjectBase):
     model_path: Annotated[str, FieldNumber(1)]
     name: Annotated[str, FieldNumber(2)]
     size: Annotated[int, FieldNumber(3)]
-    metadata: Annotated[Dict[str, str], FieldNumber(4)]
+    metadata: Annotated[JsonDict, FieldNumber(4)]
     loaded: Annotated[bool, FieldNumber(7)]
 
     # Module Information


### PR DESCRIPTION
This adds JsonDict type to metadata at ModelInfo object, so that we can have multiple types of values.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
