### PR TITLE
Propigate Exceptions to Log Handlers

### DIFF
--- a/caikit/core/exceptions/error_handler.py
+++ b/caikit/core/exceptions/error_handler.py
@@ -89,7 +89,9 @@ class ErrorHandler:
             < caikit_config.max_exception_log_messages
         ):
             self.log_chan.error(
-                log_code, "exception raised: {}".format(repr(exception))
+                log_code,
+                "exception raised: {}".format(repr(exception)),
+                exc_info=exception,
             )
 
         # if at the limit omit one message stating that we will no longer log
@@ -102,6 +104,7 @@ class ErrorHandler:
                 "reached MAX_EXCEPTION_LOG_MESSAGES of `{}`, will no log exception `{}`".format(
                     caikit_config.max_exception_log_messages, repr(exception)
                 ),
+                exc_info=exception,
             )
 
     def log_raise(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes a visual bug where `error_handler.log_raise` messages would not be present in the `exception` field of the json logging e.g.

Old

```json
{"channel": "PROCESS", "exception": "", "level": "error", "message": "<code> Error occurred when processing.", "num_indent": 0, "thread_id": 123145628893184, "timestamp": "2024-09-11T16:21:18.765035"}
```

New

```json
{"channel":"DOCPROCESSOR","exception":"Traceback (most recent call last):\n  File /caikit/caikit/runtime/client/remote_module_base.py, line 417, in _request_via_grpc\n    response = service_rpc(grpc_request, **request_kwargs)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File /lib/python3.11/site-packages/grpc/_channel.py, line 1160, in __call__\n    return _end_unary_response_blocking(state, call, False, None)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File /lib/python3.11/site-packages/grpc/_channel.py, line 1003, in _end_unary_response_blocking\n    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\ngrpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.INVALID_ARGUMENT\n\tdetails = '\n\tdebug_error_string = UNKNOWN:Error received from peer  {created_time:2024-09-11T12:21:18.76159-04:00, grpc_status:3, grpc_message:\\'}\n>\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File /workflows/processor/processor.py, line 405, in run\n    prediction = self.process.run(\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File /caikit/caikit/runtime/client/remote_module_base.py, line 155, in infer_func\n    return self.remote_method_request(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File /caikit_utils/model_shim.py, line 57, in remote_method_request\n    raise e\n  File /caikit_utils/model_shim.py, line 52, in remote_method_request\n    return super().remote_method_request(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File /caikit/caikit/runtime/client/remote_module_base.py, line 181, in remote_method_request\n    return self._request_via_grpc(method, service_type, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File /caikit/caikit/runtime/client/remote_module_base.py, line 419, in _request_via_grpc\n    raise CaikitRuntimeException(\ncaikit.runtime.types.caikit_runtime_exception.CaikitRuntimeException: Error received from GRPC request","level":"error","message":"<WDU72581349> Error occurred when processing the document.","num_indent":0,"thread_id":123145628893184,"timestamp":"2024-09-11T16:21:18.765035"}
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
