### PR TITLE
Remove duplicate calls to  _get_request_params in http server

### DIFF
--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -615,8 +615,6 @@ class RuntimeHTTPServer(RuntimeServerBase):
                 log.debug("In unary handler for %s for model %s", rpc.name, model_id)
                 loop = asyncio.get_running_loop()
 
-                request_params = self._get_request_params(rpc, request)
-
                 log.debug4(
                     "Sending request %s to model id %s", request_params, model_id
                 )


### PR DESCRIPTION
Remove the duplicate calls to _get_request_params in the unary input unary output handler in http server

closes #728 

**What this PR does / why we need it**:

Fix the duplicate calls to _get_request_params in the http server's unary input unary output handler.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
