### PR TITLE
Add explicit Retry Options to Remote Runtimes

### DIFF
--- a/caikit/interfaces/common/data_model/remote.py
+++ b/caikit/interfaces/common/data_model/remote.py
@@ -19,10 +19,9 @@ This file contains interfaces required to connect to Remote servers
 from dataclasses import field
 from http.client import HTTP_PORT, HTTPS_PORT
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 # First Party
-from py_to_proto.dataclass_to_proto import Dict
 import alog
 
 # Local
@@ -147,7 +146,7 @@ class ConnectionInfo(DataObjectBase):
     retries: Optional[int] = 1
     # Runtime specific retry options
     retry_options: Optional[JsonDict] = field(default_factory=dict)
-    
+
     def __post_init__(self):
         """Post init function to verify field types and set defaults"""
 
@@ -168,11 +167,11 @@ class ConnectionInfo(DataObjectBase):
         )
 
         error.type_check(
-            "<COR734224567E>", 
-            int, 
-            port=self.port, 
-            timeout=self.timeout, 
-            retries=self.retries
+            "<COR734224567E>",
+            int,
+            port=self.port,
+            timeout=self.timeout,
+            retries=self.retries,
         )
 
         if self.options:

--- a/caikit/runtime/client/remote_model_finder.py
+++ b/caikit/runtime/client/remote_model_finder.py
@@ -256,7 +256,7 @@ class RemoteModelFinder(ModelFinderBase):
         for conn in self._get_conn_candidates(model_name):
             target = f"{conn.hostname}:{conn.port}"
             options = [tuple(opt) for opt in conn.options.items()]
-            with construct_grpc_channel(target, options, conn.tls) as channel:
+            with construct_grpc_channel(target, options, conn.tls, conn.retries, conn.retry_options) as channel:
                 info_service_rpc = channel.unary_unary(
                     get_grpc_route_name(ServiceType.INFO, "GetModelsInfo"),
                     request_serializer=ModelInfoRequest.get_proto_class().SerializeToString,
@@ -313,7 +313,7 @@ class RemoteModelFinder(ModelFinderBase):
             target = (
                 f"{http_scheme}{conn.hostname}:" f"{conn.port}{MODELS_INFO_ENDPOINT}"
             )
-            session = construct_requests_session(conn.options, conn.tls, conn.timeout)
+            session = construct_requests_session(conn.options, conn.tls, conn.timeout, conn.retries, conn.retry_options)
 
             # Send HTTP Request
             try:

--- a/caikit/runtime/client/remote_model_finder.py
+++ b/caikit/runtime/client/remote_model_finder.py
@@ -256,7 +256,9 @@ class RemoteModelFinder(ModelFinderBase):
         for conn in self._get_conn_candidates(model_name):
             target = f"{conn.hostname}:{conn.port}"
             options = [tuple(opt) for opt in conn.options.items()]
-            with construct_grpc_channel(target, options, conn.tls, conn.retries, conn.retry_options) as channel:
+            with construct_grpc_channel(
+                target, options, conn.tls, conn.retries, conn.retry_options
+            ) as channel:
                 info_service_rpc = channel.unary_unary(
                     get_grpc_route_name(ServiceType.INFO, "GetModelsInfo"),
                     request_serializer=ModelInfoRequest.get_proto_class().SerializeToString,
@@ -313,7 +315,9 @@ class RemoteModelFinder(ModelFinderBase):
             target = (
                 f"{http_scheme}{conn.hostname}:" f"{conn.port}{MODELS_INFO_ENDPOINT}"
             )
-            session = construct_requests_session(conn.options, conn.tls, conn.timeout, conn.retries, conn.retry_options)
+            session = construct_requests_session(
+                conn.options, conn.tls, conn.timeout, conn.retries, conn.retry_options
+            )
 
             # Send HTTP Request
             try:

--- a/caikit/runtime/client/remote_module_base.py
+++ b/caikit/runtime/client/remote_module_base.py
@@ -438,7 +438,7 @@ class RemoteModuleBase(ModuleBase):
             options = list(self._connection.options.items())
 
             # Generate secure channel
-            channel = construct_grpc_channel(target, options, self._tls)
+            channel = construct_grpc_channel(target, options, self._tls, self._connection.retries, self._connection.retry_options)
             self._conn_channel = channel
             return self._conn_channel
 
@@ -456,7 +456,7 @@ class RemoteModuleBase(ModuleBase):
                 return self._conn_channel
 
             self._conn_channel = construct_requests_session(
-                self._connection.options, self._tls, self._connection.timeout
+                self._connection.options, self._tls, self._connection.timeout, self._connection.retries, self._connection.retry_options
             )
             return self._conn_channel
 

--- a/caikit/runtime/client/remote_module_base.py
+++ b/caikit/runtime/client/remote_module_base.py
@@ -438,7 +438,13 @@ class RemoteModuleBase(ModuleBase):
             options = list(self._connection.options.items())
 
             # Generate secure channel
-            channel = construct_grpc_channel(target, options, self._tls, self._connection.retries, self._connection.retry_options)
+            channel = construct_grpc_channel(
+                target,
+                options,
+                self._tls,
+                self._connection.retries,
+                self._connection.retry_options,
+            )
             self._conn_channel = channel
             return self._conn_channel
 
@@ -456,7 +462,11 @@ class RemoteModuleBase(ModuleBase):
                 return self._conn_channel
 
             self._conn_channel = construct_requests_session(
-                self._connection.options, self._tls, self._connection.timeout, self._connection.retries, self._connection.retry_options
+                self._connection.options,
+                self._tls,
+                self._connection.timeout,
+                self._connection.retries,
+                self._connection.retry_options,
             )
             return self._conn_channel
 

--- a/caikit/runtime/client/utils.py
+++ b/caikit/runtime/client/utils.py
@@ -36,7 +36,21 @@ def construct_grpc_channel(
     retries: Optional[int] = None,
     retry_options: Optional[Dict[str, str]] = None,
 ) -> grpc.Channel:
-    """Helper function to construct a grpc Channel with the given TLS config"""
+    """Helper function to construct a grpc Channel with the given TLS config
+
+    Args:
+        target (str): The target hostname
+        options (Optional[List[Tuple[str, str]]], optional): List of tuples representing GRPC
+            options. Defaults to None.
+        tls (Optional[ConnectionTlsInfo], optional): The TLS information for this channel.
+            Defaults to None.
+        retries (Optional[int], optional): The max number of retries to attempt. Defaults to None.
+        retry_options (Optional[Dict[str, str]], optional): Dictionary to override fields
+            in the GRPC retry service config. Defaults to None.
+
+    Returns:
+        grpc.Channel: The constructed channel
+    """
     # Add retry option if one was provided
     if retries and retries > 1:
         options.append(("grpc.enable_retries", 1))
@@ -94,6 +108,18 @@ def construct_requests_session(
 ) -> Session:
     """Helper function to construct a requests Session object with the given TLS
     config
+
+    Args:
+        options (Optional[Dict[str, str]], optional): Dictionary of request kwargs to pass to
+            session creation. Defaults to None.
+        tls (Optional[ConnectionTlsInfo], optional): The TLS information for this session.
+            Defaults to None.
+        retries (Optional[int], optional): The max number of retries to attempt. Defaults to None.
+        retry_options (Optional[Dict[str, str]], optional): Dictionary to override kwargs passed
+            to the Retry object construction
+
+    Returns:
+        Session: _description_
     """
     session = Session()
     session.headers["Content-type"] = "application/json"

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -57,10 +57,15 @@ class SampleModule(caikit.core.ModuleBase):
     ) -> SampleOutputType:
         """
         Args:
-            sample_input (sample_lib.data_model.SampleInputType): the input
-
+            sample_input (SampleInputType): the input
+            throw (bool, optional): If this request should throw an error. Defaults to False.
+            error (Optional[str], optional): The error string to throw. Defaults to None.
+            request_id (Optional[str], optional): The request id for tracking the end-user identity
+                for throw_first_num_requests. Defaults to None.
+            throw_first_num_requests (Optional[int], optional): How many requests to throw an error
+                for before being successful. Defaults to None.
         Returns:
-            sample_lib.data_model.SampleOutputType: The output
+            SampleOutputType: The output
         """
         if throw:
             self._raise_error(error)

--- a/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
+++ b/tests/fixtures/sample_lib/modules/sample_task/sample_implementation.py
@@ -2,7 +2,7 @@
 A sample module for sample things!
 """
 # Standard
-from typing import Iterable, List, Optional, Union, Dict
+from typing import Dict, Iterable, List, Optional, Union
 import os
 import time
 
@@ -64,16 +64,20 @@ class SampleModule(caikit.core.ModuleBase):
         """
         if throw:
             self._raise_error(error)
-            
+
         if throw_first_num_requests and not request_id:
-            self._raise_error("throw_first_num_requests requires providing a request_id")
+            self._raise_error(
+                "throw_first_num_requests requires providing a request_id"
+            )
         # If a throw_first_num_requests was provided  then increment the tracker and raise an exception
         # until the number of requests is high enough
         if throw_first_num_requests:
-            self.request_attempt_tracker[request_id] = self.request_attempt_tracker.get(request_id, 0) + 1
+            self.request_attempt_tracker[request_id] = (
+                self.request_attempt_tracker.get(request_id, 0) + 1
+            )
             if self.request_attempt_tracker[request_id] <= throw_first_num_requests:
                 self._raise_error(error)
-            
+
         assert isinstance(sample_input, SampleInputType)
         if sample_input.name == self.POISON_PILL_NAME:
             raise ValueError(f"{self.POISON_PILL_NAME} is not allowed!")

--- a/tests/runtime/client/test_remote_model_initializer.py
+++ b/tests/runtime/client/test_remote_model_initializer.py
@@ -473,7 +473,6 @@ def test_remote_initializer_exception_handling(
                 )
 
 
-
 @pytest.mark.parametrize("protocol", ["grpc", "http"])
 def test_remote_initializer_retry(sample_task_model_id, open_port, protocol):
     """Test to ensure RemoteModule Initializer works for insecure connections"""
@@ -487,7 +486,7 @@ def test_remote_initializer_retry(sample_task_model_id, open_port, protocol):
         retry_options["initialBackoff"] = "0s"
     elif protocol == "http":
         retry_options["raise_on_redirect"] = True
-        
+
     # Construct Remote Module Config with 3 retries
     connection_info = ConnectionInfo(hostname="localhost", port=open_port, retries=3)
     remote_config = RemoteModuleConfig.load_from_module(
@@ -507,11 +506,18 @@ def test_remote_initializer_retry(sample_task_model_id, open_port, protocol):
         assert isinstance(remote_model, ModuleBase)
 
         # Run RemoteModule Request and ensure that even though 2 requests fail the 3rd succeeds and the result is returned
-        model_result = remote_model.run(SampleInputType(name="Test"),  request_id=random_test_id(), throw_first_num_requests=2)
+        model_result = remote_model.run(
+            SampleInputType(name="Test"),
+            request_id=random_test_id(),
+            throw_first_num_requests=2,
+        )
         assert isinstance(model_result, SampleOutputType)
         assert model_result.greeting == "Hello Test"
-        
+
         # Run RemoteModule and ensure an exception is still raised after the number of retries maxes out
         with pytest.raises(CaikitRuntimeException):
-            model_result = remote_model.run(SampleInputType(name="Test"),  request_id=random_test_id(), throw_first_num_requests=5)
-        
+            model_result = remote_model.run(
+                SampleInputType(name="Test"),
+                request_id=random_test_id(),
+                throw_first_num_requests=5,
+            )

--- a/tests/runtime/client/test_remote_model_initializer.py
+++ b/tests/runtime/client/test_remote_model_initializer.py
@@ -471,3 +471,47 @@ def test_remote_initializer_exception_handling(
                         [SampleInputType(name="Test")]
                     )
                 )
+
+
+
+@pytest.mark.parametrize("protocol", ["grpc", "http"])
+def test_remote_initializer_retry(sample_task_model_id, open_port, protocol):
+    """Test to ensure RemoteModule Initializer works for insecure connections"""
+    local_module_class = (
+        ModelManager.get_instance().retrieve_model(sample_task_model_id).__class__
+    )
+
+    # Add custom retry options to ensure they're correctly applied
+    retry_options = {}
+    if protocol == "grpc":
+        retry_options["initialBackoff"] = "0s"
+    elif protocol == "http":
+        retry_options["raise_on_redirect"] = True
+        
+    # Construct Remote Module Config with 3 retries
+    connection_info = ConnectionInfo(hostname="localhost", port=open_port, retries=3)
+    remote_config = RemoteModuleConfig.load_from_module(
+        local_module_class,
+        connection_info,
+        protocol,
+        MODEL_MESH_MODEL_ID_KEY,
+        sample_task_model_id,
+    )
+    # Set random module_id so tests don't conflict
+    remote_config.module_id = random_test_id()
+
+    with runtime_test_server(open_port, protocol=protocol):
+        # Construct initializer and RemoteModule
+        remote_initializer = RemoteModelInitializer(Config({}), "test")
+        remote_model = remote_initializer.init(remote_config)
+        assert isinstance(remote_model, ModuleBase)
+
+        # Run RemoteModule Request and ensure that even though 2 requests fail the 3rd succeeds and the result is returned
+        model_result = remote_model.run(SampleInputType(name="Test"),  request_id=random_test_id(), throw_first_num_requests=2)
+        assert isinstance(model_result, SampleOutputType)
+        assert model_result.greeting == "Hello Test"
+        
+        # Run RemoteModule and ensure an exception is still raised after the number of retries maxes out
+        with pytest.raises(CaikitRuntimeException):
+            model_result = remote_model.run(SampleInputType(name="Test"),  request_id=random_test_id(), throw_first_num_requests=5)
+        


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds support for retrying Remote inference requests. This functionality could be achieved by messing with the `options` arg but this new system is more explicit. The current defaults retain the existing functionality

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
