### PR TITLE
Module backend context update

### DIFF
--- a/caikit/core/data_model/runtime_context.py
+++ b/caikit/core/data_model/runtime_context.py
@@ -12,8 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Forward core data model context here to interfaces
-"""
+Typing constant for the Runtime Context
 
-# Local
-from ....core.data_model.runtime_context import RuntimeServerContextType
+While caikit.core is not directly knowledgeable of caikit.interfaces or
+caikit.runtime, there are several functions within the core that expose the
+option to optionally handle context information when being called inside of a
+runtime request handler. This forward-declaration allows those methods to use a
+consistent type that derived classes would use directly.
+"""
+# Standard
+from typing import Union
+
+RuntimeServerContextType = Union[
+    "grpc.ServicerContext", "fastapi.Request"  # noqa: F821
+]

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -24,6 +24,9 @@ import abc
 # First Party
 import aconfig
 
+# Local
+from ..data_model.runtime_context import RuntimeServerContextType
+
 
 class BackendBase(abc.ABC):
     """Interface for creating configuration setup for backends"""
@@ -66,3 +69,21 @@ class BackendBase(abc.ABC):
     def start_lock(self):
         with self._start_lock:
             yield
+
+    def handle_runtime_context(
+        self,
+        model_id: str,
+        runtime_context: RuntimeServerContextType,
+    ):
+        """Update backend state for the given model based on a runtime request.
+
+        Some backends may need to handle runtime context information for the
+        target model in order to correctly configure the backend before finding
+        and loading the model. By default, this is a No-Op.
+
+        Args:
+            model_id (str): The unique ID of the model that is referenced by the
+                runtime context
+            runtime_context (RuntimeServerContextType): The context for the
+                given runtime request
+        """

--- a/caikit/core/module_backends/base.py
+++ b/caikit/core/module_backends/base.py
@@ -70,7 +70,7 @@ class BackendBase(abc.ABC):
         with self._start_lock:
             yield
 
-    def handle_runtime_context(
+    def handle_runtime_context(  # noqa: B027
         self,
         model_id: str,
         runtime_context: RuntimeServerContextType,

--- a/caikit/interfaces/runtime/data_model/context.py
+++ b/caikit/interfaces/runtime/data_model/context.py
@@ -16,4 +16,4 @@ Forward core data model context here to interfaces
 """
 
 # Local
-from ....core.data_model.runtime_context import RuntimeServerContextType
+from ....core.data_model.runtime_context import RuntimeServerContextType  # noqa: F401

--- a/caikit/runtime/http_server/http_server.py
+++ b/caikit/runtime/http_server/http_server.py
@@ -632,6 +632,13 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     "Sending request %s to model id %s", request_params, model_id
                 )
 
+                # After fetching the model_id from the request, notify module
+                # backends of the request context which may influence the lazy
+                # initialization logic.
+                self.global_predict_servicer.notify_backends_with_context(
+                    model_id, context
+                )
+
                 log.debug("In unary handler for %s for model %s", rpc.name, model_id)
                 loop = asyncio.get_running_loop()
 
@@ -701,6 +708,13 @@ class RuntimeHTTPServer(RuntimeServerBase):
                     model_id = self._get_model_id(request)
                     log.debug4(
                         "Sending request %s to model id %s", request_params, model_id
+                    )
+
+                    # After fetching the model_id from the request, notify
+                    # module backends of the request context which may influence
+                    # the lazy initialization logic.
+                    self.global_predict_servicer.notify_backends_with_context(
+                        model_id, context
                     )
 
                     aborter_context = (

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -43,6 +43,7 @@ class MockBackend(BackendBase):
     def __init__(self, config=...) -> None:
         super().__init__(config)
         self._started = False
+        self.runtime_contexts = {}
 
     def start(self):
         self._started = True
@@ -52,6 +53,9 @@ class MockBackend(BackendBase):
 
     def stop(self):
         self._started = False
+
+    def handle_runtime_context(self, model_id, runtime_context):
+        self.runtime_contexts[model_id] = runtime_context
 
 
 backend_types.register_backend_type(MockBackend)

--- a/tests/core/module_backends/test_module_backend_base.py
+++ b/tests/core/module_backends/test_module_backend_base.py
@@ -1,0 +1,64 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for default functionality in the BackendBase
+"""
+
+# Third Party
+import pytest
+
+# Local
+from caikit.core.module_backends.base import BackendBase
+from tests.core.helpers import MockBackend
+
+
+def test_backend_base_is_abstract():
+    """Make sure the class is abstract and can't be instantiated with missing
+    implementations
+    """
+
+    class IntermediateBase(BackendBase):
+        def register_config(self, config):
+            pass
+
+    with pytest.raises(TypeError):
+        IntermediateBase()
+
+
+def test_handle_runtime_context():
+    """Make sure the handle_runtime_context implementation does nothing by
+    default, but can be overridden
+    """
+
+    class Derived(BackendBase):
+        backend_type = "TEST_DERIVED"
+
+        def register_config(self, config):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    # No-op default implementation
+    model_id = "foo"
+    ctx = "dummy context"
+    be1 = Derived()
+    be1.handle_runtime_context(model_id, ctx)
+
+    # Derived with real implementation
+    be2 = MockBackend()
+    be2.handle_runtime_context(model_id, ctx)
+    assert be2.runtime_contexts[model_id] is ctx

--- a/tests/core/test_model_manager.py
+++ b/tests/core/test_model_manager.py
@@ -450,6 +450,8 @@ def test_non_local_supported_backend(reset_globals):
         dummy_model_path = os.path.join(TEST_DATA_PATH, DUMMY_BACKEND_MODEL_NAME)
         model = caikit.core.load(dummy_model_path)
         assert isinstance(model, DummyBaz)
+        assert len(backends := caikit.core.MODEL_MANAGER.get_module_backends()) == 1
+        assert isinstance(backends[0], MockBackend2)
 
 
 def test_load_must_return_model():


### PR DESCRIPTION
**What this PR does / why we need it**:

The [caikit.core.module_backends](https://github.com/caikit/caikit/blob/main/docs/adrs/018-shared-backends.md) are designed to allow individual models to be executed in multiple ways, including proxying to remote services (e.g. [caikit-tgis-backend](https://github.com/caikit/caikit-tgis-backend)).

When a backend performs remote network operations, it may need to be aware of meta-content in runtime request headers (e.g. [x-route-info](https://github.com/caikit/caikit-nlp/pull/363)). Furthermore, a backend may be used during lazy model discovery (e.g. [TGISAutoFinder](https://github.com/caikit/caikit-nlp/blob/main/caikit_nlp/model_management/tgis_auto_finder.py)).

This combination of backend functionality means that the backend needs to be made aware of the server context _before_ attempting to initialize the model. To accomplish this, this PR adds the following:

* Add `handle_runtime_context` to `caikit.core.module_backends.base.BackendBase` which can be overridden by derived backends
* Add `caikit.core.MODEL_MANAGER.get_module_backends` which exposes an easy way to get at the configured module backends
* In `GlobalPredictServicer` add `notify_backends_with_context` to call `handle_runtime_context` on all configured backends found using `MODEL_MANAGER.get_module_backends()`
* Call `notify_backends_with_context` before calls to `retrieve_model` in both `GlobalPredictServicer.Predict` (the central `grpc` request handler) and the `http_server` unary and stream handlers.

**Special notes for your reviewer**:

This PR does NOT fix the situation with `TGISAutoFinder` + `TGISBackend` yet. To support lazy auto finding for TGIS models with `x-route-info`, we will need to implement `TGISBackend.handle_runtime_context` to perform similar logic to the handling of `x-route-info` in `caikit-nlp`. This will be a change of responsibility with some strange version compatibility implications (do we remove the `x-route-info` parsing from `caikit-nlp`?).

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
