### PR TITLE
Fix Failed Loaded Modules being considered Ready

### DIFF
--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -124,9 +124,10 @@ class LoadedModel:  # pylint: disable=too-many-instance-attributes
         @param required_instance (bool): If true, require that the model has loaded successfully
         
         @returns loaded (bool): Whether or not the model is finished loading
-        if require_instance:
-            return bool(self._model)
-        return bool(self._model or self._caikit_model_future.done())
+        return (
+            bool(self._model) or
+            (not require_instance and self._caikit_model_future.done())
+        )
 
     def wait(self):
         if self._model is None:

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -118,7 +118,11 @@ class LoadedModel:  # pylint: disable=too-many-instance-attributes
         self.wait()
         return self._model
 
-    def loaded(self) -> bool:
+    def loaded(self, require_instance: bool = False) -> bool:
+        # If require_instance is true then require that the loaded model has a constructed instance
+        # attached
+        if require_instance:
+            return bool(self._model)
         return bool(self._model or self._caikit_model_future.done())
 
     def wait(self):

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -119,8 +119,11 @@ class LoadedModel:  # pylint: disable=too-many-instance-attributes
         return self._model
 
     def loaded(self, require_instance: bool = False) -> bool:
-        # If require_instance is true then require that the loaded model has a constructed instance
-        # attached
+        """Determine if the model is has finished loading
+        
+        @param required_instance (bool): If true, require that the model has loaded successfully
+        
+        @returns loaded (bool): Whether or not the model is finished loading
         if require_instance:
             return bool(self._model)
         return bool(self._model or self._caikit_model_future.done())

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -118,16 +118,13 @@ class LoadedModel:  # pylint: disable=too-many-instance-attributes
         self.wait()
         return self._model
 
-    def loaded(self, require_instance: bool = False) -> bool:
-        """Determine if the model is has finished loading
-        
-        @param required_instance (bool): If true, require that the model has loaded successfully
-        
-        @returns loaded (bool): Whether or not the model is finished loading
-        return (
-            bool(self._model) or
-            (not require_instance and self._caikit_model_future.done())
-        )
+    def loaded(self) -> bool:
+        """Return if a model load job has resulted in a local instance
+
+        Returns:
+            bool: If a local model instance is available
+        """
+        return bool(self._model)
 
     def wait(self):
         if self._model is None:

--- a/caikit/runtime/model_management/loaded_model.py
+++ b/caikit/runtime/model_management/loaded_model.py
@@ -118,6 +118,14 @@ class LoadedModel:  # pylint: disable=too-many-instance-attributes
         self.wait()
         return self._model
 
+    def loading(self) -> bool:
+        """Return if a model load job has completed. The model job might have failed
+
+        Returns:
+            bool: If a local model job is still running
+        """
+        return not bool(self._caikit_model_future.done())
+
     def loaded(self) -> bool:
         """Return if a model load job has resulted in a local instance
 

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -101,7 +101,7 @@ class InfoServicer:
         response = ModelInfoResponse(models=[])
         for name, loaded_module in loaded_model_list:
             # Skip models that haven't been loaded yet or don't have a local instance tied
-            if loaded_module.loaded(require_instance=True):
+            if loaded_module.loaded():
                 model_instance = loaded_module.model()
                 response.models.append(
                     ModelInfo(

--- a/caikit/runtime/servicers/info_servicer.py
+++ b/caikit/runtime/servicers/info_servicer.py
@@ -100,8 +100,8 @@ class InfoServicer:
         # Get all loaded models
         response = ModelInfoResponse(models=[])
         for name, loaded_module in loaded_model_list:
-            # Skip models that haven't been loaded yet
-            if loaded_module.loaded():
+            # Skip models that haven't been loaded yet or don't have a local instance tied
+            if loaded_module.loaded(require_instance=True):
                 model_instance = loaded_module.model()
                 response.models.append(
                     ModelInfo(

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -395,8 +395,8 @@ def test_load_model_loaded_status(model_loader):
         release_event.set()
         loaded_model._caikit_model_future.result()
 
-        # It is "loaded" even if .model() has not been called
-        assert loaded_model.loaded()
+        # It is done "loading" even if .model() has not been called
+        assert not loaded_model.loading()
         assert loaded_model._model is None
 
         # After calling .model() it's also loaded

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -126,6 +126,7 @@ def test_load_invalid_model_error_response(model_loader):
     assert model_id in context.value.message
     assert not loaded_model.loaded()
 
+
 def test_it_can_load_more_than_one_model(model_loader):
     """Make sure we can load multiple models without side effects"""
     # TODO: change test to load multiple models

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -116,13 +116,16 @@ def test_load_invalid_model_error_response(model_loader):
     """Test load invalid model error response"""
     model_id = random_test_id()
     with pytest.raises(CaikitRuntimeException) as context:
-        model_loader.load_model(
+        loaded_model = model_loader.load_model(
             model_id=model_id,
             local_model_path=Fixtures.get_bad_model_archive_path(),
             model_type="not_real",
-        ).wait()
+        )
+        loaded_model.wait()
     assert context.value.status_code == grpc.StatusCode.NOT_FOUND
     assert model_id in context.value.message
+    assert loaded_model.loaded()
+    assert not loaded_model.loaded(require_instance=True)
 
 
 def test_it_can_load_more_than_one_model(model_loader):

--- a/tests/runtime/model_management/test_model_loader.py
+++ b/tests/runtime/model_management/test_model_loader.py
@@ -124,9 +124,7 @@ def test_load_invalid_model_error_response(model_loader):
         loaded_model.wait()
     assert context.value.status_code == grpc.StatusCode.NOT_FOUND
     assert model_id in context.value.message
-    assert loaded_model.loaded()
-    assert not loaded_model.loaded(require_instance=True)
-
+    assert not loaded_model.loaded()
 
 def test_it_can_load_more_than_one_model(model_loader):
     """Make sure we can load multiple models without side effects"""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
There is a bug in Caikit when a model failed to load but its `LoadedModel` instance is still marked as "loaded" because the `loaded()` check only considers if the future finished not if the model is actually loaded. This PR fixes this by adding an additional parameter `require_instance` which ensures that a local instance is actually available. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
