### PR TITLE
Fix Logging Bug in Abortable Context

### DIFF
--- a/caikit/runtime/work_management/abortable_context.py
+++ b/caikit/runtime/work_management/abortable_context.py
@@ -114,7 +114,7 @@ class ThreadInterrupter:
         thread_id = self._context_thread_map.get(context_id, None)
 
         if thread_id:
-            log.debug("Interrupting thread id: ", thread_id)
+            log.debug("Interrupting thread id: %s", thread_id)
             # This raises an AbortedException asynchronously in the target thread. (We can't just
             # use raise, because this thread is the ThreadInterrupter's watch thread).
             # The exception will only be raised once the target thread regains control of the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes a logging bug in the Abortable Context code where there wasn't a correct log format:
```
2024-08-07T16:35:07.510367 [REQUEST-ABOR:DBUG:140465865261056] <RUN81824293> Client disconnected, terminating action
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/root/git/watson_doc_understanding/venv/lib/python3.11/site-packages/alog/alog.py", line 268, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/lib/python3.11/threading.py", line 1002, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/root/git/watson_doc_understanding/venv/lib/python3.11/site-packages/caikit/runtime/work_management/abortable_context.py", line 108, in _watch_loop
    self._kill_thread(context_id)
  File "/root/git/watson_doc_understanding/venv/lib/python3.11/site-packages/caikit/runtime/work_management/abortable_context.py", line 117, in _kill_thread
    log.debug("Interrupting thread id: ", thread_id)
  File "/root/git/watson_doc_understanding/venv/lib/python3.11/site-packages/alog/alog.py", line 450, in <lambda>
    lambda self, arg_one, *args, **kwargs: _log_with_code_method_override(
  File "/root/git/watson_doc_understanding/venv/lib/python3.11/site-packages/alog/alog.py", line 443, in _log_with_code_method_override
    self.log(value, arg_one, *args, **kwargs)
Message: 'Interrupting thread id: '
Arguments: (140449289254464,)
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
