### PR TITLE
replace removed class/function MessageFactory().GetPrototype()

### DIFF
--- a/caikit/core/data_model/json_dict.py
+++ b/caikit/core/data_model/json_dict.py
@@ -145,4 +145,4 @@ def _get_message_class(
     """
     if hasattr(message_factory, "GetMessageClass"):
         return message_factory.GetMessageClass(desc)  # pragma: no cover
-    return message_factory.MessageFactory().GetPrototype(desc)  # pragma: no cover
+    return message_factory.GetMessageClass(desc)  # pragma: no cover

--- a/caikit/core/data_model/json_dict.py
+++ b/caikit/core/data_model/json_dict.py
@@ -143,6 +143,4 @@ def _get_message_class(
     """Helper to get the concrete protobuf class from a descriptor. This
     supports compatibility between protobuf 3.X and 4.X
     """
-    if hasattr(message_factory, "GetMessageClass"):
-        return message_factory.GetMessageClass(desc)  # pragma: no cover
     return message_factory.GetMessageClass(desc)  # pragma: no cover


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The class MessageFactory() was previously deprecated in protobuf and has been removed entirely in new versions.  This PR replaces the use of MessageFactory().GetPrototype() with the newer GetMessageClass(), which should be a drop in replacement.


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
