### PR TITLE
Fix bug in job predictor when model_path is folder

### DIFF
--- a/caikit/core/model_management/local_job_base.py
+++ b/caikit/core/model_management/local_job_base.py
@@ -213,13 +213,11 @@ class LocalJobBase(JobBase):
         def _delete_result(self):
             """Helper function to clear out the result when purging"""
 
-            if self.save_path:
-                save_pathlib = Path(self.save_path)
-                if save_pathlib.exists():
-                    if save_pathlib.is_file():
-                        save_pathlib.unlink(missing_ok=True)
-                    else:
-                        shutil.rmtree(save_pathlib, ignore_errors=True)
+            if self.save_path and (save_pathlib := Path(self.save_path).exists():
+                if save_pathlib.is_file():
+                    save_pathlib.unlink(missing_ok=True)
+                else:
+                    shutil.rmtree(save_pathlib, ignore_errors=True)
 
         def _make_background_info(
             self, status: JobStatus, errors: Optional[List[Exception]] = None

--- a/caikit/core/model_management/local_job_base.py
+++ b/caikit/core/model_management/local_job_base.py
@@ -213,7 +213,7 @@ class LocalJobBase(JobBase):
         def _delete_result(self):
             """Helper function to clear out the result when purging"""
 
-            if self.save_path and (save_pathlib := Path(self.save_path)) and save_pathlib.exists():
+            if self.save_path and (save_pathlib := Path(self.save_path)).exists():
                 if save_pathlib.is_file():
                     save_pathlib.unlink(missing_ok=True)
                 else:

--- a/caikit/core/model_management/local_job_base.py
+++ b/caikit/core/model_management/local_job_base.py
@@ -213,7 +213,7 @@ class LocalJobBase(JobBase):
         def _delete_result(self):
             """Helper function to clear out the result when purging"""
 
-            if self.save_path and (save_pathlib := Path(self.save_path).exists():
+            if self.save_path and (save_pathlib := Path(self.save_path)) and save_pathlib.exists():
                 if save_pathlib.is_file():
                     save_pathlib.unlink(missing_ok=True)
                 else:

--- a/caikit/core/model_management/local_job_base.py
+++ b/caikit/core/model_management/local_job_base.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, Iterable, List, Optional, Type, Union
 import abc
 import os
 import re
+import shutil
 import threading
 import uuid
 
@@ -211,8 +212,14 @@ class LocalJobBase(JobBase):
         ## Impl ##
         def _delete_result(self):
             """Helper function to clear out the result when purging"""
-            if self.save_path and Path(self.save_path).exists():
-                Path(self.save_path).unlink(missing_ok=True)
+
+            if self.save_path:
+                save_pathlib = Path(self.save_path)
+                if save_pathlib.exists():
+                    if save_pathlib.is_file():
+                        save_pathlib.unlink(missing_ok=True)
+                    else:
+                        shutil.rmtree(save_pathlib, ignore_errors=True)
 
         def _make_background_info(
             self, status: JobStatus, errors: Optional[List[Exception]] = None

--- a/tests/core/model_management/test_local_model_trainer.py
+++ b/tests/core/model_management/test_local_model_trainer.py
@@ -172,6 +172,26 @@ def test_save_with_id_and_model_name(trainer_type_cfg, save_path):
     assert os.path.exists(model_future.save_path)
 
 
+def test_save_and_cleanup(trainer_type_cfg, save_path):
+    """Test that saving with the training id and model name
+    correctly injects the ID and name in the save path
+    """
+
+    trainer_type_cfg["retention_duration"] = "0s"
+    trainer = local_trainer(**trainer_type_cfg)
+    model_future = trainer.train(
+        SampleModule,
+        training_data=DataStream.from_iterable([]),
+        save_path=save_path,
+    )
+    model_future.wait()
+
+    # Force purge of futures to test
+    trainer._purge_old_futures()
+
+    assert not os.path.exists(model_future.save_path)
+
+
 def test_save_with_model_name(trainer_type_cfg, save_path):
     """Test that saving with the model name correctly
     injects the model name in the save path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This bug fixes a bug in the local model trainer where old models couldn't be purged 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
