### PR TITLE
Set Python version to 3.12 in publish action

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -36,8 +36,6 @@ jobs:
             tox: 'py311'
           - setup: '3.12'
             tox: 'py312'
-          - setup: '3.13'
-            tox: 'py313'
           # Special matrix entry to ensure core tests pass without optional deps
           - setup: '3.8'
             tox: 'core'

--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -34,6 +34,10 @@ jobs:
             tox: 'py310'
           - setup: '3.11'
             tox: 'py311'
+          - setup: '3.12'
+            tox: 'py312'
+          - setup: '3.13'
+            tox: 'py313'
           # Special matrix entry to ensure core tests pass without optional deps
           - setup: '3.8'
             tox: 'core'

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
       - name: Build and check package
         run: |
           pip install tox


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
With v0.28.0 tag Github action to publish the wheel on Pypi is failing with following error :
```
CMake Error at CMakeLists.txt:268 (find_package):
  By not providing "FindArrow.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Arrow", but
  CMake did not find one.

  Could not find a package configuration file provided by "Arrow" with any of
  the following names:

    ArrowConfig.cmake
    arrow-config.cmake
```

Python 3.13.3 is the new Stable release which is automatically picked by Setup Python Step(`actions/setup-python@v3`). Many Python packages (like pyarrow, pandas, and numpy) are still not support it. With this PR I had hardcode the Python version to `3.12`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
