### PR TITLE
Use the write_modules_json flag

### DIFF
--- a/caikit/runtime/dump_services.py
+++ b/caikit/runtime/dump_services.py
@@ -58,7 +58,7 @@ def dump_grpc_services(
         consolidate (bool): Whether or not to consolidate the generated protos
             by package
     """
-    service_packages = _get_grpc_service_packages()
+    service_packages = _get_grpc_service_packages(write_modules_file)
     if not consolidate:
         log.info(
             "Dumping raw service and data model protos without package consolidation"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

A previous PR [linked](https://github.com/caikit/caikit/commit/05895f374c83a7ebfc325281aac36820e4f6f6d5#) removed the usage of the `write_modules_json` flag in `dump_grpc_services` function. This breaks one of the libraries that rely on using `python3 -m caikit.runtime.dump_services /app/protos --write-modules-json` to have a `modules.json` output. This PR adds that flag back in

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
