### PR TITLE
Update Pydantic  Wrapper to support Pydantic 2.8

### DIFF
--- a/caikit/runtime/http_server/pydantic_wrapper.py
+++ b/caikit/runtime/http_server/pydantic_wrapper.py
@@ -162,7 +162,7 @@ def dataobject_to_pydantic(dm_class: Type[DataBase]) -> Type[pydantic.BaseModel]
     # are set correctly. This explicitly sets the name of the pydantic class to the
     # name of the grpc buffer.
     pydantic_model = pydantic.create_model(
-        __model_name=dm_class.get_proto_class().DESCRIPTOR.full_name,
+        dm_class.get_proto_class().DESCRIPTOR.full_name,
         __config__=pydantic_model_config,
         **field_mapping,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ runtime-grpc = [
 
 runtime-http = [
     "fastapi[all]>=0.100,<1",
+    "pydantic>=2.8.0,<3",
     "requests>=2.28.2,<3",
     "sse-starlette>=1.6.1,<3",
     "typing_extensions>=4.12.0,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,6 @@ runtime-http = [
     "requests>=2.28.2,<3",
     "sse-starlette>=1.6.1,<3",
     "typing_extensions>=4.12.0,<5",
-
-    # Overriding pydantic because of API changes
-    "pydantic<=2.7.4",
 ]
 
 # This is only required for HTTP clients


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Pydantic 2.8 changed some arg names  of `pydantic.create_model`. This PR updates caikit to use the new names and set a bound for the caikit version

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
